### PR TITLE
gRPC server will send header/trailer frames instead of a single frame when a trailers only case happens

### DIFF
--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -260,6 +259,22 @@ public class ServerRequestTest extends ServerTest {
     }));
 
     super.testHandleCancel(should);
+  }
+
+  @Override
+  public void testTrailersOnly(TestContext should) {
+
+    startServer(GrpcServer.server(vertx).callHandler(GreeterGrpc.getSayHelloMethod(), call -> {
+      call.handler(helloRequest -> {
+        GrpcServerResponse<HelloRequest, HelloReply> response = call.response();
+        response.trailers().set("custom_response_trailer", "custom_response_trailer_value");
+        response
+          .status(GrpcStatus.INVALID_ARGUMENT)
+          .end();
+      });
+    }));
+
+    super.testTrailersOnly(should);
   }
 
   @Test

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerTest.java
@@ -306,4 +306,20 @@ public abstract class ServerTest extends ServerTestBase {
     latch.awaitSuccess(10_000);
     items.cancel("cancelled", new Exception());
   }
+
+  @Test
+  public void testTrailersOnly(TestContext should) {
+    HelloRequest request = HelloRequest.newBuilder().setName("Julien").build();
+    channel = ManagedChannelBuilder.forAddress( "localhost", port)
+      .usePlaintext()
+      .build();
+    GreeterGrpc.GreeterBlockingStub stub = GreeterGrpc.newBlockingStub(channel);
+    try {
+      stub.sayHello(request);
+    } catch (StatusRuntimeException e) {
+      Metadata trailers = e.getTrailers();
+      should.assertEquals("custom_response_trailer_value", trailers.get(Metadata.Key.of("custom_response_trailer", Metadata.ASCII_STRING_MARSHALLER)));
+      should.assertEquals(Status.INVALID_ARGUMENT, e.getStatus());
+    }
+  }
 }


### PR DESCRIPTION
gRPC mandates to send a single response frame when an immediate occurs, the vertx server does not support it when a response trailer metadata is set, instead it will send a header frame and a trailer frame.