### PR TITLE
Fix the problem that arises when adding the vertx-grpc module to vertx-rx

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
@@ -14,6 +14,7 @@ import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpConnection;
@@ -94,4 +95,13 @@ public interface GrpcClientRequest<Req, Resp> extends GrpcWriteStream<Req> {
    * @return the underlying HTTP connection
    */
   HttpConnection connection();
+
+  @Override
+  void write(Req message, Handler<AsyncResult<Void>> handler);
+
+  @Override
+  void end(Handler<AsyncResult<Void>> handler);
+
+  @Override
+  void end(Req message, Handler<AsyncResult<Void>> handler);
 }

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
@@ -229,6 +229,11 @@ public class GrpcClientRequestImpl<Req, Resp> implements GrpcClientRequest<Req, 
     end().onComplete(handler);
   }
 
+  @Override
+  public void end(Req message, Handler<AsyncResult<Void>> handler) {
+    end(message).onComplete(handler);
+  }
+
   @Override public Future<GrpcClientResponse<Req, Resp>> response() {
     return response;
   }

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/package-info.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/package-info.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-@ModuleGen(name = "vertx-grpc-client", groupPackage = "io.vertx", useFutures = true)
+@ModuleGen(name = "vertx-grpc-client", groupPackage = "io.vertx")
 package io.vertx.grpc.client;
 
 import io.vertx.codegen.annotations.ModuleGen;

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcReadStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcReadStream.java
@@ -77,7 +77,6 @@ public interface GrpcReadStream<T> extends ReadStream<T> {
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   <R, A> Future<R> collecting(java.util.stream.Collector<T , A , R> collector);
 
-  @GenIgnore
   default void pipeTo(WriteStream<T> dst, Handler<AsyncResult<Void>> handler) {
     ReadStream.super.pipeTo(dst, handler);
   }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
@@ -61,15 +61,12 @@ public interface GrpcWriteStream<T> extends WriteStream<T> {
    */
   boolean cancel();
 
-  @GenIgnore
   @Override
   void write(T t, Handler<AsyncResult<Void>> handler);
 
-  @GenIgnore
   @Override
   void end(Handler<AsyncResult<Void>> handler);
 
-  @GenIgnore
   @Override
   default void end(T data, Handler<AsyncResult<Void>> handler) {
     WriteStream.super.end(data, handler);

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/package-info.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/package-info.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-@ModuleGen(name = "vertx-grpc-common", groupPackage = "io.vertx", useFutures = true)
+@ModuleGen(name = "vertx-grpc-common", groupPackage = "io.vertx")
 package io.vertx.grpc.common;
 
 import io.vertx.codegen.annotations.ModuleGen;

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
@@ -13,6 +13,7 @@ package io.vertx.grpc.server;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.grpc.common.GrpcStatus;
@@ -47,4 +48,12 @@ public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
   @Override
   GrpcServerResponse<Req, Resp> drainHandler(@Nullable Handler<Void> handler);
 
+  @Override
+  void write(Resp data, Handler<AsyncResult<Void>> handler);
+
+  @Override
+  void end(Handler<AsyncResult<Void>> handler);
+
+  @Override
+  void end(Resp data, Handler<AsyncResult<Void>> handler);
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -233,4 +233,9 @@ public class GrpcServerResponseImpl<Req, Resp> implements GrpcServerResponse<Req
   public void end(Handler<AsyncResult<Void>> handler) {
     end().onComplete(handler);
   }
+
+  @Override
+  public void end(Resp data, Handler<AsyncResult<Void>> handler) {
+    end(data).onComplete(handler);
+  }
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/package-info.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/package-info.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-@ModuleGen(name = "vertx-grpc-server", groupPackage = "io.vertx", useFutures = true)
+@ModuleGen(name = "vertx-grpc-server", groupPackage = "io.vertx")
 package io.vertx.grpc.server;
 
 import io.vertx.codegen.annotations.ModuleGen;


### PR DESCRIPTION

When i try to use grpc-server in my reactive vertx application.

```java
GrpcServer grpcServer = GrpcServer.server(vertx);
vertx.createHttpServer()
        .requestHandler(grpcServer)
        .rxListen(grpcPort);
```

I encountered the following error:
```
incompatible types: io.vertx.grpc.server.GrpcServer cannot be converted to io.vertx.core.Handler<io.vertx.reactivex.core.http.HttpServerRequest>
```

I am seeking to implement RxJava support for vertx-grpc. I have incorporated the vertx-grpc module into the vertx-rx generation process to achieve this. However, I am encountering numerous errors, such as
```
end() in io.vertx.rxjava.grpc.server.GrpcServerResponse cannot implement end() in io.vertx.rxjava.core.streams.WriteStream
write(Req) in io.vertx.rxjava.grpc.client.GrpcClientRequest cannot implement write(T) in io.vertx.rxjava.core.streams.WriteStream
write(Resp) in io.vertx.rxjava.grpc.server.GrpcServerResponse cannot implement write(T) in io.vertx.rxjava.core.streams.WriteStream
... 
```

This pull request intends to resolve all those errors. I've confirmed that both the generated reactive grpc-server and grpc-client functions are operational. However, I need to alter the @ModuleGen setting of `useFutures` to false. May I proceed with this change?





