### PR TITLE
GrpcClient API simplified call API to simplify interactions with a gRPC service 

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClient.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClient.java
@@ -14,11 +14,15 @@ import io.grpc.MethodDescriptor;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.grpc.client.impl.GrpcClientImpl;
+
+import java.util.function.Function;
 
 /**
  * A gRPC client for Vert.x
@@ -71,10 +75,42 @@ public interface GrpcClient {
    * Connect to the remote {@code server} and create a request for given {@code method} of a hosted gRPC service.
    *
    * @param server the server hosting the service
+   * @param service the service to be called
    * @return a future request
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(SocketAddress server, MethodDescriptor<Req, Resp> method);
+  <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(SocketAddress server, MethodDescriptor<Req, Resp> service);
+
+  /**
+   * Call the {@code service} gRPC service hosted by {@code server}.
+   * <p>
+   *   The {@code requestHandler} is called to send the request, e.g. {@code req -> req.send(item)}
+   * <p>
+   *   The {@code responseFunction} extracts the result, e.g. {@code resp -> resp.last()}
+   * <p>
+   *   It can be used in various ways:
+   * <ul>
+   *   <li>{@code Future<Resp> fut = client.call(..., req -> req.send(item), resp -> resp.last());}</li>
+   *   <li>{@code Future<Void> fut = client.call(..., req -> req.send(stream), resp -> resp.pipeTo(anotherService));}</li>
+   *   <li>{@code Future<List<Resp>> fut = client.call(..., req -> req.send(stream), resp -> resp.collecting(Collectors.toList()));}</li>
+   * </ul>
+   * <pre>
+   *
+   * @param server the server hosting the service
+   * @param service the service to call
+   * @param requestHandler the handler called to send the request
+   * @param resultFn the function applied to extract the result.
+   * @return a future of the result
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <Req, Resp, T> Future<T> call(SocketAddress server, MethodDescriptor<Req, Resp> service, Handler<GrpcClientRequest<Req, Resp>> requestHandler, Function<GrpcClientResponse<Req, Resp>, Future<T>> resultFn) {
+    return request(server, service).compose(req -> {
+      requestHandler.handle(req);
+      return req
+        .response()
+        .compose(resultFn);
+    });
+  }
 
   /**
    * Close this client.

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
@@ -16,7 +16,12 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.grpc.common.GrpcWriteStream;
 import io.vertx.grpc.common.ServiceName;
 
@@ -94,4 +99,14 @@ public interface GrpcClientRequest<Req, Resp> extends GrpcWriteStream<Req> {
    * @return the underlying HTTP connection
    */
   HttpConnection connection();
+
+  default Future<GrpcClientResponse<Req, Resp>> send(Req item) {
+    this.end(item);
+    return this.response();
+  }
+
+  default Future<GrpcClientResponse<Req, Resp>> send(ReadStream<Req> body) {
+    body.pipeTo(this);
+    return this.response();
+  }
 }

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientImpl.java
@@ -51,16 +51,16 @@ public class GrpcClientImpl implements GrpcClient {
       .map(request -> new GrpcClientRequestImpl<>(request, GrpcMessageEncoder.IDENTITY, GrpcMessageDecoder.IDENTITY));
   }
 
-  @Override public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(SocketAddress server, MethodDescriptor<Req, Resp> method) {
+  @Override public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(SocketAddress server, MethodDescriptor<Req, Resp> service) {
     RequestOptions options = new RequestOptions()
       .setMethod(HttpMethod.POST)
       .setServer(server);
-    GrpcMessageDecoder<Resp> messageDecoder = GrpcMessageDecoder.unmarshaller(method.getResponseMarshaller());
-    GrpcMessageEncoder<Req> messageEncoder = GrpcMessageEncoder.marshaller(method.getRequestMarshaller());
+    GrpcMessageDecoder<Resp> messageDecoder = GrpcMessageDecoder.unmarshaller(service.getResponseMarshaller());
+    GrpcMessageEncoder<Req> messageEncoder = GrpcMessageEncoder.marshaller(service.getRequestMarshaller());
     return client.request(options)
       .map(request -> {
         GrpcClientRequestImpl<Req, Resp> call = new GrpcClientRequestImpl<>(request, messageEncoder, messageDecoder);
-        call.fullMethodName(method.getFullMethodName());
+        call.fullMethodName(service.getFullMethodName());
         return call;
       });
   }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
@@ -13,8 +13,10 @@ package io.vertx.grpc.server;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.GrpcWriteStream;
 
@@ -47,4 +49,11 @@ public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
   @Override
   GrpcServerResponse<Req, Resp> drainHandler(@Nullable Handler<Void> handler);
 
+  default Future<Void> send(Resp item) {
+    return end(item);
+  }
+
+  default Future<Void> send(ReadStream<Resp> body) {
+    return body.pipeTo(this);
+  }
 }


### PR DESCRIPTION
A simplified API to interact with a gRPC service:

```java
Future<T> fut = client.call(server, service, req -> req.send(item), resp -> resp.last());
```

```java
Future<List<T>> fut = client.call(server, service, req -> req.send(item), resp -> resp.collecting(Collectors.toList()));
```