### PR TITLE
New feature: vertx grpc protoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <module>vertx-grpc-server</module>
     <module>vertx-grpc-client</module>
     <module>vertx-grpc-context-storage</module>
+    <module>vertx-grpc-protoc-plugin</module>
     <module>vertx-grpc-it</module>
   </modules>
 

--- a/vertx-grpc-it/pom.xml
+++ b/vertx-grpc-it/pom.xml
@@ -123,6 +123,15 @@
           <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+          <protocPlugins>
+            <protocPlugin>
+              <id>vertx-grpc-protoc-plugin</id>
+              <groupId>io.vertx</groupId>
+              <artifactId>vertx-grpc-protoc-plugin</artifactId>
+              <version>${project.version}</version>
+              <mainClass>io.vertx.grpc.plugin.VertxGrpcGenerator</mainClass>
+            </protocPlugin>
+          </protocPlugins>
         </configuration>
         <executions>
           <execution>

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
@@ -11,11 +11,9 @@
 package io.vertx.grpc.it;
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.EmptyProtos;
 import io.grpc.testing.integration.Messages;
 import io.grpc.testing.integration.VertxTestServiceGrpcClient;
 import io.grpc.testing.integration.VertxTestServiceGrpcServer;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.net.SocketAddress;
@@ -30,7 +28,6 @@ import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 public class ProtocPluginTest extends ProxyTestBase {
 
@@ -42,44 +39,12 @@ public class ProtocPluginTest extends ProxyTestBase {
     VertxTestServiceGrpcServer server = new VertxTestServiceGrpcServer(vertx)
       .callHandlers(new VertxTestServiceGrpcServer.TestServiceApi() {
         @Override
-        public Future<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
-          return Future.succeededFuture(
-            Messages.SimpleResponse.newBuilder()
-              .setUsername("FooBar")
-              .build());
-        }
-
-        @Override
-        public Future<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
-          return response -> {};
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
-          return response -> {};
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> halfDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
-          return response -> {};
+        public void unaryCall(Messages.SimpleRequest request, Promise<Messages.SimpleResponse> response) {
+          response.complete(Messages.SimpleResponse.newBuilder()
+            .setUsername("FooBar")
+            .build());
         }
       });
-
     HttpServer httpServer = vertx.createHttpServer();
     httpServer.requestHandler(server.getGrpcServer())
       .listen(port)
@@ -105,50 +70,17 @@ public class ProtocPluginTest extends ProxyTestBase {
     VertxTestServiceGrpcServer server = new VertxTestServiceGrpcServer(vertx)
       .callHandlers(new VertxTestServiceGrpcServer.TestServiceApi() {
         @Override
-        public Future<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
-          Promise<Messages.StreamingInputCallResponse> promise = Promise.promise();
+        public void streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request, Promise<Messages.StreamingInputCallResponse> response) {
           List<Messages.StreamingInputCallRequest> list = new ArrayList<>();
           request.handler(list::add);
           request.endHandler($ -> {
             Messages.StreamingInputCallResponse resp = Messages.StreamingInputCallResponse.newBuilder()
               .setAggregatedPayloadSize(list.size())
               .build();
-            promise.complete(resp);
+            response.complete(resp);
           });
-          return promise.future();
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
-          return response -> {};
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
-          return response -> {};
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> halfDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
-          return response -> {};
         }
       });
-
     HttpServer httpServer = vertx.createHttpServer();
     httpServer.requestHandler(server.getGrpcServer())
       .listen(port)
@@ -180,49 +112,16 @@ public class ProtocPluginTest extends ProxyTestBase {
     VertxTestServiceGrpcServer server = new VertxTestServiceGrpcServer(vertx)
       .callHandlers(new VertxTestServiceGrpcServer.TestServiceApi() {
         @Override
-        public Future<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
-          return response -> {
-            response.write(Messages.StreamingOutputCallResponse.newBuilder()
-              .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-1", StandardCharsets.UTF_8)).build())
-              .build());
-            response.write(Messages.StreamingOutputCallResponse.newBuilder()
-              .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-2", StandardCharsets.UTF_8)).build())
-              .build());
-            response.end();
-          };
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
-          return response -> {};
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> halfDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
-          return response -> {};
-        }
+        public void streamingOutputCall(Messages.StreamingOutputCallRequest request, WriteStream<Messages.StreamingOutputCallResponse> response) {
+          response.write(Messages.StreamingOutputCallResponse.newBuilder()
+            .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-1", StandardCharsets.UTF_8)).build())
+            .build());
+          response.write(Messages.StreamingOutputCallResponse.newBuilder()
+            .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-2", StandardCharsets.UTF_8)).build())
+            .build());
+          response.end();
+        };
       });
-
     HttpServer httpServer = vertx.createHttpServer();
     httpServer.requestHandler(server.getGrpcServer())
       .listen(port)
@@ -255,51 +154,18 @@ public class ProtocPluginTest extends ProxyTestBase {
     VertxTestServiceGrpcServer server = new VertxTestServiceGrpcServer(vertx)
       .callHandlers(new VertxTestServiceGrpcServer.TestServiceApi() {
         @Override
-        public Future<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
-          return Future.failedFuture("Not yet implemented");
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
-          return response -> {};
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
-          return response -> {
-            request.endHandler($ -> {
-              response.write(Messages.StreamingOutputCallResponse.newBuilder()
-                .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-1", StandardCharsets.UTF_8)).build())
-                .build());
-              response.write(Messages.StreamingOutputCallResponse.newBuilder()
-                .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-2", StandardCharsets.UTF_8)).build())
-                .build());
-              response.end();
-            });
-          };
-        }
-
-        @Override
-        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> halfDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
-          return response -> {};
-        }
+        public void fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request, WriteStream<Messages.StreamingOutputCallResponse> response) {
+          request.endHandler($ -> {
+            response.write(Messages.StreamingOutputCallResponse.newBuilder()
+              .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-1", StandardCharsets.UTF_8)).build())
+              .build());
+            response.write(Messages.StreamingOutputCallResponse.newBuilder()
+              .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-2", StandardCharsets.UTF_8)).build())
+              .build());
+            response.end();
+          });
+        };
       });
-
     HttpServer httpServer = vertx.createHttpServer();
     httpServer.requestHandler(server.getGrpcServer())
       .listen(port)

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.it;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.EmptyProtos;
+import io.grpc.testing.integration.Messages;
+import io.grpc.testing.integration.VertxTestServiceGrpcClient;
+import io.grpc.testing.integration.VertxTestServiceGrpcServer;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class ProtocPluginTest extends ProxyTestBase {
+
+  @Test
+  public void testUnary(TestContext should) throws IOException {
+    port = getFreePort();
+
+    // Create gRPC Server
+    VertxTestServiceGrpcServer server = new VertxTestServiceGrpcServer(vertx)
+      .callHandlers(new VertxTestServiceGrpcServer.TestServiceApi() {
+        @Override
+        public Future<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
+          return Future.succeededFuture(
+            Messages.SimpleResponse.newBuilder()
+              .setUsername("FooBar")
+              .build());
+        }
+
+        @Override
+        public Future<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
+          return response -> {};
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
+          return response -> {};
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> halfDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
+          return response -> {};
+        }
+      });
+
+    HttpServer httpServer = vertx.createHttpServer();
+    httpServer.requestHandler(server.getGrpcServer())
+      .listen(port)
+      .onFailure(should::fail);
+
+    // Create gRPC Client
+    VertxTestServiceGrpcClient client = new VertxTestServiceGrpcClient(vertx, SocketAddress.inetSocketAddress(port, "localhost"));
+
+    Async test = should.async();
+    client.unaryCall(Messages.SimpleRequest.newBuilder()
+        .setFillUsername(true)
+        .build())
+      .onSuccess(reply -> should.assertEquals("FooBar", reply.getUsername()))
+      .onSuccess(reply -> test.complete())
+      .onFailure(should::fail);
+  }
+
+  @Test
+  public void testManyUnary(TestContext should) throws IOException {
+    int port = getFreePort();
+
+    // Create gRPC Server
+    VertxTestServiceGrpcServer server = new VertxTestServiceGrpcServer(vertx)
+      .callHandlers(new VertxTestServiceGrpcServer.TestServiceApi() {
+        @Override
+        public Future<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
+          Promise<Messages.StreamingInputCallResponse> promise = Promise.promise();
+          List<Messages.StreamingInputCallRequest> list = new ArrayList<>();
+          request.handler(list::add);
+          request.endHandler($ -> {
+            Messages.StreamingInputCallResponse resp = Messages.StreamingInputCallResponse.newBuilder()
+              .setAggregatedPayloadSize(list.size())
+              .build();
+            promise.complete(resp);
+          });
+          return promise.future();
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
+          return response -> {};
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
+          return response -> {};
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> halfDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
+          return response -> {};
+        }
+      });
+
+    HttpServer httpServer = vertx.createHttpServer();
+    httpServer.requestHandler(server.getGrpcServer())
+      .listen(port)
+      .onFailure(should::fail);
+
+    // Create gRPC Client
+    VertxTestServiceGrpcClient client = new VertxTestServiceGrpcClient(vertx, SocketAddress.inetSocketAddress(port, "localhost"));
+
+    Async test = should.async();
+    client.streamingInputCall(req -> {
+        req.write(Messages.StreamingInputCallRequest.newBuilder()
+          .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingInputRequest-1", StandardCharsets.UTF_8)).build())
+          .build());
+        req.write(Messages.StreamingInputCallRequest.newBuilder()
+          .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingInputRequest-2", StandardCharsets.UTF_8)).build())
+          .build());
+        req.end();
+      })
+      .onSuccess(reply -> should.assertEquals(2, reply.getAggregatedPayloadSize()))
+      .onSuccess(reply -> test.complete())
+      .onFailure(should::fail);
+  }
+
+  @Test
+  public void testUnaryMany(TestContext should) throws IOException {
+    int port = getFreePort();
+
+    // Create gRPC Server
+    VertxTestServiceGrpcServer server = new VertxTestServiceGrpcServer(vertx)
+      .callHandlers(new VertxTestServiceGrpcServer.TestServiceApi() {
+        @Override
+        public Future<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
+          return response -> {
+            response.write(Messages.StreamingOutputCallResponse.newBuilder()
+              .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-1", StandardCharsets.UTF_8)).build())
+              .build());
+            response.write(Messages.StreamingOutputCallResponse.newBuilder()
+              .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-2", StandardCharsets.UTF_8)).build())
+              .build());
+            response.end();
+          };
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
+          return response -> {};
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> halfDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
+          return response -> {};
+        }
+      });
+
+    HttpServer httpServer = vertx.createHttpServer();
+    httpServer.requestHandler(server.getGrpcServer())
+      .listen(port)
+      .onFailure(should::fail);
+
+    // Create gRPC Client
+    VertxTestServiceGrpcClient client = new VertxTestServiceGrpcClient(vertx, SocketAddress.inetSocketAddress(port, "localhost"));
+
+    Async test = should.async();
+    Messages.StreamingOutputCallRequest request = Messages.StreamingOutputCallRequest.newBuilder()
+      .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputRequest", StandardCharsets.UTF_8)).build())
+      .build();
+    client.streamingOutputCall(request)
+      .onSuccess(response -> {
+        List<Messages.StreamingOutputCallResponse> list = new ArrayList<>();
+        response.handler(list::add);
+        response.endHandler($ -> {
+          should.assertEquals(2, list.size());
+          test.complete();
+        });
+        response.exceptionHandler(should::fail);
+      });
+  }
+
+  @Test
+  public void testmanyMany(TestContext should) throws IOException {
+    int port = getFreePort();
+
+    // Create gRPC Server
+    VertxTestServiceGrpcServer server = new VertxTestServiceGrpcServer(vertx)
+      .callHandlers(new VertxTestServiceGrpcServer.TestServiceApi() {
+        @Override
+        public Future<EmptyProtos.Empty> emptyCall(EmptyProtos.Empty request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<EmptyProtos.Empty> unimplementedCall(EmptyProtos.Empty request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
+          return Future.failedFuture("Not yet implemented");
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
+          return response -> {};
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
+          return response -> {
+            request.endHandler($ -> {
+              response.write(Messages.StreamingOutputCallResponse.newBuilder()
+                .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-1", StandardCharsets.UTF_8)).build())
+                .build());
+              response.write(Messages.StreamingOutputCallResponse.newBuilder()
+                .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-2", StandardCharsets.UTF_8)).build())
+                .build());
+              response.end();
+            });
+          };
+        }
+
+        @Override
+        public Consumer<WriteStream<Messages.StreamingOutputCallResponse>> halfDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
+          return response -> {};
+        }
+      });
+
+    HttpServer httpServer = vertx.createHttpServer();
+    httpServer.requestHandler(server.getGrpcServer())
+      .listen(port)
+      .onFailure(should::fail);
+
+    // Create gRPC Client
+    VertxTestServiceGrpcClient client = new VertxTestServiceGrpcClient(vertx, SocketAddress.inetSocketAddress(port, "localhost"));
+
+    Async test = should.async();
+    client.fullDuplexCall(req -> {
+        req.write(Messages.StreamingOutputCallRequest.newBuilder()
+          .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputRequest-1", StandardCharsets.UTF_8)).build())
+          .build());
+        req.write(Messages.StreamingOutputCallRequest.newBuilder()
+          .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputRequest-2", StandardCharsets.UTF_8)).build())
+          .build());
+        req.end();
+      })
+      .onSuccess(response -> {
+        List<Messages.StreamingOutputCallResponse> list = new ArrayList<>();
+        response.handler(list::add);
+        response.endHandler($ -> {
+          should.assertEquals(2, list.size());
+          test.complete();
+        });
+        response.exceptionHandler(should::fail);
+      });
+  }
+
+  private static Integer getFreePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+}

--- a/vertx-grpc-protoc-plugin/pom.xml
+++ b/vertx-grpc-protoc-plugin/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (c) 2011-2014 The original author or authors
+  ~
+  ~  All rights reserved. This program and the accompanying materials
+  ~  are made available under the terms of the Eclipse Public License v1.0
+  ~  and Apache License v2.0 which accompanies this distribution.
+  ~
+  ~      The Eclipse Public License is available at
+  ~      http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~      The Apache License v2.0 is available at
+  ~      http://www.opensource.org/licenses/apache2.0.php
+  ~
+  ~  You may elect to redistribute this code under either of these licenses.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vertx</groupId>
+    <artifactId>vertx-grpc-aggregator</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>vertx-grpc-protoc-plugin</artifactId>
+
+  <name>Vert.x gRPC Protoc Plugin</name>
+
+  <properties>
+    <canteen.version>1.1.0</canteen.version>
+    <protoc.version>3.21.12</protoc.version>
+    <jprotoc.version>1.2.1</jprotoc.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.salesforce.servicelibs</groupId>
+      <artifactId>jprotoc</artifactId>
+      <version>${jprotoc.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>io.vertx.grpc.plugin.VertxGrpcGenerator</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>canteen-maven-plugin</artifactId>
+        <version>${canteen.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bootstrap</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/vertx-grpc-protoc-plugin/src/main/java/io/vertx/grpc/plugin/VertxGrpcGenerator.java
+++ b/vertx-grpc-protoc-plugin/src/main/java/io/vertx/grpc/plugin/VertxGrpcGenerator.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.plugin;
+
+import com.google.common.base.Strings;
+import com.google.common.html.HtmlEscapers;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.compiler.PluginProtos;
+import com.salesforce.jprotoc.Generator;
+import com.salesforce.jprotoc.GeneratorException;
+import com.salesforce.jprotoc.ProtoTypeMap;
+import com.salesforce.jprotoc.ProtocPlugin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class VertxGrpcGenerator extends Generator {
+
+  private static final int SERVICE_NUMBER_OF_PATHS = 2;
+  private static final int METHOD_NUMBER_OF_PATHS = 4;
+  private static final String CLASS_PREFIX = "Vertx";
+
+  private String getServiceJavaDocPrefix() {
+    return "    ";
+  }
+
+  private String getMethodJavaDocPrefix() {
+    return "        ";
+  }
+
+  public static void main(String[] args) {
+    if (args.length == 0) {
+      ProtocPlugin.generate(new VertxGrpcGenerator());
+    } else {
+      ProtocPlugin.debug(new VertxGrpcGenerator(), args[0]);
+    }
+  }
+
+  @Override
+  protected List<PluginProtos.CodeGeneratorResponse.Feature> supportedFeatures() {
+    return Collections.singletonList(PluginProtos.CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL);
+  }
+
+  @Override
+  public List<PluginProtos.CodeGeneratorResponse.File> generateFiles(PluginProtos.CodeGeneratorRequest request) throws GeneratorException {
+    ProtoTypeMap typeMap = ProtoTypeMap.of(request.getProtoFileList());
+
+    List<DescriptorProtos.FileDescriptorProto> protosToGenerate = request.getProtoFileList().stream()
+      .filter(protoFile -> request.getFileToGenerateList().contains(protoFile.getName()))
+      .collect(Collectors.toList());
+
+    List<ServiceContext> services = findServices(protosToGenerate, typeMap);
+    return generateFiles(services);
+  }
+
+  private List<ServiceContext> findServices(List<DescriptorProtos.FileDescriptorProto> protos, ProtoTypeMap typeMap) {
+    List<ServiceContext> contexts = new ArrayList<>();
+
+    protos.forEach(fileProto -> {
+      for (int serviceNumber = 0; serviceNumber < fileProto.getServiceCount(); serviceNumber++) {
+        ServiceContext serviceContext = buildServiceContext(
+          fileProto.getService(serviceNumber),
+          typeMap,
+          fileProto.getSourceCodeInfo().getLocationList(),
+          serviceNumber
+        );
+        serviceContext.protoName = fileProto.getName();
+        serviceContext.packageName = extractPackageName(fileProto);
+        contexts.add(serviceContext);
+      }
+    });
+
+    return contexts;
+  }
+
+  private String extractPackageName(DescriptorProtos.FileDescriptorProto proto) {
+    DescriptorProtos.FileOptions options = proto.getOptions();
+    if (options != null) {
+      String javaPackage = options.getJavaPackage();
+      if (!Strings.isNullOrEmpty(javaPackage)) {
+        return javaPackage;
+      }
+    }
+
+    return Strings.nullToEmpty(proto.getPackage());
+  }
+
+  private ServiceContext buildServiceContext(DescriptorProtos.ServiceDescriptorProto serviceProto, ProtoTypeMap typeMap, List<DescriptorProtos.SourceCodeInfo.Location> locations, int serviceNumber) {
+    ServiceContext serviceContext = new ServiceContext();
+    // Set Later
+    //serviceContext.fileName = CLASS_PREFIX + serviceProto.getName() + "Grpc.java";
+    //serviceContext.className = CLASS_PREFIX + serviceProto.getName() + "Grpc";
+    serviceContext.serviceName = serviceProto.getName();
+    serviceContext.deprecated = serviceProto.getOptions() != null && serviceProto.getOptions().getDeprecated();
+
+    List<DescriptorProtos.SourceCodeInfo.Location> allLocationsForService = locations.stream()
+      .filter(location ->
+        location.getPathCount() >= 2 &&
+          location.getPath(0) == DescriptorProtos.FileDescriptorProto.SERVICE_FIELD_NUMBER &&
+          location.getPath(1) == serviceNumber
+      )
+      .collect(Collectors.toList());
+
+    DescriptorProtos.SourceCodeInfo.Location serviceLocation = allLocationsForService.stream()
+      .filter(location -> location.getPathCount() == SERVICE_NUMBER_OF_PATHS)
+      .findFirst()
+      .orElseGet(DescriptorProtos.SourceCodeInfo.Location::getDefaultInstance);
+    serviceContext.javaDoc = getJavaDoc(getComments(serviceLocation), getServiceJavaDocPrefix());
+
+    for (int methodNumber = 0; methodNumber < serviceProto.getMethodCount(); methodNumber++) {
+      MethodContext methodContext = buildMethodContext(
+        serviceProto.getMethod(methodNumber),
+        typeMap,
+        locations,
+        methodNumber
+      );
+
+      serviceContext.methods.add(methodContext);
+    }
+    return serviceContext;
+  }
+
+  private MethodContext buildMethodContext(DescriptorProtos.MethodDescriptorProto methodProto, ProtoTypeMap typeMap, List<DescriptorProtos.SourceCodeInfo.Location> locations, int methodNumber) {
+    MethodContext methodContext = new MethodContext();
+    methodContext.methodName = mixedLower(methodProto.getName());
+    methodContext.inputType = typeMap.toJavaTypeName(methodProto.getInputType());
+    methodContext.outputType = typeMap.toJavaTypeName(methodProto.getOutputType());
+    methodContext.deprecated = methodProto.getOptions() != null && methodProto.getOptions().getDeprecated();
+    methodContext.isManyInput = methodProto.getClientStreaming();
+    methodContext.isManyOutput = methodProto.getServerStreaming();
+    methodContext.methodNumber = methodNumber;
+
+    DescriptorProtos.SourceCodeInfo.Location methodLocation = locations.stream()
+      .filter(location ->
+        location.getPathCount() == METHOD_NUMBER_OF_PATHS &&
+          location.getPath(METHOD_NUMBER_OF_PATHS - 1) == methodNumber
+      )
+      .findFirst()
+      .orElseGet(DescriptorProtos.SourceCodeInfo.Location::getDefaultInstance);
+    methodContext.javaDoc = getJavaDoc(getComments(methodLocation), getMethodJavaDocPrefix());
+
+    if (!methodProto.getClientStreaming() && !methodProto.getServerStreaming()) {
+      methodContext.vertxCallsMethodName = "oneToOne";
+      methodContext.grpcCallsMethodName = "asyncUnaryCall";
+    }
+    if (!methodProto.getClientStreaming() && methodProto.getServerStreaming()) {
+      methodContext.vertxCallsMethodName = "oneToMany";
+      methodContext.grpcCallsMethodName = "asyncServerStreamingCall";
+    }
+    if (methodProto.getClientStreaming() && !methodProto.getServerStreaming()) {
+      methodContext.vertxCallsMethodName = "manyToOne";
+      methodContext.grpcCallsMethodName = "asyncClientStreamingCall";
+    }
+    if (methodProto.getClientStreaming() && methodProto.getServerStreaming()) {
+      methodContext.vertxCallsMethodName = "manyToMany";
+      methodContext.grpcCallsMethodName = "asyncBidiStreamingCall";
+    }
+    return methodContext;
+  }
+
+  // java keywords from: https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.9
+  private static final List<CharSequence> JAVA_KEYWORDS = Arrays.asList(
+    "abstract",
+    "assert",
+    "boolean",
+    "break",
+    "byte",
+    "case",
+    "catch",
+    "char",
+    "class",
+    "const",
+    "continue",
+    "default",
+    "do",
+    "double",
+    "else",
+    "enum",
+    "extends",
+    "final",
+    "finally",
+    "float",
+    "for",
+    "goto",
+    "if",
+    "implements",
+    "import",
+    "instanceof",
+    "int",
+    "interface",
+    "long",
+    "native",
+    "new",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "return",
+    "short",
+    "static",
+    "strictfp",
+    "super",
+    "switch",
+    "synchronized",
+    "this",
+    "throw",
+    "throws",
+    "transient",
+    "try",
+    "void",
+    "volatile",
+    "while",
+    // additional ones added by us
+    "true",
+    "false"
+  );
+
+  /**
+   * Adjust a method name prefix identifier to follow the JavaBean spec:
+   * - decapitalize the first letter
+   * - remove embedded underscores & capitalize the following letter
+   * <p>
+   * Finally, if the result is a reserved java keyword, append an underscore.
+   *
+   * @param word method name
+   * @return lower name
+   */
+  private static String mixedLower(String word) {
+    StringBuffer w = new StringBuffer();
+    w.append(Character.toLowerCase(word.charAt(0)));
+
+    boolean afterUnderscore = false;
+
+    for (int i = 1; i < word.length(); ++i) {
+      char c = word.charAt(i);
+
+      if (c == '_') {
+        afterUnderscore = true;
+      } else {
+        if (afterUnderscore) {
+          w.append(Character.toUpperCase(c));
+        } else {
+          w.append(c);
+        }
+        afterUnderscore = false;
+      }
+    }
+
+    if (JAVA_KEYWORDS.contains(w)) {
+      w.append('_');
+    }
+
+    return w.toString();
+  }
+
+  private List<PluginProtos.CodeGeneratorResponse.File> generateFiles(List<ServiceContext> services) {
+    return services.stream()
+      .map(this::buildFiles)
+      .flatMap(Collection::stream)
+      .collect(Collectors.toList());
+  }
+
+  private List<PluginProtos.CodeGeneratorResponse.File> buildFiles(ServiceContext context) {
+    return Arrays.asList(
+      buildClientFile(context),
+      buildServerFile(context));
+  }
+
+  private PluginProtos.CodeGeneratorResponse.File buildClientFile(ServiceContext context) {
+    context.fileName = CLASS_PREFIX + context.serviceName + "GrpcClient.java";
+    context.className = CLASS_PREFIX + context.serviceName + "GrpcClient";
+    return buildFile(context, applyTemplate("client.mustache", context));
+  }
+
+  private PluginProtos.CodeGeneratorResponse.File buildServerFile(ServiceContext context) {
+    context.fileName = CLASS_PREFIX + context.serviceName + "GrpcServer.java";
+    context.className = CLASS_PREFIX + context.serviceName + "GrpcServer";
+    return buildFile(context, applyTemplate("server.mustache", context));
+  }
+
+  private PluginProtos.CodeGeneratorResponse.File buildFile(ServiceContext context, String content) {
+    return PluginProtos.CodeGeneratorResponse.File
+      .newBuilder()
+      .setName(absoluteFileName(context))
+      .setContent(content)
+      .build();
+  }
+
+  private String absoluteFileName(ServiceContext ctx) {
+    String dir = ctx.packageName.replace('.', '/');
+    if (Strings.isNullOrEmpty(dir)) {
+      return ctx.fileName;
+    } else {
+      return dir + "/" + ctx.fileName;
+    }
+  }
+
+  private String getComments(DescriptorProtos.SourceCodeInfo.Location location) {
+    return location.getLeadingComments().isEmpty() ? location.getTrailingComments() : location.getLeadingComments();
+  }
+
+  private String getJavaDoc(String comments, String prefix) {
+    if (!comments.isEmpty()) {
+      StringBuilder builder = new StringBuilder("/**\n")
+        .append(prefix).append(" * <pre>\n");
+      Arrays.stream(HtmlEscapers.htmlEscaper().escape(comments).split("\n"))
+        .map(line -> line.replace("*/", "&#42;&#47;").replace("*", "&#42;"))
+        .forEach(line -> builder.append(prefix).append(" * ").append(line).append("\n"));
+      builder
+        .append(prefix).append(" * </pre>\n")
+        .append(prefix).append(" */");
+      return builder.toString();
+    }
+    return null;
+  }
+
+  /**
+   * Template class for proto Service objects.
+   */
+  private static class ServiceContext {
+    // CHECKSTYLE DISABLE VisibilityModifier FOR 8 LINES
+    public String fileName;
+    public String protoName;
+    public String packageName;
+    public String className;
+    public String serviceName;
+    public boolean deprecated;
+    public String javaDoc;
+    public final List<MethodContext> methods = new ArrayList<>();
+
+    public List<MethodContext> streamMethods() {
+      return methods.stream().filter(m -> m.isManyInput || m.isManyOutput).collect(Collectors.toList());
+    }
+
+    public List<MethodContext> unaryMethods() {
+      return methods.stream().filter(m -> !m.isManyInput && !m.isManyOutput).collect(Collectors.toList());
+    }
+
+    public List<MethodContext> unaryManyMethods() {
+      return methods.stream().filter(m -> !m.isManyInput && m.isManyOutput).collect(Collectors.toList());
+    }
+
+    public List<MethodContext> manyUnaryMethods() {
+      return methods.stream().filter(m -> m.isManyInput && !m.isManyOutput).collect(Collectors.toList());
+    }
+
+    public List<MethodContext> manyManyMethods() {
+      return methods.stream().filter(m -> m.isManyInput && m.isManyOutput).collect(Collectors.toList());
+    }
+  }
+
+  /**
+   * Template class for proto RPC objects.
+   */
+  private static class MethodContext {
+    // CHECKSTYLE DISABLE VisibilityModifier FOR 10 LINES
+    public String methodName;
+    public String inputType;
+    public String outputType;
+    public boolean deprecated;
+    public boolean isManyInput;
+    public boolean isManyOutput;
+    public String vertxCallsMethodName;
+    public String grpcCallsMethodName;
+    public int methodNumber;
+    public String javaDoc;
+
+    // This method mimics the upper-casing method ogf gRPC to ensure compatibility
+    // See https://github.com/grpc/grpc-java/blob/v1.8.0/compiler/src/java_plugin/cpp/java_generator.cpp#L58
+    public String methodNameUpperUnderscore() {
+      StringBuilder s = new StringBuilder();
+      for (int i = 0; i < methodName.length(); i++) {
+        char c = methodName.charAt(i);
+        s.append(Character.toUpperCase(c));
+        if ((i < methodName.length() - 1) && Character.isLowerCase(c) && Character.isUpperCase(methodName.charAt(i + 1))) {
+          s.append('_');
+        }
+      }
+      return s.toString();
+    }
+
+    public String methodNameGetter() {
+      return VertxGrpcGenerator.mixedLower("get_" + methodName + "_method");
+    }
+
+    public String methodHeader() {
+      String mh = "";
+      if (!Strings.isNullOrEmpty(javaDoc)) {
+        mh = javaDoc;
+      }
+
+      if (deprecated) {
+        mh += "\n        @Deprecated";
+      }
+
+      return mh;
+    }
+  }
+}

--- a/vertx-grpc-protoc-plugin/src/main/resources/client.mustache
+++ b/vertx-grpc-protoc-plugin/src/main/resources/client.mustache
@@ -1,0 +1,58 @@
+{{#packageName}}
+package {{packageName}};
+{{/packageName}}
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import java.util.function.Consumer;
+
+public class {{className}} {
+  private final GrpcClient client;
+  private final SocketAddress socketAddress;
+
+  public {{className}}(Vertx vertx, SocketAddress socketAddress) {
+    this.client = GrpcClient.client(vertx);
+    this.socketAddress = socketAddress;
+  }
+
+{{#unaryMethods}}
+  public Future<{{outputType}}> {{methodName}}({{inputType}} request) {
+    return client.request(socketAddress, {{serviceName}}Grpc.{{methodNameGetter}}()).compose(req -> {
+      req.end(request);
+      return req.response().compose(resp -> resp.last());
+    });
+  }
+
+{{/unaryMethods}}
+{{#unaryManyMethods}}
+  public Future<ReadStream<{{outputType}}>> {{methodName}}({{inputType}} request) {
+    return client.request(socketAddress, {{serviceName}}Grpc.{{methodNameGetter}}()).compose(req -> {
+      req.end(request);
+      return req.response().map(resp -> resp);
+    });
+  }
+
+{{/unaryManyMethods}}
+{{#manyUnaryMethods}}
+  public Future<{{outputType}}> {{methodName}}(Consumer<WriteStream<{{inputType}}>> request) {
+    return client.request(socketAddress, {{serviceName}}Grpc.{{methodNameGetter}}()).compose(req -> {
+      request.accept(req);
+      return req.response().compose(resp -> resp.last());
+    });
+  }
+
+{{/manyUnaryMethods}}
+{{#manyManyMethods}}
+  public Future<ReadStream<{{outputType}}>> {{methodName}}(Consumer<WriteStream<{{inputType}}>> request) {
+    return client.request(socketAddress, {{serviceName}}Grpc.{{methodNameGetter}}()).compose(req -> {
+      request.accept(req);
+      return req.response().map(resp -> resp);
+    });
+  }
+
+{{/manyManyMethods}}
+}

--- a/vertx-grpc-protoc-plugin/src/main/resources/server.mustache
+++ b/vertx-grpc-protoc-plugin/src/main/resources/server.mustache
@@ -2,7 +2,7 @@
 package {{packageName}};
 {{/packageName}}
 
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerRequest;
@@ -12,7 +12,6 @@ import io.vertx.grpc.server.GrpcServer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 public class {{className}}  {
   private final GrpcServer server;
@@ -23,34 +22,43 @@ public class {{className}}  {
 
   public interface {{serviceName}}Api {
 {{#unaryMethods}}
-    Future<{{outputType}}> {{methodName}}({{inputType}} request);
+    default void {{methodName}}({{inputType}} request, Promise<{{outputType}}> response) {}
 {{/unaryMethods}}
 {{#unaryManyMethods}}
-    Consumer<WriteStream<{{outputType}}>> {{methodName}}({{inputType}} request);
+    default void {{methodName}}({{inputType}} request, WriteStream<{{outputType}}> response) {}
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
-    Future<{{outputType}}> {{methodName}}(ReadStream<{{inputType}}> request);
+    default void {{methodName}}(ReadStream<{{inputType}}> request, Promise<{{outputType}}> response) {}
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
-    Consumer<WriteStream<{{outputType}}>> {{methodName}}(ReadStream<{{inputType}}> request);
+    default void {{methodName}}(ReadStream<{{inputType}}> request, WriteStream<{{outputType}}> response) {}
 {{/manyManyMethods}}
   }
 
   public {{className}} callHandlers({{serviceName}}Api implementation) {
 {{#unaryMethods}}
-    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request ->
-            request.handler(req -> implementation.{{methodName}}(req)
-                .onSuccess(resp -> request.response().end(resp))
-            ));
+    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> {
+      Promise<{{outputType}}> promise = Promise.promise();
+      request.handler(req -> implementation.{{methodName}}(req, promise));
+      promise.future().onSuccess(resp -> request.response().end(resp));
+    });
 {{/unaryMethods}}
 {{#unaryManyMethods}}
-    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> request.handler(req -> implementation.{{methodName}}(req).accept(request.response())));
+    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> {
+      request.handler(req -> implementation.{{methodName}}(req, request.response()));
+    });
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
-    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> implementation.{{methodName}}(request).onSuccess(resp -> request.response().end(resp)));
+    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> {
+      Promise<{{outputType}}> promise = Promise.promise();
+      implementation.{{methodName}}(request, promise);
+      promise.future().onSuccess(resp -> request.response().end(resp));
+    });
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
-    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> implementation.{{methodName}}(request).accept(request.response()));
+    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> {
+      implementation.{{methodName}}(request, request.response());
+    });
 {{/manyManyMethods}}
     return this;
   }

--- a/vertx-grpc-protoc-plugin/src/main/resources/server.mustache
+++ b/vertx-grpc-protoc-plugin/src/main/resources/server.mustache
@@ -1,0 +1,61 @@
+{{#packageName}}
+package {{packageName}};
+{{/packageName}}
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.server.GrpcServer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class {{className}}  {
+  private final GrpcServer server;
+
+  public {{className}}(Vertx vertx) {
+    this.server = GrpcServer.server(vertx);
+  }
+
+  public interface {{serviceName}}Api {
+{{#unaryMethods}}
+    Future<{{outputType}}> {{methodName}}({{inputType}} request);
+{{/unaryMethods}}
+{{#unaryManyMethods}}
+    Consumer<WriteStream<{{outputType}}>> {{methodName}}({{inputType}} request);
+{{/unaryManyMethods}}
+{{#manyUnaryMethods}}
+    Future<{{outputType}}> {{methodName}}(ReadStream<{{inputType}}> request);
+{{/manyUnaryMethods}}
+{{#manyManyMethods}}
+    Consumer<WriteStream<{{outputType}}>> {{methodName}}(ReadStream<{{inputType}}> request);
+{{/manyManyMethods}}
+  }
+
+  public {{className}} callHandlers({{serviceName}}Api implementation) {
+{{#unaryMethods}}
+    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request ->
+            request.handler(req -> implementation.{{methodName}}(req)
+                .onSuccess(resp -> request.response().end(resp))
+            ));
+{{/unaryMethods}}
+{{#unaryManyMethods}}
+    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> request.handler(req -> implementation.{{methodName}}(req).accept(request.response())));
+{{/unaryManyMethods}}
+{{#manyUnaryMethods}}
+    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> implementation.{{methodName}}(request).onSuccess(resp -> request.response().end(resp)));
+{{/manyUnaryMethods}}
+{{#manyManyMethods}}
+    server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> implementation.{{methodName}}(request).accept(request.response()));
+{{/manyManyMethods}}
+    return this;
+  }
+
+  public Handler<HttpServerRequest> getGrpcServer() {
+    return server;
+  }
+}


### PR DESCRIPTION
Create a protoc-plugin that uses the latest vertx-grpc-server and vertx-grpc-client library. This plugin enforces the use of RPCs that are only defined in the proto specification, ensuring greater consistency in communication between the server and client. Additionally, the generated code provides a clearer interface for the user and reduces boilerplate code