### PR TITLE
[4.x] update javax to Jakarta

### DIFF
--- a/vertx-grpc-client/pom.xml
+++ b/vertx-grpc-client/pom.xml
@@ -166,10 +166,11 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-          <version>1.3.2</version>
-        </dependency>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+          <version>2.1.1</version>
+      </dependency>
+
       </dependencies>
     </profile>
   </profiles>

--- a/vertx-grpc-client/src/main/java/examples/GreeterGrpc.java
+++ b/vertx-grpc-client/src/main/java/examples/GreeterGrpc.java
@@ -7,7 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * The greeting service definition.
  * </pre>
  */
-@javax.annotation.Generated(
+@jakarta.annotation.Generated(
     value = "by gRPC proto compiler (version 1.50.2)",
     comments = "Source: helloworld.proto")
 @io.grpc.stub.annotations.GrpcGenerated

--- a/vertx-grpc-client/src/main/java/examples/StreamingGrpc.java
+++ b/vertx-grpc-client/src/main/java/examples/StreamingGrpc.java
@@ -7,7 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * Interface exported by the server.
  * </pre>
  */
-@javax.annotation.Generated(
+@jakarta.annotation.Generated(
     value = "by gRPC proto compiler (version 1.50.2)",
     comments = "Source: streaming.proto")
 @io.grpc.stub.annotations.GrpcGenerated

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/VertxClientCall.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/VertxClientCall.java
@@ -17,7 +17,7 @@ import io.vertx.grpc.common.impl.ReadStreamAdapter;
 import io.vertx.grpc.common.impl.Utils;
 import io.vertx.grpc.common.impl.WriteStreamAdapter;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.util.concurrent.Executor;
 
 class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, ResponseT> {

--- a/vertx-grpc-common/pom.xml
+++ b/vertx-grpc-common/pom.xml
@@ -149,10 +149,11 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-          <version>1.3.2</version>
-        </dependency>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+          <version>2.1.1</version>
+      </dependency>
+
       </dependencies>
     </profile>
   </profiles>

--- a/vertx-grpc-context-storage/pom.xml
+++ b/vertx-grpc-context-storage/pom.xml
@@ -114,10 +114,11 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-          <version>1.3.2</version>
-        </dependency>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+          <version>2.1.1</version>
+      </dependency>
+
       </dependencies>
     </profile>
   </profiles>

--- a/vertx-grpc-it/pom.xml
+++ b/vertx-grpc-it/pom.xml
@@ -154,10 +154,11 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-          <version>1.3.2</version>
-        </dependency>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+          <version>2.1.1</version>
+      </dependency>
+
       </dependencies>
     </profile>
   </profiles>

--- a/vertx-grpc-server/pom.xml
+++ b/vertx-grpc-server/pom.xml
@@ -151,10 +151,11 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-          <version>1.3.2</version>
-        </dependency>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+          <version>2.1.1</version>
+      </dependency>
+
       </dependencies>
     </profile>
   </profiles>

--- a/vertx-grpc-server/src/main/java/examples/GreeterGrpc.java
+++ b/vertx-grpc-server/src/main/java/examples/GreeterGrpc.java
@@ -7,7 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * The greeting service definition.
  * </pre>
  */
-@javax.annotation.Generated(
+@jakarta.annotation.Generated(
     value = "by gRPC proto compiler (version 1.50.2)",
     comments = "Source: helloworld.proto")
 @io.grpc.stub.annotations.GrpcGenerated

--- a/vertx-grpc-server/src/main/java/examples/StreamingGrpc.java
+++ b/vertx-grpc-server/src/main/java/examples/StreamingGrpc.java
@@ -7,7 +7,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * Interface exported by the server.
  * </pre>
  */
-@javax.annotation.Generated(
+@jakarta.annotation.Generated(
     value = "by gRPC proto compiler (version 1.50.2)",
     comments = "Source: streaming.proto")
 @io.grpc.stub.annotations.GrpcGenerated


### PR DESCRIPTION
Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Upgrade to jakarta-annotation-api, javax.annotation-api has been deprecated

related: https://github.com/etcd-io/jetcd/issues/1243

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
