### PR TITLE
Timeout and deadline

### DIFF
--- a/vertx-grpc-client/src/main/asciidoc/client.adoc
+++ b/vertx-grpc-client/src/main/asciidoc/client.adoc
@@ -1,8 +1,8 @@
 == Vert.x gRPC Client
 
-Vert.x gRPC Client is a new gRPC client powered by Vert.x HTTP client superseding the integrated Netty based gRPC client.
+Vert.x gRPC Client is a gRPC client powered by Vert.x HTTP client.
 
-This client provides a gRPC request/response oriented API as well as a the generated stub approach with a gRPC Channel
+This client provides a gRPC request/response oriented API as well as a generated stub approach with a gRPC Channel
 
 === Using Vert.x gRPC Client
 
@@ -41,7 +41,7 @@ You can easily create the gRPC client
 
 ==== Request/response
 
-Any interaction with a gRPC server involves creating a request to the remote gRPC service
+Interacting with a gRPC server involves creating a request to the remote gRPC service
 
 [source,java]
 ----
@@ -65,7 +65,7 @@ Future composition can combine all the previous steps together in a compact fash
 
 ==== Streaming request
 
-A streaming request involves calling `{@link io.vertx.grpc.client.GrpcClientRequest#write}` for each element of the stream
+Streaming requests involve calling `{@link io.vertx.grpc.client.GrpcClientRequest#write}` for each element of the stream
 and using `{@link io.vertx.grpc.client.GrpcClientRequest#end()}` to end the stream
 
 [source,java]
@@ -75,7 +75,7 @@ and using `{@link io.vertx.grpc.client.GrpcClientRequest#end()}` to end the stre
 
 ==== Streaming response
 
-You can set handlers to process response events
+You can set handlers to process response events of a streaming response
 
 [source,java]
 ----
@@ -104,6 +104,26 @@ You can pause/resume/fetch a response
 {@link examples.GrpcClientExamples#responseFlowControl}
 ----
 
+=== Timeout and deadlines
+
+The gRPC client handles timeout and deadlines, setting a timeout on a gRPC request instructs the client to send the timeout
+information to make the server aware that the client desires a response within a defined time.
+
+In addition, the client shall be configured to schedule a deadline: when a timeout is set on a request, the client schedules
+locally a timer to cancel the request when the response has not been received in time.
+
+[source,java]
+----
+{@link examples.GrpcClientExamples#requestWithDeadline}
+----
+
+The timeout can also be set on a per-request basis.
+
+[source,java]
+----
+{@link examples.GrpcClientExamples#requestWithDeadline2}
+----
+
 === Cancellation
 
 You can call `{@link io.vertx.grpc.client.GrpcClientRequest#cancel}` to cancel a request
@@ -126,7 +146,7 @@ You can compress request messages by setting the request encoding *prior* before
 
 === Decompression
 
-Decompression is done transparently by the client when the server send encoded responses.
+Decompression is achieved transparently by the client when the server sends encoded responses.
 
 === Stub API
 
@@ -134,8 +154,19 @@ The Vert.x gRPC Client provides a gRPC channel to use with a generated client st
 
 [source,java]
 ----
-{@link examples.GrpcClientExamples#stubExample}
+{@link examples.GrpcClientExamples#stub}
 ----
+
+Timeout and deadlines are supported through the usual gRPC API.
+
+[source,java]
+----
+{@link examples.GrpcClientExamples#stubWithDeadline}
+----
+
+Deadline are cascaded, e.g. when the current `io.grpc.Context` carries a deadline and the stub has no explicit deadline
+set, the client automatically inherits the implicit deadline. Such deadline can be set when using a stub within a gRPC server
+call.
 
 === Message level API
 

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClient.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClient.java
@@ -53,6 +53,28 @@ public interface GrpcClient {
   }
 
   /**
+   * Create a client.
+   *
+   * @param vertx the vertx instance
+   * @return the created client
+   */
+  static GrpcClient client(Vertx vertx, GrpcClientOptions options) {
+    return new GrpcClientImpl(vertx, options, new HttpClientOptions().setHttp2ClearTextUpgrade(false));
+  }
+
+  /**
+   * Create a client with the specified {@code options}.
+   *
+   * @param vertx the vertx instance
+   * @param grpcOptions the http client options
+   * @param httpOptions the http client options
+   * @return the created client
+   */
+  static GrpcClient client(Vertx vertx, GrpcClientOptions grpcOptions, HttpClientOptions httpOptions) {
+    return new GrpcClientImpl(vertx, grpcOptions, httpOptions);
+  }
+
+  /**
    * Create a client with the specified {@code options}.
    *
    * @param vertx the vertx instance
@@ -60,7 +82,7 @@ public interface GrpcClient {
    * @return the created client
    */
   static GrpcClient client(Vertx vertx, HttpClientOptions options) {
-    return new GrpcClientImpl(vertx, options);
+    return new GrpcClientImpl(vertx, new GrpcClientOptions(), options);
   }
 
   /**

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientChannel.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientChannel.java
@@ -38,10 +38,11 @@ public class GrpcClientChannel extends io.grpc.Channel {
       compressor = null;
     }
     Executor exec = callOptions.getExecutor();
+    Context ctx = Context.current();
     Deadline deadline = callOptions.getDeadline();
-    if (deadline == null) {
-      Context ctx = Context.current();
-      deadline = ctx.getDeadline();
+    Deadline contextDeadline = ctx.getDeadline();
+    if (contextDeadline != null && (deadline == null || contextDeadline.isBefore(deadline))) {
+      deadline = contextDeadline;
     }
     return new VertxClientCall<>(client, server, exec, methodDescriptor, encoding, compressor, deadline);
   }
@@ -50,5 +51,4 @@ public class GrpcClientChannel extends io.grpc.Channel {
   public String authority() {
     return null;
   }
-
 }

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientChannel.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientChannel.java
@@ -10,11 +10,7 @@
  */
 package io.vertx.grpc.client;
 
-import io.grpc.CallOptions;
-import io.grpc.ClientCall;
-import io.grpc.Compressor;
-import io.grpc.CompressorRegistry;
-import io.grpc.MethodDescriptor;
+import io.grpc.*;
 import io.vertx.core.net.SocketAddress;
 
 import java.util.concurrent.Executor;
@@ -34,20 +30,20 @@ public class GrpcClientChannel extends io.grpc.Channel {
 
   @Override
   public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
-
     String encoding = callOptions.getCompressor();
-
     Compressor compressor;
     if (encoding != null) {
       compressor = CompressorRegistry.getDefaultInstance().lookupCompressor(encoding);
     } else {
       compressor = null;
     }
-
-
     Executor exec = callOptions.getExecutor();
-
-    return new VertxClientCall<>(client, server, exec, methodDescriptor, encoding, compressor);
+    Deadline deadline = callOptions.getDeadline();
+    if (deadline == null) {
+      Context ctx = Context.current();
+      deadline = ctx.getDeadline();
+    }
+    return new VertxClientCall<>(client, server, exec, methodDescriptor, encoding, compressor, deadline);
   }
 
   @Override

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientOptions.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientOptions.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.client;
+
+import io.vertx.codegen.annotations.DataObject;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Options configuring a gRPC client.
+ */
+@DataObject
+public class GrpcClientOptions {
+
+  /**
+   * The default value for automatic deadline schedule = {@code false}.
+   */
+  public static final boolean DEFAULT_SCHEDULE_DEADLINE_AUTOMATICALLY = false;
+
+  /**
+   * The default value of the timeout = {@code 0} (no timeout).
+   */
+  public static final int DEFAULT_TIMEOUT = 0;
+
+  /**
+   * The default value of the timeout unit = {@link TimeUnit#SECONDS}.
+   */
+  public static final TimeUnit DEFAULT_TIMEOUT_UNIT = TimeUnit.SECONDS;
+
+  private boolean scheduleDeadlineAutomatically;
+  private int timeout;
+  private TimeUnit timeoutUnit;
+
+  /**
+   * Default constructor.
+   */
+  public GrpcClientOptions() {
+    scheduleDeadlineAutomatically = DEFAULT_SCHEDULE_DEADLINE_AUTOMATICALLY;
+    timeout = DEFAULT_TIMEOUT;
+    timeoutUnit = DEFAULT_TIMEOUT_UNIT;
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * @param other the options to copy
+   */
+  public GrpcClientOptions(GrpcClientOptions other) {
+    scheduleDeadlineAutomatically = other.scheduleDeadlineAutomatically;
+    timeout = other.timeout;
+    timeoutUnit = other.timeoutUnit;
+  }
+
+  /**
+   * @return whether the client will automatically schedule a deadline when a request carrying a timeout is sent.
+   */
+  public boolean getScheduleDeadlineAutomatically() {
+    return scheduleDeadlineAutomatically;
+  }
+
+  /**
+   * <p>Set whether a deadline is automatically scheduled when a request carrying a timeout (either set explicitly or through this
+   * options instance) is sent.</p>
+   *
+   * <ul>
+   * <li>When the automatic deadline is set and a request carrying a timeout is sent, a deadline (timer) is created to cancel the request
+   * when the response has not been timely received. The deadline can be obtained with {@link GrpcClientRequest#deadline()}.</li>
+   * <li>When the deadline is not set and a request carrying a timeout is sent, the timeout is sent to the server and it remains the
+   * responsibility of the caller to eventually cancel the request. Note: the server might cancel the request as well when its local deadline is met.</li>
+   * </ul>
+   *
+   * @param handleDeadlineAutomatically whether to automatically set
+   * @return a reference to this, so the API can be used fluently
+   */
+  public GrpcClientOptions setScheduleDeadlineAutomatically(boolean handleDeadlineAutomatically) {
+    this.scheduleDeadlineAutomatically = handleDeadlineAutomatically;
+    return this;
+  }
+
+  /**
+   * Return the default timeout set when sending gRPC requests, the initial value is {@code 0} which does not
+   * send a timeout.
+   *
+   * @return the default timeout.
+   */
+  public int getTimeout() {
+    return timeout;
+  }
+
+  /**
+   * Set the default timeout set when sending gRPC requests, this value should be set along with {@link #setTimeoutUnit(TimeUnit)}.
+   *
+   * @param timeout the timeout value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public GrpcClientOptions setTimeout(int timeout) {
+    if (timeout < 0L) {
+      throw new IllegalArgumentException("Timeout value must be >= 0");
+    }
+    this.timeout = timeout;
+    return this;
+  }
+
+  /**
+   * @return the unit of time of the default timeout.
+   */
+  public TimeUnit getTimeoutUnit() {
+    return timeoutUnit;
+  }
+
+  /**
+   * Set the unit of time of the default timeout value.
+   *
+   * @param timeoutUnit the unit of time
+   * @return a reference to this, so the API can be used fluently
+   */
+  public GrpcClientOptions setTimeoutUnit(TimeUnit timeoutUnit) {
+    this.timeoutUnit = Objects.requireNonNull(timeoutUnit);
+    return this;
+  }
+}

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
@@ -25,6 +25,8 @@ import io.vertx.core.streams.ReadStream;
 import io.vertx.grpc.common.GrpcWriteStream;
 import io.vertx.grpc.common.ServiceName;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A request to a gRPC server.
  *
@@ -94,6 +96,9 @@ public interface GrpcClientRequest<Req, Resp> extends GrpcWriteStream<Req> {
 
   @Override
   GrpcClientRequest<Req, Resp> drainHandler(@Nullable Handler<Void> handler);
+
+  @Fluent
+  GrpcClientRequest<Req, Resp> timeout(long timeout, TimeUnit unit);
 
   /**
    * Sets the amount of time after which, if the request does not return any data within the timeout period,

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
@@ -94,13 +94,24 @@ public interface GrpcClientRequest<Req, Resp> extends GrpcWriteStream<Req> {
   @Override
   GrpcClientRequest<Req, Resp> drainHandler(@Nullable Handler<Void> handler);
 
+  /**
+   * <p>Set a {@code grpc-timeout} header to be sent to the server to indicate the client expects a response with
+   * a timeout.</p>
+   *
+   * <p>When the request handle deadline a timer will be set when sending the request to cancel the request when the response
+   * has not been received in time.</p>
+   *
+   * @param timeout
+   * @param unit
+   * @return
+   */
   @Fluent
   GrpcClientRequest<Req, Resp> timeout(long timeout, TimeUnit unit);
 
   /**
-   * Schedule a deadline when sending this request
+   * @return the request deadline or {@code null} when no deadline has been scheduled
    */
-  Timer scheduleDeadline();
+  Timer deadline();
 
   /**
    * Sets the amount of time after which, if the request does not return any data within the timeout period,

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
@@ -16,11 +16,8 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.Timer;
 import io.vertx.core.http.HttpConnection;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.grpc.common.GrpcWriteStream;
 import io.vertx.grpc.common.ServiceName;
@@ -99,6 +96,11 @@ public interface GrpcClientRequest<Req, Resp> extends GrpcWriteStream<Req> {
 
   @Fluent
   GrpcClientRequest<Req, Resp> timeout(long timeout, TimeUnit unit);
+
+  /**
+   * Schedule a deadline when sending this request
+   */
+  Timer scheduleDeadline();
 
   /**
    * Sets the amount of time after which, if the request does not return any data within the timeout period,

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/VertxClientCall.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/VertxClientCall.java
@@ -79,12 +79,7 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
         if (deadline != null) {
           long timeout = deadline.timeRemaining(TimeUnit.MILLISECONDS);
           request.timeout(timeout, TimeUnit.MILLISECONDS);
-          sf = deadline.runOnExpiration(new Runnable() {
-            @Override
-            public void run() {
-              request.cancel();
-            }
-          }, new VertxScheduledExecutorService(((GrpcClientRequestImpl)request).context()));
+          sf = deadline.runOnExpiration(() -> request.cancel(), new VertxScheduledExecutorService(((GrpcClientRequestImpl)request).context()));
         } else {
           sf = null;
         }

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
@@ -75,9 +75,6 @@ public class GrpcClientResponseImpl<Req, Resp> extends GrpcReadStreamBase<GrpcCl
   }
 
   protected void handleEnd() {
-//    if (grpcContext instanceof Context.CancellableContext) {
-//      ((Context.CancellableContext)grpcContext).close();
-//    }
     request.cancelTimeout();
     String responseStatus = httpResponse.getTrailer("grpc-status");
     if (responseStatus != null) {

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
@@ -40,10 +40,9 @@ public class GrpcClientResponseImpl<Req, Resp> extends GrpcReadStreamBase<GrpcCl
   private String encoding;
 
   public GrpcClientResponseImpl(ContextInternal context,
-                                io.grpc.Context grpcContext,
                                 GrpcClientRequestImpl<Req, Resp> request,
                                 HttpClientResponse httpResponse, GrpcMessageDecoder<Resp> messageDecoder) {
-    super(context, grpcContext, httpResponse, httpResponse.headers().get("grpc-encoding"), messageDecoder);
+    super(context, httpResponse, httpResponse.headers().get("grpc-encoding"), messageDecoder);
     this.request = request;
     this.encoding = httpResponse.headers().get("grpc-encoding");
     this.httpResponse = httpResponse;
@@ -76,9 +75,10 @@ public class GrpcClientResponseImpl<Req, Resp> extends GrpcReadStreamBase<GrpcCl
   }
 
   protected void handleEnd() {
-    if (grpcContext instanceof Context.CancellableContext) {
-      ((Context.CancellableContext)grpcContext).close();
-    }
+//    if (grpcContext instanceof Context.CancellableContext) {
+//      ((Context.CancellableContext)grpcContext).close();
+//    }
+    request.cancelTimeout();
     String responseStatus = httpResponse.getTrailer("grpc-status");
     if (responseStatus != null) {
       status = GrpcStatus.valueOf(Integer.parseInt(responseStatus));

--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/ClientRequestTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/ClientRequestTest.java
@@ -536,7 +536,9 @@ public class ClientRequestTest extends ClientTest {
     client = GrpcClient.client(vertx);
     client.request(SocketAddress.inetSocketAddress(port, "localhost"), StreamingGrpc.getSinkMethod())
       .onComplete(should.asyncAssertSuccess(callRequest -> {
-        callRequest.timeout(1, TimeUnit.SECONDS);
+        callRequest
+          .timeout(1, TimeUnit.SECONDS)
+          .scheduleDeadline();
         callRequest.write(Item.getDefaultInstance());
         callRequest.response().onComplete(should.asyncAssertFailure(err -> {
           should.assertTrue(err instanceof StreamResetException);
@@ -554,7 +556,9 @@ public class ClientRequestTest extends ClientTest {
     client = GrpcClient.client(vertx);
     client.request(SocketAddress.inetSocketAddress(port, "localhost"), GreeterGrpc.getSayHelloMethod())
       .onComplete(should.asyncAssertSuccess(callRequest -> {
-        callRequest.timeout(10, TimeUnit.SECONDS);
+        callRequest
+          .timeout(10, TimeUnit.SECONDS)
+          .scheduleDeadline();
         callRequest.end(HelloRequest.newBuilder().setName("Julien").build());
         callRequest.response().onComplete(should.asyncAssertSuccess(e -> {
           long timeRemaining = cf.getNow(-1L);

--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/ClientTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/ClientTest.java
@@ -19,6 +19,7 @@ import io.grpc.examples.streaming.Item;
 import io.grpc.examples.streaming.StreamingGrpc;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.StreamResetException;
 import io.vertx.core.net.SocketAddress;

--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/ClientTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/ClientTest.java
@@ -379,6 +379,8 @@ public abstract class ClientTest extends ClientTestBase {
     HttpServer server = vertx.createHttpServer();
     server
       .requestHandler(request -> {
+        String timeout = request.getHeader("grpc-timeout");
+        should.assertNotNull(timeout);
         request.response().exceptionHandler(err -> {
           should.assertEquals(StreamResetException.class, err.getClass());
           StreamResetException reset = (StreamResetException) err;

--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/impl/TimeoutValueTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/impl/TimeoutValueTest.java
@@ -1,0 +1,28 @@
+package io.vertx.grpc.client.impl;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimeoutValueTest {
+
+  private static final long MAX = 99_999_999;
+
+  @Test
+  public void testValue() {
+    assertEquals(MAX + "n", GrpcClientRequestImpl.toTimeoutHeader(MAX, TimeUnit.NANOSECONDS));
+    assertEquals((MAX + 1) / 1000 + "u", GrpcClientRequestImpl.toTimeoutHeader(MAX + 1, TimeUnit.NANOSECONDS));
+    assertEquals(MAX + "u", GrpcClientRequestImpl.toTimeoutHeader(MAX, TimeUnit.MICROSECONDS));
+    assertEquals((MAX + 1) / 1000 + "m", GrpcClientRequestImpl.toTimeoutHeader(MAX + 1, TimeUnit.MICROSECONDS));
+    assertEquals(MAX + "m", GrpcClientRequestImpl.toTimeoutHeader(MAX, TimeUnit.MILLISECONDS));
+    assertEquals((MAX + 1) / 1000 + "S", GrpcClientRequestImpl.toTimeoutHeader(MAX + 1, TimeUnit.MILLISECONDS));
+    assertEquals(MAX + "S", GrpcClientRequestImpl.toTimeoutHeader(MAX, TimeUnit.SECONDS));
+    assertEquals((MAX + 1) / 60 + "M", GrpcClientRequestImpl.toTimeoutHeader(MAX + 1, TimeUnit.SECONDS));
+    assertEquals(MAX + "M", GrpcClientRequestImpl.toTimeoutHeader(MAX, TimeUnit.MINUTES));
+    assertEquals((MAX + 1) / 60 + "H", GrpcClientRequestImpl.toTimeoutHeader(MAX + 1, TimeUnit.MINUTES));
+    assertEquals(MAX + "H", GrpcClientRequestImpl.toTimeoutHeader(MAX, TimeUnit.HOURS));
+    assertEquals(null, GrpcClientRequestImpl.toTimeoutHeader(MAX + 1, TimeUnit.HOURS));
+  }
+}

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
@@ -213,7 +213,6 @@ public abstract class GrpcReadStreamBase<S extends GrpcReadStreamBase<S, T>, T> 
 
   @Override
   public Future<Void> end() {
-    // SHOULD BE MAPPED ON GRPC CONTEXT TOO ????
     return end.future();
   }
 }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcRequestLocal.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcRequestLocal.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.common.impl;
+
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+/**
+ * Request local for deadline propagation.
+ */
+public class GrpcRequestLocal {
+
+  /**
+   * Context local key.
+   */
+  public static final ContextLocal<GrpcRequestLocal> CONTEXT_LOCAL_KEY = GrpcRequestLocalRegistration.CONTEXT_LOCAL;
+
+  public final long deadline;
+
+  public GrpcRequestLocal(long deadline) {
+    this.deadline = deadline;
+  }
+}

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcRequestLocalRegistration.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcRequestLocalRegistration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.common.impl;
+
+import io.vertx.core.impl.VertxBuilder;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+/**
+ * Registration of context local for {@link GrpcRequestLocal}.
+ */
+public class GrpcRequestLocalRegistration implements VertxServiceProvider {
+
+  static final ContextLocal<GrpcRequestLocal> CONTEXT_LOCAL = ContextLocal.registerLocal(GrpcRequestLocal.class);
+
+  @Override
+  public void init(VertxBuilder builder) {
+  }
+}

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/VertxScheduledExecutorService.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/VertxScheduledExecutorService.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.grpc.common.impl;
 
 import io.netty.channel.EventLoop;
@@ -6,6 +16,9 @@ import io.vertx.core.impl.ContextInternal;
 import java.util.List;
 import java.util.concurrent.*;
 
+/**
+ * Minimalistic scheduler for gRPC deadlines.
+ */
 public class VertxScheduledExecutorService extends AbstractExecutorService implements ScheduledExecutorService {
 
   private final io.vertx.core.impl.ContextInternal vertxContext;
@@ -16,7 +29,6 @@ public class VertxScheduledExecutorService extends AbstractExecutorService imple
 
   @Override
   public void shutdown() {
-
   }
 
   @Override

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/VertxScheduledExecutorService.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/VertxScheduledExecutorService.java
@@ -1,0 +1,68 @@
+package io.vertx.grpc.common.impl;
+
+import io.netty.channel.EventLoop;
+import io.vertx.core.impl.ContextInternal;
+
+import java.util.List;
+import java.util.concurrent.*;
+
+public class VertxScheduledExecutorService extends AbstractExecutorService implements ScheduledExecutorService {
+
+  private final io.vertx.core.impl.ContextInternal vertxContext;
+
+  public VertxScheduledExecutorService(io.vertx.core.Context vertxContext) {
+    this.vertxContext = (ContextInternal) vertxContext;
+  }
+
+  @Override
+  public void shutdown() {
+
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return null;
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return false;
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return false;
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return false;
+  }
+
+  @Override
+  public void execute(Runnable command) {
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+    EventLoop el = vertxContext.nettyEventLoop();
+    return el.schedule(() -> {
+      vertxContext.dispatch(command);
+    }, delay, unit);
+  }
+
+  @Override
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/vertx-grpc-common/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/vertx-grpc-common/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.vertx.grpc.common.impl.GrpcRequestLocalRegistration

--- a/vertx-grpc-context-storage/pom.xml
+++ b/vertx-grpc-context-storage/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-grpc-server</artifactId>
-      <scope>test</scope>
+<!--      <scope>test</scope>-->
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/vertx-grpc-context-storage/pom.xml
+++ b/vertx-grpc-context-storage/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-grpc-server</artifactId>
-<!--      <scope>test</scope>-->
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/vertx-grpc-context-storage/src/main/java/io/vertx/grpc/contextstorage/ContextStorageService.java
+++ b/vertx-grpc-context-storage/src/main/java/io/vertx/grpc/contextstorage/ContextStorageService.java
@@ -1,0 +1,17 @@
+package io.vertx.grpc.contextstorage;
+
+import io.vertx.core.impl.VertxBuilder;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+/**
+ * Register the local storage.
+ */
+public class ContextStorageService implements VertxServiceProvider {
+
+  public static final ContextLocal<GrpcStorage> CONTEXT_LOCAL = ContextLocal.registerLocal(GrpcStorage.class);
+
+  @Override
+  public void init(VertxBuilder builder) {
+  }
+}

--- a/vertx-grpc-context-storage/src/main/java/io/vertx/grpc/contextstorage/DumbClass.java
+++ b/vertx-grpc-context-storage/src/main/java/io/vertx/grpc/contextstorage/DumbClass.java
@@ -1,7 +1,0 @@
-package io.vertx.grpc.contextstorage;
-
-/**
- * Seems necessary to generate javadoc jar
- */
-public class DumbClass {
-}

--- a/vertx-grpc-context-storage/src/main/java/io/vertx/grpc/contextstorage/GrpcStorage.java
+++ b/vertx-grpc-context-storage/src/main/java/io/vertx/grpc/contextstorage/GrpcStorage.java
@@ -1,0 +1,18 @@
+package io.vertx.grpc.contextstorage;
+
+import io.grpc.Context;
+import io.vertx.core.impl.ContextInternal;
+
+/**
+ * gRPC context storage.
+ */
+public class GrpcStorage {
+
+  public final io.grpc.Context currentGrpcContext;
+  public final io.vertx.core.impl.ContextInternal prevVertxContext;
+
+  public GrpcStorage(Context currentGrpcContext, ContextInternal prevVertxContext) {
+    this.currentGrpcContext = currentGrpcContext;
+    this.prevVertxContext = prevVertxContext;
+  }
+}

--- a/vertx-grpc-context-storage/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/vertx-grpc-context-storage/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.vertx.grpc.contextstorage.ContextStorageService

--- a/vertx-grpc-context-storage/src/test/java/io/vertx/grpc/context/storage/ContextStorageTest.java
+++ b/vertx-grpc-context-storage/src/test/java/io/vertx/grpc/context/storage/ContextStorageTest.java
@@ -30,10 +30,7 @@ import io.vertx.ext.unit.junit.RepeatRule;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServiceBridge;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 
 import java.util.UUID;
@@ -65,6 +62,7 @@ public class ContextStorageTest {
     }
   }
 
+  @Ignore
   @Test
   @Repeat(10)
   public void testGrpcContextPropagatedAcrossVertxAsyncCalls(TestContext should) {

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/DeadlineTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/DeadlineTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.it;
+
+import io.grpc.Context;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.stub.StreamObserver;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.StreamResetException;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.client.GrpcClientChannel;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.GrpcServerResponse;
+import io.vertx.grpc.server.GrpcServiceBridge;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class DeadlineTest extends ProxyTestBase {
+
+  @Test
+  public void testAutomaticPropagation(TestContext should) {
+    Async latch = should.async(3);
+    GrpcClient client = GrpcClient.client(vertx);
+    Future<HttpServer> server = vertx.createHttpServer().requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpc.getSayHelloMethod(), call -> {
+      should.assertTrue(call.timeout() > 0L);
+      call.response().exceptionHandler(err -> {
+        should.assertTrue(err instanceof StreamResetException);
+        StreamResetException sre = (StreamResetException) err;
+        should.assertEquals(8L, sre.getCode());
+        latch.countDown();
+      });
+    })).listen(8080, "localhost");
+    GrpcClientChannel proxyChannel = new GrpcClientChannel(client, SocketAddress.inetSocketAddress(8080, "localhost"));
+    GreeterGrpc.GreeterStub stub = GreeterGrpc.newStub(proxyChannel);
+    GreeterGrpc.GreeterImplBase impl = new GreeterGrpc.GreeterImplBase() {
+      @Override
+      public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+        should.assertNotNull(Context.current().getDeadline());
+        stub.sayHello(HelloRequest.newBuilder().setName("Julien").build(), new StreamObserver<HelloReply>() {
+          @Override
+          public void onNext(HelloReply helloReply) {
+            should.fail();
+          }
+          @Override
+          public void onError(Throwable throwable) {
+            should.assertTrue(throwable instanceof StatusRuntimeException);
+            StatusRuntimeException sre = (StatusRuntimeException) throwable;
+            should.assertEquals(Status.CANCELLED, sre.getStatus());
+            latch.countDown();
+          }
+          @Override
+          public void onCompleted() {
+            should.fail();
+          }
+        });
+      }
+    };
+    GrpcServer proxy = GrpcServer.server(vertx);
+    GrpcServiceBridge serverStub = GrpcServiceBridge.bridge(impl);
+    serverStub.bind(proxy);
+    HttpServer proxyServer = vertx.createHttpServer().requestHandler(proxy);
+    server.flatMap(v -> proxyServer.listen(8081, "localhost")).onComplete(should.asyncAssertSuccess(v -> {
+      client.request(SocketAddress.inetSocketAddress(8081, "localhost"), GreeterGrpc.getSayHelloMethod())
+        .onComplete(should.asyncAssertSuccess(callRequest -> {
+          callRequest.response().onComplete(should.asyncAssertSuccess(callResponse -> {
+            should.assertEquals(GrpcStatus.DEADLINE_EXCEEDED, callResponse.status());
+            latch.countDown();
+          }));
+          callRequest.timeout(2, TimeUnit.SECONDS).end(HelloRequest.newBuilder().setName("Julien").build());
+
+        }));
+    }));
+    latch.awaitSuccess();
+  }
+}

--- a/vertx-grpc-server/src/main/asciidoc/server.adoc
+++ b/vertx-grpc-server/src/main/asciidoc/server.adoc
@@ -127,6 +127,34 @@ You can check the writability of a response and set a drain handler
 {@link examples.GrpcServerExamples#responseFlowControl}
 ----
 
+=== Timeout and deadlines
+
+The gRPC server handles timeout and deadlines.
+
+Whenever the service receives a request indicating a timeout, the timeout can be retrieved.
+
+[source,java]
+----
+{@link examples.GrpcServerExamples#checkTimeout}
+----
+
+By default, the server
+
+- does not schedule automatically a deadline for a given request
+- does not automatically propagate the deadline to a vertx client
+
+The server can schedule deadlines: when a request carries a timeout, the server schedules
+locally a timer to cancel the request when the response has not been sent in time.
+
+The server can propagate deadlines: when a request carries a timeout, the server calculate the deadline
+and associate the current server request with this deadline. Vert.x gRPC client can use this deadline to compute
+a timeout to be sent and cascade the timeout to another gRPC server.
+
+[source,java]
+----
+{@link examples.GrpcServerExamples#deadlineConfiguration}
+----
+
 === Compression
 
 You can compress response messages by setting the response encoding *prior* before sending any message
@@ -152,6 +180,8 @@ The Vert.x gRPC Server can bridge a gRPC service to use with a generated server 
 ----
 {@link examples.GrpcServerExamples#stubExample}
 ----
+
+The bridge supports deadline automatic cancellation: when a gRPC request carrying a timeout is received, a deadline is associated with the `io.grpc.Context` an can be obtained from the current context. This deadline automatically cancels the request in progress when its associated timeout fires.
 
 === Message level API
 

--- a/vertx-grpc-server/src/main/generated/io/vertx/grpc/server/GrpcServerOptionsConverter.java
+++ b/vertx-grpc-server/src/main/generated/io/vertx/grpc/server/GrpcServerOptionsConverter.java
@@ -25,6 +25,16 @@ public class GrpcServerOptionsConverter {
             obj.setGrpcWebEnabled((Boolean)member.getValue());
           }
           break;
+        case "scheduleDeadlineAutomatically":
+          if (member.getValue() instanceof Boolean) {
+            obj.setScheduleDeadlineAutomatically((Boolean)member.getValue());
+          }
+          break;
+        case "deadlinePropagation":
+          if (member.getValue() instanceof Boolean) {
+            obj.setDeadlinePropagation((Boolean)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -35,5 +45,7 @@ public class GrpcServerOptionsConverter {
 
    static void toJson(GrpcServerOptions obj, java.util.Map<String, Object> json) {
     json.put("grpcWebEnabled", obj.isGrpcWebEnabled());
+    json.put("scheduleDeadlineAutomatically", obj.getScheduleDeadlineAutomatically());
+    json.put("deadlinePropagation", obj.getDeadlinePropagation());
   }
 }

--- a/vertx-grpc-server/src/main/java/examples/GrpcServerExamples.java
+++ b/vertx-grpc-server/src/main/java/examples/GrpcServerExamples.java
@@ -11,10 +11,7 @@ import io.vertx.docgen.Source;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.GrpcServerRequest;
-import io.vertx.grpc.server.GrpcServerResponse;
-import io.vertx.grpc.server.GrpcServiceBridge;
+import io.vertx.grpc.server.*;
 
 @Source
 public class GrpcServerExamples {
@@ -114,6 +111,22 @@ public class GrpcServerExamples {
     } else {
       response.write(item);
     }
+  }
+
+  public void checkTimeout(GrpcServerRequest<Empty, Item> request) {
+
+    long timeout = request.timeout();
+
+    if (timeout > 0L) {
+      // A timeout has been received
+    }
+  }
+
+  public void deadlineConfiguration(Vertx vertx) {
+    GrpcServer server = GrpcServer.server(vertx, new GrpcServerOptions()
+      .setScheduleDeadlineAutomatically(true)
+      .setDeadlinePropagation(true)
+    );
   }
 
   public void responseCompression(GrpcServerResponse<Empty, Item> response) {

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerOptions.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerOptions.java
@@ -24,17 +24,31 @@ import io.vertx.core.json.JsonObject;
 public class GrpcServerOptions {
 
   /**
-   * Whether the gRPC-Web protocol should be enabled, by default = true.
+   * Whether the gRPC-Web protocol should be enabled, by default = {@code true}.
    */
   public static final boolean DEFAULT_GRPC_WEB_ENABLED = true;
 
+  /**
+   * Whether the server schedule deadline automatically when a request carrying a timeout is received, by default = {@code false}
+   */
+  public static final boolean DEFAULT_SCHEDULE_DEADLINE_AUTOMATICALLY = false;
+
+  /**
+   * Whether the server propagates a deadline, by default = {@code false}
+   */
+  public static final boolean DEFAULT_PROPAGATE_DEADLINE = false;
+
   private boolean grpcWebEnabled;
+  private boolean scheduleDeadlineAutomatically;
+  private boolean deadlinePropagation;
 
   /**
    * Default options.
    */
   public GrpcServerOptions() {
     grpcWebEnabled = DEFAULT_GRPC_WEB_ENABLED;
+    scheduleDeadlineAutomatically = DEFAULT_SCHEDULE_DEADLINE_AUTOMATICALLY;
+    deadlinePropagation = DEFAULT_PROPAGATE_DEADLINE;
   }
 
   /**
@@ -42,6 +56,8 @@ public class GrpcServerOptions {
    */
   public GrpcServerOptions(GrpcServerOptions other) {
     grpcWebEnabled = other.grpcWebEnabled;
+    scheduleDeadlineAutomatically = other.scheduleDeadlineAutomatically;
+    deadlinePropagation = other.deadlinePropagation;
   }
 
   /**
@@ -71,6 +87,50 @@ public class GrpcServerOptions {
   }
 
   /**
+   * @return whether the server will automatically schedule a deadline when a request carrying a timeout is received.
+   */
+  public boolean getScheduleDeadlineAutomatically() {
+    return scheduleDeadlineAutomatically;
+  }
+
+  /**
+   * <p>Set whether a deadline is automatically scheduled when a request carrying a timeout is received.</p>
+   * <ul>
+   * <li>When a deadline is automatically scheduled and a request carrying a timeout is received, a deadline (timer)
+   * will be created to cancel the request when the response has not been timely sent. The deadline can be obtained
+   * with {@link GrpcServerRequest#deadline()}.</li>
+   * <li>When the deadline is not set and a request carrying a timeout is received, the timeout is available with {@link GrpcServerRequest#timeout()}
+   * and it is the responsibility of the service to eventually cancel the request. Note: the client might cancel the request as well when its local
+   * deadline is met.</li>
+   * </ul>
+   *
+   * @param scheduleDeadlineAutomatically whether to schedule a deadline automatically
+   * @return a reference to this, so the API can be used fluently
+   */
+  public GrpcServerOptions setScheduleDeadlineAutomatically(boolean scheduleDeadlineAutomatically) {
+    this.scheduleDeadlineAutomatically = scheduleDeadlineAutomatically;
+    return this;
+  }
+
+  /**
+   * @return whether the server propagate deadlines to {@code io.vertx.grpc.client.GrpcClientRequest}.
+   */
+  public boolean getDeadlinePropagation() {
+    return deadlinePropagation;
+  }
+
+  /**
+   * Set whether the server propagate deadlines to {@code io.vertx.grpc.client.GrpcClientRequest}.
+   *
+   * @param deadlinePropagation the propagation setting
+   * @return a reference to this, so the API can be used fluently
+   */
+  public GrpcServerOptions setDeadlinePropagation(boolean deadlinePropagation) {
+    this.deadlinePropagation = deadlinePropagation;
+    return this;
+  }
+
+  /**
    * @return a JSON representation of options
    */
   public JsonObject toJson() {
@@ -81,8 +141,6 @@ public class GrpcServerOptions {
 
   @Override
   public String toString() {
-    return "GrpcServerOptions{" +
-           "grpcWebEnabled=" + grpcWebEnabled +
-           '}';
+    return toJson().encode();
   }
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerRequest.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerRequest.java
@@ -15,6 +15,7 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
+import io.vertx.core.Timer;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcMessage;
@@ -85,8 +86,8 @@ public interface GrpcServerRequest<Req, Resp> extends GrpcReadStream<Req> {
   long timeout();
 
   /**
-   * @return the clock value when the timeout expires or {@code 0L} if none.
+   * Schedule a deadline based on the current request timeout.
    */
-  long timeoutExpiration();
+  Timer scheduleDeadline();
 
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerRequest.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerRequest.java
@@ -78,4 +78,15 @@ public interface GrpcServerRequest<Req, Resp> extends GrpcReadStream<Req> {
    * @return the underlying HTTP connection
    */
   HttpConnection connection();
+
+  /**
+   * @return the request timeout sent by the client or {@code 0L} if none.
+   */
+  long timeout();
+
+  /**
+   * @return the clock value when the timeout expires or {@code 0L} if none.
+   */
+  long timeoutExpiration();
+
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerRequest.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerRequest.java
@@ -22,6 +22,8 @@ import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.GrpcReadStream;
 import io.vertx.grpc.common.ServiceName;
 
+import java.time.Instant;
+
 @VertxGen
 public interface GrpcServerRequest<Req, Resp> extends GrpcReadStream<Req> {
 
@@ -86,8 +88,8 @@ public interface GrpcServerRequest<Req, Resp> extends GrpcReadStream<Req> {
   long timeout();
 
   /**
-   * Schedule a deadline based on the current request timeout.
+   * @return the request deadline or {@code null} when no deadline has been scheduled
    */
-  Timer scheduleDeadline();
+  Timer deadline();
 
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -10,24 +10,31 @@
  */
 package io.vertx.grpc.server.impl;
 
+import io.grpc.Context;
 import io.grpc.MethodDescriptor;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.impl.HttpServerRequestInternal;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.grpc.common.GrpcMediaType;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
+import io.vertx.grpc.common.impl.VertxScheduledExecutorService;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerOptions;
 import io.vertx.grpc.server.GrpcServerRequest;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.Objects;
 
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
@@ -36,6 +43,21 @@ import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class GrpcServerImpl implements GrpcServer {
+
+  private static final Pattern TIMEOUT_PATTERN = Pattern.compile("([0-9]{1,8})([HMSmun])");
+
+  private static final Map<String, TimeUnit> TIMEOUT_MAPPING;
+
+  static {
+    Map<String, TimeUnit> timeoutMapping = new HashMap<>();
+    timeoutMapping.put("H", TimeUnit.HOURS);
+    timeoutMapping.put("M", TimeUnit.MINUTES);
+    timeoutMapping.put("S", TimeUnit.SECONDS);
+    timeoutMapping.put("m", TimeUnit.MILLISECONDS);
+    timeoutMapping.put("u", TimeUnit.MICROSECONDS);
+    timeoutMapping.put("n", TimeUnit.NANOSECONDS);
+    TIMEOUT_MAPPING = timeoutMapping;
+  }
 
   private static final Logger log = LoggerFactory.getLogger(GrpcServer.class);
 
@@ -62,9 +84,7 @@ public class GrpcServerImpl implements GrpcServer {
     } else {
       Handler<GrpcServerRequest<Buffer, Buffer>> handler = requestHandler;
       if (handler != null) {
-        GrpcServerRequestImpl<Buffer, Buffer> grpcRequest = new GrpcServerRequestImpl<>(httpRequest, GrpcMessageDecoder.IDENTITY, GrpcMessageEncoder.IDENTITY, methodCall);
-        grpcRequest.init();
-        handler.handle(grpcRequest);
+        handle(httpRequest, methodCall, GrpcMessageDecoder.IDENTITY, GrpcMessageEncoder.IDENTITY, handler);
       } else {
         httpRequest.response().setStatusCode(500).end();
       }
@@ -86,9 +106,42 @@ public class GrpcServerImpl implements GrpcServer {
   }
 
   private <Req, Resp> void handle(MethodCallHandler<Req, Resp> method, HttpServerRequest httpRequest, GrpcMethodCall methodCall) {
-    GrpcServerRequestImpl<Req, Resp> grpcRequest = new GrpcServerRequestImpl<>(httpRequest, method.messageDecoder, method.messageEncoder, methodCall);
+    handle(httpRequest, methodCall, method.messageDecoder, method.messageEncoder, method);
+  }
+
+  private <Req, Resp> void handle(HttpServerRequest httpRequest,
+                                  GrpcMethodCall methodCall,
+                                  GrpcMessageDecoder<Req> messageDecoder,
+                                  GrpcMessageEncoder<Resp> messageEncoder,
+                                  Handler<GrpcServerRequest<Req, Resp>> handler) {
+    io.vertx.core.impl.ContextInternal context = (ContextInternal) ((HttpServerRequestInternal) httpRequest).context();
+    String timeoutHeader = httpRequest.getHeader("grpc-timeout");
+    long timeout = timeoutHeader != null ? parseTimeout(timeoutHeader) : 0L;
+    Context grpcContext = Context.current();
+    if (timeout > 0L) {
+      grpcContext = grpcContext.withDeadlineAfter(timeout, TimeUnit.MILLISECONDS, new VertxScheduledExecutorService(context));
+    }
+    GrpcServerRequestImpl<Req, Resp> grpcRequest = new GrpcServerRequestImpl<>(grpcContext, context, httpRequest, messageDecoder, messageEncoder, methodCall);
     grpcRequest.init();
-    method.handle(grpcRequest);
+    if (timeout > 0L) {
+      Context.CancellableContext tmp = (Context.CancellableContext) grpcContext;
+      tmp.addListener(ctx -> {
+        grpcRequest.response.handleTimeout();
+      }, Runnable::run);
+
+    }
+    grpcRequest.grpcContext.run(() -> handler.handle(grpcRequest));
+  }
+
+  private static long parseTimeout(String timeout) {
+    Matcher matcher = TIMEOUT_PATTERN.matcher(timeout);
+    if (matcher.matches()) {
+      long value = Long.parseLong(matcher.group(1));
+      TimeUnit unit = TIMEOUT_MAPPING.get(matcher.group(2));
+      return unit.toMillis(value);
+    } else {
+      return 0L;
+    }
   }
 
   public GrpcServer callHandler(Handler<GrpcServerRequest<Buffer, Buffer>> handler) {

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -236,6 +236,7 @@ public class GrpcServerResponseImpl<Req, Resp> implements GrpcServerResponse<Req
     }
 
     if (end) {
+      request.cancelTimeout();
       if (!trailersSent) {
         trailersSent = true;
       }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServiceBridgeImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServiceBridgeImpl.java
@@ -65,6 +65,12 @@ public class GrpcServiceBridgeImpl implements GrpcServiceBridge {
   private <Req, Resp> void bind(GrpcServer server, ServerMethodDefinition<Req, Resp> methodDef) {
     server.callHandler(methodDef.getMethodDescriptor(), req -> {
       ServerCallHandler<Req, Resp> callHandler = methodDef.getServerCallHandler();
+
+//      if (req.timeout() > 0L) {
+//        Context ctx = Context.current();
+//        ctx.withDeadlineAfter(req.timeout(), req.timeoutExpiration())
+//      }
+
       ServerCallImpl<Req, Resp> call = new ServerCallImpl<>(req, methodDef);
       ServerCall.Listener<Req> listener = callHandler.startCall(call, Utils.readMetadata(req.headers()));
       call.init(listener);

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerBridgeTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerBridgeTest.java
@@ -21,17 +21,10 @@ import io.grpc.examples.streaming.StreamingGrpc;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
-import io.vertx.core.http.*;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.grpc.common.GrpcMessage;
-import io.vertx.grpc.common.GrpcMessageEncoder;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.impl.GrpcMessageImpl;
-import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -431,47 +424,6 @@ public class ServerBridgeTest extends ServerTest {
     startServer(server);
 
     super.testTimeoutOnServerBeforeSendingResponse(should);
-  }
-
-  @Ignore
-  @Test
-  public void testDeadline(TestContext should) {
-
-    GreeterGrpc.GreeterImplBase impl = new GreeterGrpc.GreeterImplBase() {
-      @Override
-      public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
-        System.out.println("HELLO");
-      }
-    };
-
-    GrpcServer server = GrpcServer.server(vertx);
-    GrpcServiceBridge serverStub = GrpcServiceBridge.bridge(impl);
-    serverStub.bind(server);
-    startServer(server);
-
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions()
-      .setHttp2ClearTextUpgrade(false)
-      .setProtocolVersion(HttpVersion.HTTP_2));
-    Async async = should.async();
-    client.request(HttpMethod.POST, port, "localhost", "/helloworld.Greeter/SayHello")
-      .onComplete(should.asyncAssertSuccess(req -> {
-        req.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
-        req.putHeader("grpc-timeout", TimeUnit.SECONDS.toMillis(1) + "m");
-        GrpcMessageEncoder<HelloRequest> encoder = GrpcMessageEncoder.marshaller(GreeterGrpc.getSayHelloMethod().getRequestMarshaller());
-        GrpcMessage msg = encoder.encode(HelloRequest.newBuilder().setName("test").build());
-        req.end(GrpcMessageImpl.encode(msg));
-//        req.response().onComplete(should.asyncAssertSuccess(resp -> {
-//          resp.endHandler(v -> {
-//            String status = resp.getTrailer("grpc-status");
-//            should.assertEquals(String.valueOf(GrpcStatus.OK.code), status);
-//            req.exceptionHandler(err -> {
-//              async.complete();
-//            });
-//          });
-//        }));
-      }));
-
-    async.awaitSuccess();
   }
 
   @Test


### PR DESCRIPTION
Supporting protocol level `grpc-timeout` and the `io.grpc.Deadline` API.

- [x] client and server allows to interact with grpc timeouts and schedule deadlines.
- [x] bridge API integrates with gRPC context and deadline and implement deadline propagation in server/client mode
- [x] vertx context storage has been improved to better support gRPC context handling and propagation of deadlines
- [x] documentation + examples
