### PR TITLE
Add GrpcServerRouteHandler

### DIFF
--- a/vertx-grpc-server/pom.xml
+++ b/vertx-grpc-server/pom.xml
@@ -50,7 +50,11 @@
         </exclusion>
       </exclusions>
     </dependency>
-
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-grpc-common</artifactId>

--- a/vertx-grpc-server/src/main/asciidoc/server.adoc
+++ b/vertx-grpc-server/src/main/asciidoc/server.adoc
@@ -39,7 +39,15 @@ A `{@link io.vertx.grpc.server.GrpcServer}` is a `Handler<HttpServerRequest>` an
 {@link examples.GrpcServerExamples#createServer}
 ----
 
-TIP: a `GrpcServer` can be mounted in a Vert.x Web router
+[TIP]
+====
+A {@link io.vertx.grpc.server.GrpcServer} can be adapted to a Vert.x Web {@link io.vertx.ext.web.Route} with {@link io.vertx.grpc.server.GrpcServerRouteHandler}:
+
+[source,java]
+----
+{@link examples.GrpcServerExamples#routeHandler}
+----
+====
 
 ==== Request/response
 

--- a/vertx-grpc-server/src/main/java/examples/GrpcServerExamples.java
+++ b/vertx-grpc-server/src/main/java/examples/GrpcServerExamples.java
@@ -1,6 +1,5 @@
 package examples;
 
-import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -8,13 +7,11 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.docgen.Source;
+import io.vertx.ext.web.Router;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.GrpcServerRequest;
-import io.vertx.grpc.server.GrpcServerResponse;
-import io.vertx.grpc.server.GrpcServiceBridge;
+import io.vertx.grpc.server.*;
 
 @Source
 public class GrpcServerExamples {
@@ -27,6 +24,19 @@ public class GrpcServerExamples {
 
     server
       .requestHandler(grpcServer)
+      .listen();
+  }
+
+  public void routeHandler(Vertx vertx, HttpServerOptions options) {
+    GrpcServer grpcServer = GrpcServer.server(vertx);
+
+    HttpServer server = vertx.createHttpServer(options);
+
+    Router router = Router.router(vertx);
+    router.route().handler(GrpcServerRouteHandler.create(grpcServer));
+
+    server
+      .requestHandler(router)
       .listen();
   }
 

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerRouteHandler.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerRouteHandler.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.grpc.server;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Adapt a {@link GrpcServer} to a Vert.x Web {@link io.vertx.ext.web.Route} handler.
+ */
+public interface GrpcServerRouteHandler extends Handler<RoutingContext> {
+
+  static GrpcServerRouteHandler create(GrpcServer server) {
+    return rc -> server.handle(rc.request());
+  }
+}

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/GrpcServerRouteHandlerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/GrpcServerRouteHandlerTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.grpc.server;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.Router;
+
+public class GrpcServerRouteHandlerTest extends ServerRequestTest {
+
+  @Override
+  protected Handler<HttpServerRequest> requestHandler(GrpcServer server) {
+    Router router = Router.router(vertx);
+    router.route().handler(GrpcServerRouteHandler.create(server));
+    return router;
+  }
+}

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerTestBase.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerTestBase.java
@@ -11,14 +11,13 @@
 package io.vertx.grpc.server;
 
 import io.grpc.ManagedChannel;
-import io.vertx.core.Vertx;
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.grpc.common.GrpcTestBase;
 import junit.framework.AssertionFailedError;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.CompletableFuture;
@@ -48,7 +47,8 @@ public abstract class ServerTestBase extends GrpcTestBase {
 
   protected void startServer(HttpServerOptions options, GrpcServer server) {
     CompletableFuture<Void> res = new CompletableFuture<>();
-    vertx.createHttpServer(options).requestHandler(server).listen()
+    Handler<HttpServerRequest> requestHandler = requestHandler(server);
+    vertx.createHttpServer(options).requestHandler(requestHandler).listen()
       .onComplete(ar -> {
         if (ar.succeeded()) {
           res.complete(null);
@@ -72,5 +72,9 @@ public abstract class ServerTestBase extends GrpcTestBase {
       afe.initCause(e);
       throw afe;
     }
+  }
+
+  protected Handler<HttpServerRequest> requestHandler(GrpcServer server) {
+    return server;
   }
 }


### PR DESCRIPTION
Fixes #84

In order to integrate Vert.x Web routes and gRPC servers, we need an adapter.