### PR TITLE
HTTP client updates

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientImpl.java
@@ -19,6 +19,8 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.RequestOptions;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.Address;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
 import io.vertx.grpc.client.GrpcClientRequest;
@@ -32,29 +34,43 @@ public class GrpcClientImpl implements GrpcClient {
 
   private final Vertx vertx;
   private HttpClient client;
+  private boolean closeClient;
 
-  public GrpcClientImpl(HttpClientOptions options, Vertx vertx) {
-    this.vertx = vertx;
-    this.client = vertx.createHttpClient(new HttpClientOptions(options)
-      .setProtocolVersion(HttpVersion.HTTP_2));
+  public GrpcClientImpl(Vertx vertx, HttpClientOptions options) {
+    this(vertx, vertx.createHttpClient(new HttpClientOptions(options)
+      .setProtocolVersion(HttpVersion.HTTP_2)), true);
   }
 
   public GrpcClientImpl(Vertx vertx) {
-    this(new HttpClientOptions().setHttp2ClearTextUpgrade(false), vertx);
+    this(vertx, new HttpClientOptions().setHttp2ClearTextUpgrade(false));
   }
 
-  @Override public Future<GrpcClientRequest<Buffer, Buffer>> request(SocketAddress server) {
-    RequestOptions options = new RequestOptions()
-      .setMethod(HttpMethod.POST)
-      .setServer(server);
+  public GrpcClientImpl(Vertx vertx, HttpClient client) {
+    this(vertx, client, false);
+  }
+
+  private GrpcClientImpl(Vertx vertx, HttpClient client, boolean close) {
+    this.vertx = vertx;
+    this.client = client;
+    this.closeClient = close;
+  }
+
+  private Future<GrpcClientRequest<Buffer, Buffer>> request(RequestOptions options) {
     return client.request(options)
       .map(request -> new GrpcClientRequestImpl<>(request, GrpcMessageEncoder.IDENTITY, GrpcMessageDecoder.IDENTITY));
   }
 
-  @Override public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(SocketAddress server, MethodDescriptor<Req, Resp> service) {
-    RequestOptions options = new RequestOptions()
-      .setMethod(HttpMethod.POST)
-      .setServer(server);
+  @Override
+  public Future<GrpcClientRequest<Buffer, Buffer>> request() {
+    return request(new RequestOptions().setMethod(HttpMethod.POST));
+  }
+
+  @Override
+  public Future<GrpcClientRequest<Buffer, Buffer>> request(Address server) {
+    return request(new RequestOptions().setMethod(HttpMethod.POST).setServer(server));
+  }
+
+  private <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(RequestOptions options, MethodDescriptor<Req, Resp> service) {
     GrpcMessageDecoder<Resp> messageDecoder = GrpcMessageDecoder.unmarshaller(service.getResponseMarshaller());
     GrpcMessageEncoder<Req> messageEncoder = GrpcMessageEncoder.marshaller(service.getRequestMarshaller());
     return client.request(options)
@@ -66,7 +82,22 @@ public class GrpcClientImpl implements GrpcClient {
   }
 
   @Override
+  public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(MethodDescriptor<Req, Resp> service) {
+    return request(new RequestOptions().setMethod(HttpMethod.POST), service);
+  }
+
+  @Override public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(Address server, MethodDescriptor<Req, Resp> service) {
+    return request(new RequestOptions()
+      .setMethod(HttpMethod.POST)
+      .setServer(server), service);
+  }
+
+  @Override
   public Future<Void> close() {
-    return client.close();
+    if (closeClient) {
+      return client.close();
+    } else {
+      return ((VertxInternal)vertx).getOrCreateContext().succeededFuture();
+    }
   }
 }

--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/HttpClientWrappingTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/HttpClientWrappingTest.java
@@ -1,0 +1,56 @@
+package io.vertx.grpc.client;
+
+import io.grpc.*;
+import io.grpc.examples.helloworld.GreeterGrpc;
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import io.vertx.core.http.HttpClientAgent;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpConnectOptions;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.common.GrpcReadStream;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class HttpClientWrappingTest extends ClientTestBase {
+
+  @Test
+  public void testUnary(TestContext should) throws IOException {
+    GreeterGrpc.GreeterImplBase called = new GreeterGrpc.GreeterImplBase() {
+      @Override
+      public void sayHello(HelloRequest request, StreamObserver<HelloReply> plainResponseObserver) {
+        ServerCallStreamObserver<HelloReply> responseObserver =
+          (ServerCallStreamObserver<HelloReply>) plainResponseObserver;
+        responseObserver.onNext(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
+        responseObserver.onCompleted();
+      }
+    };
+    startServer(called, ServerBuilder.forPort(port));
+    Async async = should.async();
+    HttpClientAgent agent = vertx.createHttpClient(new HttpClientOptions()
+      .setProtocolVersion(HttpVersion.HTTP_2)
+      .setHttp2ClearTextUpgrade(false));
+
+    // Connect -> request -> response -> close
+    agent.connect(new HttpConnectOptions()
+      .setPort(port)
+      .setHost("localhost")
+    ).compose(conn -> {
+      GrpcClient client = GrpcClient.client(vertx, conn);
+      return client.request(GreeterGrpc.getSayHelloMethod())
+        .compose(req -> {
+          req.end(HelloRequest.newBuilder().setName("Julien").build());
+          return req.response().compose(GrpcReadStream::last);
+        }).eventually(client::close);
+    }).onComplete(should.asyncAssertSuccess(reply -> {
+      should.assertEquals("Hello Julien", reply.getMessage());
+      async.complete();
+    }));
+    async.await(20_000);
+  }
+}


### PR DESCRIPTION
The gRPC client builds its own HTTP client. Since the HTTP client got new capabilities (service name resolution, unpooled connections), it makes sense to allow wrapping an existing HTTP client interface.

Modify the gRPC client to allow wrapping an existing HTTP client interface.
