### PR TITLE
Deprecate GrpcReadStream#collecting in favour of ReadStream#collect

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcReadStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcReadStream.java
@@ -9,6 +9,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.streams.ReadStream;
 
+import java.util.stream.Collector;
+
 @VertxGen
 public interface GrpcReadStream<T> extends ReadStream<T> {
 
@@ -71,8 +73,12 @@ public interface GrpcReadStream<T> extends ReadStream<T> {
 
   /**
    * @return the result of applying a collector on the stream
+   * @deprecated instead use {@link #collect(Collector)}
    */
+  @Deprecated
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  <R, A> Future<R> collecting(java.util.stream.Collector<T , A , R> collector);
+  default <R, A> Future<R> collecting(java.util.stream.Collector<T , A , R> collector) {
+    return collect(collector);
+  }
 
 }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
@@ -17,7 +17,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.StreamResetException;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.impl.InboundBuffer;
 import io.vertx.grpc.common.CodecException;
@@ -25,9 +24,6 @@ import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcReadStream;
-
-import java.util.function.BiConsumer;
-import java.util.stream.Collector;
 
 import static io.vertx.grpc.common.GrpcError.mapHttp2ErrorCode;
 
@@ -219,17 +215,4 @@ public abstract class GrpcReadStreamBase<S extends GrpcReadStreamBase<S, T>, T> 
     return end.future();
   }
 
-  @Override
-  public <R, C> Future<R> collecting(Collector<T, C, R> collector) {
-    PromiseInternal<R> promise = context.promise();
-    C cumulation = collector.supplier().get();
-    BiConsumer<C, T> accumulator = collector.accumulator();
-    handler(elt -> accumulator.accept(cumulation, elt));
-    endHandler(v -> {
-      R result = collector.finisher().apply(cumulation);
-      promise.tryComplete(result);
-    });
-    exceptionHandler(promise::tryFail);
-    return promise.future();
-  }
 }


### PR DESCRIPTION
Deprecate `GrpcReadStream#collecting` in favour of `ReadStream#collect` that is the same method.
