### PR TITLE
Improve tests failing in CI

### DIFF
--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/ClientMessageEncodingTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/ClientMessageEncodingTest.java
@@ -35,6 +35,8 @@ import java.util.function.Consumer;
  */
 public class ClientMessageEncodingTest extends ClientTestBase {
 
+  private GrpcClient client;
+
   @Test
   public void testZipRequestCompress(TestContext should) throws Exception {
     testEncode(should, "gzip", GrpcMessage.message("identity", Buffer.buffer("Hello World")), true);
@@ -77,7 +79,7 @@ public class ClientMessageEncodingTest extends ClientTestBase {
       .get(20, TimeUnit.SECONDS);
 
     Async test = should.async();
-    GrpcClient client = GrpcClient.client(vertx);
+    client = GrpcClient.client(vertx);
     client.request(SocketAddress.inetSocketAddress(port, "localhost"))
       .onComplete(should.asyncAssertSuccess(callRequest -> {
         callRequest.fullMethodName(GreeterGrpc.getSayHelloMethod().getFullMethodName());
@@ -100,7 +102,7 @@ public class ClientMessageEncodingTest extends ClientTestBase {
       .toCompletableFuture()
       .get(20, TimeUnit.SECONDS);
 
-    GrpcClient client = GrpcClient.client(vertx);
+    client = GrpcClient.client(vertx);
     client.request(SocketAddress.inetSocketAddress(port, "localhost"))
       .onComplete(should.asyncAssertSuccess(callRequest -> {
         callRequest.fullMethodName(GreeterGrpc.getSayHelloMethod().getFullMethodName());
@@ -176,7 +178,7 @@ public class ClientMessageEncodingTest extends ClientTestBase {
       .toCompletableFuture()
       .get(20, TimeUnit.SECONDS);
 
-    GrpcClient client = GrpcClient.client(vertx);
+    client = GrpcClient.client(vertx);
     client.request(SocketAddress.inetSocketAddress(port, "localhost"))
       .onComplete(should.asyncAssertSuccess(callRequest -> {
         callRequest.fullMethodName(GreeterGrpc.getSayHelloMethod().getFullMethodName());
@@ -186,7 +188,5 @@ public class ClientMessageEncodingTest extends ClientTestBase {
         }));
         callRequest.end(Buffer.buffer());
       }));
-
-    async.awaitSuccess();
   }
 }

--- a/vertx-grpc-context-storage/src/test/java/io/vertx/grpc/context/storage/ContextStorageTest.java
+++ b/vertx-grpc-context-storage/src/test/java/io/vertx/grpc/context/storage/ContextStorageTest.java
@@ -60,9 +60,6 @@ public class ContextStorageTest {
     if (channel != null) {
       channel.shutdown();
     }
-    if (httpServer != null) {
-      httpServer.close().onComplete(should.asyncAssertSuccess());
-    }
     if (vertx != null) {
       vertx.close().onComplete(should.asyncAssertSuccess());
     }
@@ -113,7 +110,7 @@ public class ContextStorageTest {
         this.httpServer = httpServer;
         servertStart.complete();
       }));
-    servertStart.await();
+    servertStart.awaitSuccess();
 
     channel = ManagedChannelBuilder.forAddress("localhost", httpServer.actualPort())
       .usePlaintext()


### PR DESCRIPTION
- retain the client as a field to avoid it being collected
- the context storage test closes the HTTP server and the vertx instance, since the vertx instance also closes the server, it seems that sometimes the explicit HTTP server close does not complete which indicates there might be a bug in vertx HTTP server close sequence which should be investigated