### PR TITLE
Deprecate GrpcClient/GrpcServer methods declaring a MethodDescriptor

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientImpl.java
@@ -24,11 +24,12 @@ import io.vertx.grpc.client.GrpcClient;
 import io.vertx.grpc.client.GrpcClientRequest;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
+import io.vertx.grpcio.client.GrpcIoClient;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class GrpcClientImpl implements GrpcClient {
+public class GrpcClientImpl implements GrpcIoClient {
 
   private final Vertx vertx;
   private HttpClient client;

--- a/vertx-grpc-client/src/main/java/io/vertx/grpcio/client/package-info.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpcio/client/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+@ModuleGen(name = "vertx-grpcio-client", groupPackage = "io.vertx", useFutures = true)
+package io.vertx.grpcio.client;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
@@ -6,17 +6,22 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpcio.client.GrpcIoClient;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.grpc.common.GrpcStatus;
 
 public class {{className}} {
-  private final GrpcClient client;
+  private final GrpcIoClient client;
   private final SocketAddress socketAddress;
 
   public {{className}}(GrpcClient client, SocketAddress socketAddress) {
-    this.client = client;
-    this.socketAddress = socketAddress;
+    this((GrpcIoClient)client, socketAddress);
+  }
+
+  public {{className}}(GrpcIoClient client, SocketAddress socketAddress) {
+  this.client = client;
+  this.socketAddress = socketAddress;
   }
 
 {{#unaryMethods}}

--- a/vertx-grpc-protoc-plugin2/src/main/resources/server.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/server.mustache
@@ -10,6 +10,7 @@ import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpcio.server.GrpcIoServer;
 import io.vertx.grpc.server.GrpcServerResponse;
 
 import java.util.ArrayList;
@@ -62,6 +63,9 @@ public class {{className}}  {
 
 {{#unaryMethods}}
     default {{serviceName}}Api bind_{{methodName}}(GrpcServer server) {
+      return this.bind_{{methodName}}((GrpcIoServer)server);
+    }
+    default {{serviceName}}Api bind_{{methodName}}(GrpcIoServer server) {
       server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> {
         Promise<{{outputType}}> promise = Promise.promise();
         request.handler(req -> {
@@ -80,6 +84,9 @@ public class {{className}}  {
 {{/unaryMethods}}
 {{#unaryManyMethods}}
     default {{serviceName}}Api bind_{{methodName}}(GrpcServer server) {
+    return this.bind_{{methodName}}((GrpcIoServer)server);
+    }
+    default {{serviceName}}Api bind_{{methodName}}(GrpcIoServer server) {
       server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> {
         request.handler(req -> {
           try {
@@ -94,6 +101,9 @@ public class {{className}}  {
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
     default {{serviceName}}Api bind_{{methodName}}(GrpcServer server) {
+    return this.bind_{{methodName}}((GrpcIoServer)server);
+    }
+    default {{serviceName}}Api bind_{{methodName}}(GrpcIoServer server) {
       server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> {
         Promise<{{outputType}}> promise = Promise.promise();
         promise.future()
@@ -110,6 +120,9 @@ public class {{className}}  {
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
     default {{serviceName}}Api bind_{{methodName}}(GrpcServer server) {
+    return this.bind_{{methodName}}((GrpcIoServer)server);
+    }
+    default {{serviceName}}Api bind_{{methodName}}(GrpcIoServer server) {
       server.callHandler({{serviceName}}Grpc.{{methodNameGetter}}(), request -> {
         try {
           {{methodName}}(request, request.response());
@@ -122,6 +135,9 @@ public class {{className}}  {
 {{/manyManyMethods}}
 
     default {{serviceName}}Api bindAll(GrpcServer server) {
+      return bindAll((GrpcIoServer)server);
+    }
+    default {{serviceName}}Api bindAll(GrpcIoServer server) {
 {{#methods}}
       bind_{{methodName}}(server);
 {{/methods}}

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServer.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServer.java
@@ -60,11 +60,9 @@ public interface GrpcServer extends Handler<HttpServerRequest> {
   GrpcServer callHandler(Handler<GrpcServerRequest<Buffer, Buffer>> handler);
 
   /**
-   * Set a service method call handler that handles any call call made to the server for the {@link MethodDescriptor} service method.
-   *
-   * @param handler the service method call handler
-   * @return a reference to this, so the API can be used fluently
+   * @deprecated use {@link io.vertx.grpcio.server.GrpcIoServer#callHandler(MethodDescriptor, Handler)}
    */
+  @Deprecated
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   <Req, Resp> GrpcServer callHandler(MethodDescriptor<Req, Resp> methodDesc, Handler<GrpcServerRequest<Req, Resp>> handler);
 

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -20,6 +20,7 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpcio.server.GrpcIoServer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +28,7 @@ import java.util.Map;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class GrpcServerImpl implements GrpcServer {
+public class GrpcServerImpl implements GrpcIoServer {
 
   private final Vertx vertx;
   private Handler<GrpcServerRequest<Buffer, Buffer>> requestHandler;
@@ -67,7 +68,7 @@ public class GrpcServerImpl implements GrpcServer {
     return this;
   }
 
-  public <Req, Resp> GrpcServer callHandler(MethodDescriptor<Req, Resp> methodDesc, Handler<GrpcServerRequest<Req, Resp>> handler) {
+  public <Req, Resp> GrpcIoServer callHandler(MethodDescriptor<Req, Resp> methodDesc, Handler<GrpcServerRequest<Req, Resp>> handler) {
     if (handler != null) {
       methodCallHandlers.put(methodDesc.getFullMethodName(), new MethodCallHandler<>(methodDesc, GrpcMessageDecoder.unmarshaller(methodDesc.getRequestMarshaller()), GrpcMessageEncoder.marshaller(methodDesc.getResponseMarshaller()), handler));
     } else {

--- a/vertx-grpc-server/src/main/java/io/vertx/grpcio/server/GrpcIoServer.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpcio/server/GrpcIoServer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpcio.server;
+
+import io.grpc.MethodDescriptor;
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.GrpcServerResponse;
+import io.vertx.grpc.server.impl.GrpcServerImpl;
+
+/**
+ * <p>Extends the {@link GrpcServer} so it can be utilized with {@link MethodDescriptor}.</p>
+ *
+ * <p>In Vert.x 5, the core {@link GrpcServer} is decoupled from `io.grpc.*` packages to support JPMS.</p>
+ */
+@VertxGen
+public interface GrpcIoServer extends GrpcServer {
+
+  /**
+   * Create a blank gRPC/IO server
+   *
+   * @return the created server
+   */
+  static GrpcIoServer server(Vertx vertx) {
+    return new GrpcServerImpl(vertx);
+  }
+
+  /**
+   * Set a service method call handler that handles any call made to the server for the {@link MethodDescriptor} service method.
+   *
+   * @param handler the service method call handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  <Req, Resp> GrpcIoServer callHandler(MethodDescriptor<Req, Resp> methodDesc, Handler<GrpcServerRequest<Req, Resp>> handler);
+
+}

--- a/vertx-grpc-server/src/main/java/io/vertx/grpcio/server/package-info.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpcio/server/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+@ModuleGen(name = "vertx-grpcio-server", groupPackage = "io.vertx", useFutures = true)
+package io.vertx.grpcio.server;
+
+import io.vertx.codegen.annotations.ModuleGen;


### PR DESCRIPTION
Instead these methods are now available in GrpcIoClient/GrpcIoServer interfaces which extend GrpcClient/GrpcServer interfaces. 
