### PR TITLE
Support json wire format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java-util</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-protobuf</artifactId>
         <version>${grpc.version}</version>
@@ -173,6 +178,11 @@
     </dependency>
 
     <!-- Testing -->
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/vertx-grpc-client/pom.xml
+++ b/vertx-grpc-client/pom.xml
@@ -56,11 +56,6 @@
       <artifactId>grpc-stub</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <!-- Self signed certificate generation -->
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientRequest.java
@@ -19,6 +19,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Timer;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.streams.ReadStream;
+import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.common.GrpcWriteStream;
 import io.vertx.grpc.common.ServiceName;
 
@@ -44,6 +45,9 @@ public interface GrpcClientRequest<Req, Resp> extends GrpcWriteStream<Req> {
 
   @Fluent
   GrpcClientRequest<Req, Resp> encoding(String encoding);
+
+  @Override
+  GrpcClientRequest<Req, Resp> format(WireFormat format);
 
   /**
    * Set the full method name to call, it must follow the format {@code package-name + '.' + service-name + '/' + method-name}

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientMessageEncodingTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientMessageEncodingTest.java
@@ -13,6 +13,7 @@ package io.vertx.tests.client;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.StreamResetException;
@@ -167,6 +168,7 @@ public class ClientMessageEncodingTest extends ClientTestBase {
         req.endHandler(v -> {
           HttpServerResponse resp = req.response();
           resp.putHeader("grpc-encoding", "gzip");
+          resp.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
           resp.putTrailer("grpc-status", "" + GrpcStatus.OK.code);
           resp.write(Buffer.buffer()
             .appendByte((byte)1)

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientTestBase.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientTestBase.java
@@ -23,6 +23,7 @@ import io.vertx.tests.common.GrpcTestBase;
 import org.junit.After;
 import org.junit.runner.RunWith;
 
+
 import java.io.IOException;
 
 import static io.vertx.grpc.common.GrpcMessageDecoder.decoder;

--- a/vertx-grpc-common/pom.xml
+++ b/vertx-grpc-common/pom.xml
@@ -43,15 +43,13 @@
       <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
       <version>2.41.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMediaType.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMediaType.java
@@ -68,6 +68,29 @@ public final class GrpcMediaType {
     return AsciiString.regionMatches(GRPC_WEB_TEXT, true, 0, mediaType, 0, GRPC_WEB_TEXT.length());
   }
 
+  public static WireFormat parseContentType(String contentType, String mediaType) {
+    if (contentType.startsWith(mediaType)) {
+      String s = contentType.substring(mediaType.length());
+      WireFormat format;
+      if (s.isEmpty()) {
+        format = WireFormat.PROTOBUF;
+      } else {
+        switch (s) {
+          case "+json":
+            format = WireFormat.JSON;
+            break;
+          case "+proto":
+            format = WireFormat.PROTOBUF;
+            break;
+          default:
+            return null;
+        }
+      }
+      return format;
+    }
+    return null;
+  }
+
   private GrpcMediaType() {
     // Constants
   }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessage.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessage.java
@@ -25,14 +25,26 @@ public interface GrpcMessage {
   /**
    * @return a new message
    */
+  static GrpcMessage message(String encoding, WireFormat format, Buffer payload) {
+    return new GrpcMessageImpl(encoding, format, payload);
+  }
+
+  /**
+   * @return a new message in proto format
+   */
   static GrpcMessage message(String encoding, Buffer payload) {
-    return new GrpcMessageImpl(encoding, payload);
+    return new GrpcMessageImpl(encoding, WireFormat.PROTOBUF, payload);
   }
 
   /**
    * @return the message encoding
    */
   String encoding();
+
+  /**
+   * @return the message format
+   */
+  WireFormat format();
 
   /**
    * @return the message payload, usually in Protobuf format encoded in the {@link #encoding()} format

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcReadStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcReadStream.java
@@ -17,9 +17,14 @@ public interface GrpcReadStream<T> extends ReadStream<T> {
   MultiMap headers();
 
   /**
-   * @return the stream encoding, e.g {@code identity} or {@code gzip}
+   * @return the stream encoding, e.g. {@code identity} or {@code gzip}
    */
   String encoding();
+
+  /**
+   * @return the message format, e.g. {@code proto} or {@code json}
+   */
+  WireFormat format();
 
   /**
    * Set a handler to be notified with incoming encoded messages. The {@code handler} is

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
@@ -17,15 +17,26 @@ public interface GrpcWriteStream<T> extends WriteStream<T> {
   MultiMap headers();
 
   /**
-   * Set the stream encoding, e.g {@code identity} or {@code gzip}.
+   * Set the stream encoding, e.g. {@code identity} or {@code gzip}.
    *
-   * It must be called before sending any message, otherwise {@code identity will be used.
+   * It must be called before sending any message, otherwise {@code identity} will be used.
    *
    * @param encoding the target message encoding
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
   GrpcWriteStream<T> encoding(String encoding);
+
+  /**
+   * Set the stream format, e.g. {@code proto} or {@code json}.
+   *
+   * It must be called before sending any message, otherwise {@code proto} will be used.
+   *
+   * @param format the message format
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  GrpcWriteStream<T> format(WireFormat format);
 
   @Override
   GrpcWriteStream<T> exceptionHandler(@Nullable Handler<Throwable> handler);

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/WireFormat.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/WireFormat.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.common;
+
+/**
+ * The serialization format as an enum.
+ */
+public enum WireFormat {
+
+  /**
+   * Protobuf wire format.
+   */
+  PROTOBUF("proto"),
+
+  /**
+   * JSON wire format.
+   */
+  JSON("json");
+
+  final String name;
+
+  WireFormat(String name) {
+    this.name = name;
+  }
+}

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/Utils.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/Utils.java
@@ -10,10 +10,73 @@
  */
 package io.vertx.grpc.common.impl;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.compression.*;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.internal.buffer.BufferInternal;
+import io.vertx.core.internal.buffer.VertxByteBufAllocator;
+import io.vertx.grpc.common.CodecException;
+import io.vertx.grpc.common.GrpcMessage;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Queue;
+import java.util.function.Function;
 
 public class Utils {
+
+  public static final Function<Buffer, Buffer> GZIP_DECODER = data -> {
+    EmbeddedChannel channel = new EmbeddedChannel(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
+    channel.config().setAllocator(VertxByteBufAllocator.UNPOOLED_ALLOCATOR);
+    try {
+      ChannelFuture fut = channel.writeOneInbound(((BufferInternal)data).getByteBuf());
+      if (fut.isSuccess()) {
+        Buffer decoded = null;
+        while (true) {
+          ByteBuf buf = channel.readInbound();
+          if (buf == null) {
+            break;
+          }
+          if (decoded == null) {
+            decoded = BufferInternal.buffer(buf);
+          } else {
+            decoded.appendBuffer(BufferInternal.buffer(buf));
+          }
+        }
+        if (decoded == null) {
+          throw new CodecException("Invalid GZIP input");
+        }
+        return decoded;
+      } else {
+        throw new CodecException(fut.cause());
+      }
+    } finally {
+      channel.close();
+    }
+  };
+
+  public static final Function<Buffer, Buffer> GZIP_ENCODER = data -> {
+    CompositeByteBuf composite = Unpooled.compositeBuffer();
+    GzipOptions options = StandardCompressionOptions.gzip();
+    ZlibEncoder encoder = ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP, options.compressionLevel(), options.windowBits(), options.memLevel());
+    EmbeddedChannel channel = new EmbeddedChannel(encoder);
+    channel.config().setAllocator(VertxByteBufAllocator.UNPOOLED_ALLOCATOR);
+    channel.writeOutbound(((BufferInternal) data).getByteBuf());
+    channel.finish();
+    Queue<Object> messages = channel.outboundMessages();
+    ByteBuf a;
+    while ((a = (ByteBuf) messages.poll()) != null) {
+      composite.addComponent(true, a);
+    }
+    channel.close();
+    return BufferInternal.buffer(composite);
+  };
 
   public static String utf8PercentEncode(String s) {
     try {

--- a/vertx-grpc-common/src/main/java/module-info.java
+++ b/vertx-grpc-common/src/main/java/module-info.java
@@ -8,7 +8,8 @@ module io.vertx.grpc.common {
   requires io.netty.transport;
   requires transitive io.vertx.core;
   requires static io.vertx.codegen.api;
-  exports io.vertx.grpc.common;
+    requires com.google.protobuf.util;
+    exports io.vertx.grpc.common;
   exports io.vertx.grpc.common.impl to io.vertx.tests.common, io.vertx.grpc.server, io.vertx.grpc.client, io.vertx.tests.server, io.vertx.tests.client;
   provides VertxServiceProvider with io.vertx.grpc.common.impl.GrpcRequestLocalRegistration;
 }

--- a/vertx-grpc-docs/src/main/asciidoc/client.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/client.adoc
@@ -139,6 +139,28 @@ You can call `{@link io.vertx.grpc.client.GrpcClientRequest#cancel}` to cancel a
 
 NOTE: cancellation sends an HTTP/2 reset frame to the server
 
+=== JSON wire format
+
+gRPC implicitly assumes the usage of the https://protobuf.dev[Protobuf] wire format.
+
+The Vert.x gRPC client supports the JSON wire format as well.
+
+You can call a JSON service method with the `application/grpc+json` content-type.
+
+[source,java]
+----
+{@link examples.GrpcClientExamples#jsonWireFormat01}
+----
+
+NOTE: JSON encoding/decoding is achieved by `com.google.protobuf:protobuf-java-util` library.
+
+Anemic JSON is also supported with Vert.x `JsonObject`
+
+[source,java]
+----
+{@link examples.GrpcClientExamples#jsonWireFormat02}
+----
+
 === Compression
 
 You can compress request messages by setting the request encoding *prior* before sending any message
@@ -183,12 +205,21 @@ handle the message encoding:
 
 In addition to the request/response API, the Vert.x gRPC protoc plugin idiomatic service clients.
 
-A client wraps a `GrpcClient` and provides Vert.x idiomatic API to interact with the service:
+A client wraps a `GrpcClient` and provides Vert.x idiomatic API to interact with the service
 
 [source,java]
 ----
 {@link examples.GrpcClientExamples#createClientStub}
 ----
+
+You can also specify the JSON wire format when creating a stub
+
+[source,java]
+----
+{@link examples.GrpcClientExamples#createClientStubJson}
+----
+
+The client will send `application/grpc+json` requests.
 
 ==== Unary services
 
@@ -198,7 +229,6 @@ Unary services returns a Vert.x `Future`
 ----
 {@link examples.GrpcClientExamples#unaryStub}
 ----
-
 ==== Streaming requests
 
 Streaming requests use a lambda passed a Vert.x `WriteStream` of messages sent to the service

--- a/vertx-grpc-docs/src/main/asciidoc/server.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/server.adoc
@@ -160,6 +160,30 @@ a timeout to be sent and cascade the timeout to another gRPC server.
 {@link examples.GrpcServerExamples#deadlineConfiguration}
 ----
 
+=== JSON wire format
+
+gRPC implicitly assumes the usage of the https://protobuf.dev[Protobuf] wire format.
+
+The Vert.x gRPC server supports the JSON wire format as well.
+
+You can use a JSON service method to bind a service method accepting requests carrying the `application/grpc+json` content-type.
+
+[source,java]
+----
+{@link examples.GrpcServerExamples#jsonWireFormat01}
+----
+
+The `com.google.protobuf:protobuf-java-util` library performs the JSON encoding/decoding.
+
+NOTE: the same service method can be bound twice with Protobuf and JSON wire formats.
+
+Anemic JSON is also supported with Vert.x `JsonObject`
+
+[source,java]
+----
+{@link examples.GrpcServerExamples#jsonWireFormat02}
+----
+
 === Compression
 
 You can compress response messages by setting the response encoding *prior* before sending any message
@@ -214,7 +238,7 @@ Each service comes in two flavors, you can override the method you like dependin
 
 ==== Unary services
 
-Unary services can return a Vert.x `Future`:
+Unary services can return a Vert.x `Future`
 
 [source,java]
 ----
@@ -228,12 +252,21 @@ or process a Vert.x `Promise`
 {@link examples.GrpcServerExamples#unaryStub2}
 ----
 
-In both case you need to bind the stub to an existing `GrpcServer`:
+In both case you need to bind the stub to an existing `GrpcServer`
 
 [source,java]
 ----
 {@link examples.GrpcServerExamples#unaryStub3}
 ----
+
+You can also specify the JSON wire format when binding a stub.
+
+[source,java]
+----
+{@link examples.GrpcServerExamples#unaryStub4}
+----
+
+The server will accept the `application/grpc+json` requests.
 
 ==== Streaming requests
 

--- a/vertx-grpc-docs/src/main/java/examples/VertxStreamingGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/VertxStreamingGrpcClient.java
@@ -15,31 +15,63 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
 public class VertxStreamingGrpcClient {
 
   public static final ServiceMethod<examples.Item, examples.Empty> Source = ServiceMethod.client(
-  ServiceName.create("streaming", "Streaming"),
-  "Source",
-  GrpcMessageEncoder.encoder(),
-  GrpcMessageDecoder.decoder(examples.Item.parser()));
+    ServiceName.create("streaming", "Streaming"),
+    "Source",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.Item.parser()));
+  public static final ServiceMethod<examples.Item, examples.Empty> Source_JSON = ServiceMethod.client(
+    ServiceName.create("streaming", "Streaming"),
+    "Source",
+    GrpcMessageEncoder.json(),
+    GrpcMessageDecoder.json(() -> examples.Item.newBuilder()));
   public static final ServiceMethod<examples.Empty, examples.Item> Sink = ServiceMethod.client(
-  ServiceName.create("streaming", "Streaming"),
-  "Sink",
-  GrpcMessageEncoder.encoder(),
-  GrpcMessageDecoder.decoder(examples.Empty.parser()));
+    ServiceName.create("streaming", "Streaming"),
+    "Sink",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.Empty.parser()));
+  public static final ServiceMethod<examples.Empty, examples.Item> Sink_JSON = ServiceMethod.client(
+    ServiceName.create("streaming", "Streaming"),
+    "Sink",
+    GrpcMessageEncoder.json(),
+    GrpcMessageDecoder.json(() -> examples.Empty.newBuilder()));
   public static final ServiceMethod<examples.Item, examples.Item> Pipe = ServiceMethod.client(
-  ServiceName.create("streaming", "Streaming"),
-  "Pipe",
-  GrpcMessageEncoder.encoder(),
-  GrpcMessageDecoder.decoder(examples.Item.parser()));
+    ServiceName.create("streaming", "Streaming"),
+    "Pipe",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.Item.parser()));
+  public static final ServiceMethod<examples.Item, examples.Item> Pipe_JSON = ServiceMethod.client(
+    ServiceName.create("streaming", "Streaming"),
+    "Pipe",
+    GrpcMessageEncoder.json(),
+    GrpcMessageDecoder.json(() -> examples.Item.newBuilder()));
 
   private final GrpcClient client;
   private final SocketAddress socketAddress;
+  private final io.vertx.grpc.common.WireFormat wireFormat;
 
   public VertxStreamingGrpcClient(GrpcClient client, SocketAddress socketAddress) {
-    this.client = client;
-    this.socketAddress = socketAddress;
+    this(client, socketAddress, io.vertx.grpc.common.WireFormat.PROTOBUF);
+  }
+
+  public VertxStreamingGrpcClient(GrpcClient client, SocketAddress socketAddress, io.vertx.grpc.common.WireFormat wireFormat) {
+    this.client = java.util.Objects.requireNonNull(client);
+    this.socketAddress = java.util.Objects.requireNonNull(socketAddress);
+    this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
   }
 
   public Future<ReadStream<examples.Item>> source(examples.Empty request) {
-    return client.request(socketAddress, Source).compose(req -> {
+    ServiceMethod<examples.Item,examples.Empty> serviceMethod;
+    switch(wireFormat) {
+      case PROTOBUF:
+        serviceMethod = Source;
+        break;
+      case JSON:
+        serviceMethod = Source_JSON;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod).compose(req -> {
       req.end(request);
       return req.response().flatMap(resp -> {
         if (resp.status() != null && resp.status() != GrpcStatus.OK) {
@@ -52,14 +84,36 @@ public class VertxStreamingGrpcClient {
   }
 
   public Future<examples.Empty> sink(Handler<WriteStream<examples.Item>> request) {
-    return client.request(socketAddress, Sink).compose(req -> {
+    ServiceMethod<examples.Empty,examples.Item> serviceMethod;
+    switch(wireFormat) {
+      case PROTOBUF:
+        serviceMethod = Sink;
+        break;
+      case JSON:
+        serviceMethod = Sink_JSON;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod).compose(req -> {
       request.handle(req);
       return req.response().compose(resp -> resp.last());
     });
   }
 
   public Future<ReadStream<examples.Item>> pipe(Handler<WriteStream<examples.Item>> request) {
-    return client.request(socketAddress, Pipe).compose(req -> {
+    ServiceMethod<examples.Item,examples.Item> serviceMethod;
+    switch(wireFormat) {
+      case PROTOBUF:
+        serviceMethod = Pipe;
+        break;
+      case JSON:
+        serviceMethod = Pipe_JSON;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod).compose(req -> {
       request.handle(req);
       return req.response().flatMap(resp -> {
         if (resp.status() != null && resp.status() != GrpcStatus.OK) {

--- a/vertx-grpc-it/pom.xml
+++ b/vertx-grpc-it/pom.xml
@@ -59,11 +59,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <scope>test</scope>

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/JsonWireFormatTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/JsonWireFormatTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.it;
+
+import io.grpc.examples.helloworld.HelloReply;
+import io.grpc.examples.helloworld.HelloRequest;
+import io.grpc.examples.helloworld.VertxGreeterGrpcClient;
+import io.grpc.examples.helloworld.VertxGreeterGrpcServer;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.server.GrpcServer;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class JsonWireFormatTest extends ProxyTestBase {
+
+  @Test
+  public void testUnary01(TestContext should) {
+
+    GrpcClient client = GrpcClient.client(vertx);
+
+    Future<HttpServer> server = vertx.createHttpServer().requestHandler(GrpcServer.server(vertx).callHandler(VertxGreeterGrpcServer.SayHello_JSON, call -> {
+      call.handler(helloRequest -> {
+        HelloReply helloReply = HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName()).build();
+        call.response().end(helloReply);
+      });
+    })).listen(8080, "localhost");
+
+    Async test = should.async();
+    server.onComplete(should.asyncAssertSuccess(v -> {
+      client.request(SocketAddress.inetSocketAddress(8080, "localhost"), VertxGreeterGrpcClient.SayHello_JSON)
+        .onComplete(should.asyncAssertSuccess(callRequest -> {
+          callRequest.response().onComplete(should.asyncAssertSuccess(callResponse -> {
+            AtomicInteger count = new AtomicInteger();
+            callResponse.handler(reply -> {
+              should.assertEquals(1, count.incrementAndGet());
+              should.assertEquals("Hello Julien", reply.getMessage());
+            });
+            callResponse.endHandler(v2 -> {
+              should.assertEquals(1, count.get());
+              test.complete();
+            });
+          }));
+          callRequest.end(HelloRequest.newBuilder().setName("Julien").build());
+        }));
+    }));
+
+    test.awaitSuccess(20_000);
+  }
+
+  @Test
+  public void testUnary02(TestContext should) {
+
+    GrpcClient client = GrpcClient.client(vertx);
+
+    VertxGreeterGrpcServer.GreeterApi greeter = new VertxGreeterGrpcServer.GreeterApi() {
+      @Override
+      public Future<HelloReply> sayHello(HelloRequest request) {
+        return Future.succeededFuture(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
+      }
+    };
+
+    GrpcServer grpcServer = GrpcServer.server(vertx);
+
+    greeter.bind_sayHello(grpcServer, WireFormat.JSON);
+
+    Future<HttpServer> server = vertx
+      .createHttpServer()
+      .requestHandler(grpcServer)
+      .listen(8080, "localhost");
+
+    VertxGreeterGrpcClient stub = new VertxGreeterGrpcClient(client, SocketAddress.inetSocketAddress(8080, "localhost"), WireFormat.JSON);
+
+    Async test = should.async();
+    server.onComplete(should.asyncAssertSuccess(v -> {
+      stub.sayHello(HelloRequest.newBuilder().setName("Julien").build()).onComplete(should.asyncAssertSuccess(reply -> {
+        should.assertEquals("Hello Julien", reply.getMessage());
+        test.complete();
+      }));
+    }));
+
+    test.awaitSuccess(20_000);
+  }
+}

--- a/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
@@ -18,23 +18,45 @@ public class {{className}} {
 
 {{#allMethods}}
   public static final ServiceMethod<{{outputType}}, {{inputType}}> {{methodName}} = ServiceMethod.client(
-  ServiceName.create("{{packageName}}", "{{serviceName}}"),
-  "{{methodName}}",
-  GrpcMessageEncoder.encoder(),
-  GrpcMessageDecoder.decoder({{outputType}}.parser()));
+    ServiceName.create("{{packageName}}", "{{serviceName}}"),
+    "{{methodName}}",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder({{outputType}}.parser()));
+  public static final ServiceMethod<{{outputType}}, {{inputType}}> {{methodName}}_JSON = ServiceMethod.client(
+    ServiceName.create("{{packageName}}", "{{serviceName}}"),
+    "{{methodName}}",
+    GrpcMessageEncoder.json(),
+    GrpcMessageDecoder.json(() -> {{outputType}}.newBuilder()));
 {{/allMethods}}
 
   private final GrpcClient client;
   private final SocketAddress socketAddress;
+  private final io.vertx.grpc.common.WireFormat wireFormat;
 
   public {{className}}(GrpcClient client, SocketAddress socketAddress) {
-    this.client = client;
-    this.socketAddress = socketAddress;
+    this(client, socketAddress, io.vertx.grpc.common.WireFormat.PROTOBUF);
+  }
+
+  public {{className}}(GrpcClient client, SocketAddress socketAddress, io.vertx.grpc.common.WireFormat wireFormat) {
+    this.client = java.util.Objects.requireNonNull(client);
+    this.socketAddress = java.util.Objects.requireNonNull(socketAddress);
+    this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
   }
 
 {{#unaryMethods}}
   public Future<{{outputType}}> {{vertxMethodName}}({{inputType}} request) {
-    return client.request(socketAddress, {{methodName}}).compose(req -> {
+    ServiceMethod<{{outputType}},{{inputType}}> serviceMethod;
+    switch(wireFormat) {
+      case PROTOBUF:
+        serviceMethod = {{methodName}};
+        break;
+      case JSON:
+        serviceMethod = {{methodName}}_JSON;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod).compose(req -> {
       req.end(request);
       return req.response().compose(resp -> resp.last());
     });
@@ -43,7 +65,18 @@ public class {{className}} {
 {{/unaryMethods}}
 {{#unaryManyMethods}}
   public Future<ReadStream<{{outputType}}>> {{vertxMethodName}}({{inputType}} request) {
-    return client.request(socketAddress, {{methodName}}).compose(req -> {
+    ServiceMethod<{{outputType}},{{inputType}}> serviceMethod;
+    switch(wireFormat) {
+      case PROTOBUF:
+        serviceMethod = {{methodName}};
+        break;
+      case JSON:
+        serviceMethod = {{methodName}}_JSON;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod).compose(req -> {
       req.end(request);
       return req.response().flatMap(resp -> {
         if (resp.status() != null && resp.status() != GrpcStatus.OK) {
@@ -58,7 +91,18 @@ public class {{className}} {
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
   public Future<{{outputType}}> {{vertxMethodName}}(Handler<WriteStream<{{inputType}}>> request) {
-    return client.request(socketAddress, {{methodName}}).compose(req -> {
+    ServiceMethod<{{outputType}},{{inputType}}> serviceMethod;
+    switch(wireFormat) {
+      case PROTOBUF:
+        serviceMethod = {{methodName}};
+        break;
+      case JSON:
+        serviceMethod = {{methodName}}_JSON;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod).compose(req -> {
       request.handle(req);
       return req.response().compose(resp -> resp.last());
     });
@@ -67,7 +111,18 @@ public class {{className}} {
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
   public Future<ReadStream<{{outputType}}>> {{vertxMethodName}}(Handler<WriteStream<{{inputType}}>> request) {
-    return client.request(socketAddress, {{methodName}}).compose(req -> {
+    ServiceMethod<{{outputType}},{{inputType}}> serviceMethod;
+    switch(wireFormat) {
+      case PROTOBUF:
+        serviceMethod = {{methodName}};
+        break;
+      case JSON:
+        serviceMethod = {{methodName}}_JSON;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod).compose(req -> {
       request.handle(req);
       return req.response().flatMap(resp -> {
         if (resp.status() != null && resp.status() != GrpcStatus.OK) {

--- a/vertx-grpc-protoc-plugin2/src/main/resources/server.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/server.mustache
@@ -23,10 +23,15 @@ public class {{className}}  {
 
 {{#allMethods}}
   public static final ServiceMethod<{{inputType}}, {{outputType}}> {{methodName}} = ServiceMethod.server(
-  ServiceName.create("{{packageName}}", "{{serviceName}}"),
-  "{{methodName}}",
-  GrpcMessageEncoder.encoder(),
-  GrpcMessageDecoder.decoder({{inputType}}.parser()));
+    ServiceName.create("{{packageName}}", "{{serviceName}}"),
+    "{{methodName}}",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder({{inputType}}.parser()));
+  public static final ServiceMethod<{{inputType}}, {{outputType}}> {{methodName}}_JSON = ServiceMethod.server(
+    ServiceName.create("{{packageName}}", "{{serviceName}}"),
+    "{{methodName}}",
+    GrpcMessageEncoder.json(),
+    GrpcMessageDecoder.json(() -> {{inputType}}.newBuilder()));
 {{/allMethods}}
 
   public interface {{serviceName}}Api {
@@ -76,7 +81,21 @@ public class {{className}}  {
 
 {{#unaryMethods}}
     default {{serviceName}}Api bind_{{vertxMethodName}}(GrpcServer server) {
-      server.callHandler({{methodName}}, request -> {
+      return bind_{{vertxMethodName}}(server, io.vertx.grpc.common.WireFormat.PROTOBUF);
+    }
+    default {{serviceName}}Api bind_{{vertxMethodName}}(GrpcServer server, io.vertx.grpc.common.WireFormat format) {
+      ServiceMethod<{{inputType}},{{outputType}}> serviceMethod;
+      switch(format) {
+        case PROTOBUF:
+          serviceMethod = {{methodName}};
+          break;
+        case JSON:
+          serviceMethod = {{methodName}}_JSON;
+          break;
+        default:
+          throw new AssertionError();
+      }
+      server.callHandler(serviceMethod, request -> {
         Promise<{{outputType}}> promise = Promise.promise();
         request.handler(req -> {
           try {
@@ -94,7 +113,21 @@ public class {{className}}  {
 {{/unaryMethods}}
 {{#unaryManyMethods}}
     default {{serviceName}}Api bind_{{vertxMethodName}}(GrpcServer server) {
-      server.callHandler({{methodName}}, request -> {
+      return bind_{{vertxMethodName}}(server, io.vertx.grpc.common.WireFormat.PROTOBUF);
+    }
+    default {{serviceName}}Api bind_{{vertxMethodName}}(GrpcServer server, io.vertx.grpc.common.WireFormat format) {
+      ServiceMethod<{{inputType}},{{outputType}}> serviceMethod;
+      switch(format) {
+        case PROTOBUF:
+          serviceMethod = {{methodName}};
+          break;
+        case JSON:
+          serviceMethod = {{methodName}}_JSON;
+          break;
+        default:
+          throw new AssertionError();
+      }
+      server.callHandler(serviceMethod, request -> {
         request.handler(req -> {
           try {
             {{vertxMethodName}}(req, request.response());
@@ -108,7 +141,21 @@ public class {{className}}  {
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
     default {{serviceName}}Api bind_{{vertxMethodName}}(GrpcServer server) {
-      server.callHandler({{methodName}}, request -> {
+      return bind_{{vertxMethodName}}(server, io.vertx.grpc.common.WireFormat.PROTOBUF);
+    }
+    default {{serviceName}}Api bind_{{vertxMethodName}}(GrpcServer server, io.vertx.grpc.common.WireFormat format) {
+      ServiceMethod<{{inputType}},{{outputType}}> serviceMethod;
+      switch(format) {
+        case PROTOBUF:
+          serviceMethod = {{methodName}};
+          break;
+        case JSON:
+          serviceMethod = {{methodName}}_JSON;
+          break;
+        default:
+          throw new AssertionError();
+      }
+      server.callHandler(serviceMethod, request -> {
         Promise<{{outputType}}> promise = Promise.promise();
         promise.future()
           .onFailure(err -> request.response().status(GrpcStatus.INTERNAL).end())
@@ -124,7 +171,21 @@ public class {{className}}  {
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
     default {{serviceName}}Api bind_{{vertxMethodName}}(GrpcServer server) {
-      server.callHandler({{methodName}}, request -> {
+      return bind_{{vertxMethodName}}(server, io.vertx.grpc.common.WireFormat.PROTOBUF);
+    }
+    default {{serviceName}}Api bind_{{vertxMethodName}}(GrpcServer server, io.vertx.grpc.common.WireFormat format) {
+      ServiceMethod<{{inputType}},{{outputType}}> serviceMethod;
+      switch(format) {
+        case PROTOBUF:
+          serviceMethod = {{methodName}};
+          break;
+        case JSON:
+          serviceMethod = {{methodName}}_JSON;
+          break;
+        default:
+          throw new AssertionError();
+      }
+      server.callHandler(serviceMethod, request -> {
         try {
           {{vertxMethodName}}(request, request.response());
         } catch (RuntimeException err) {
@@ -138,6 +199,13 @@ public class {{className}}  {
     default {{serviceName}}Api bindAll(GrpcServer server) {
 {{#methods}}
       bind_{{vertxMethodName}}(server);
+{{/methods}}
+      return this;
+    }
+
+    default {{serviceName}}Api bindAll(GrpcServer server, io.vertx.grpc.common.WireFormat format) {
+{{#methods}}
+      bind_{{vertxMethodName}}(server, format);
 {{/methods}}
       return this;
     }

--- a/vertx-grpc-server/pom.xml
+++ b/vertx-grpc-server/pom.xml
@@ -46,11 +46,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <!-- Self signed certificate generation -->
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcProtocol.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcProtocol.java
@@ -1,0 +1,22 @@
+package io.vertx.grpc.server;
+
+public enum GrpcProtocol {
+
+  HTTP_2("application/grpc", false), WEB("application/grpc-web", true), WEB_TEXT("application/grpc-web-text", true);
+
+  private final String mediaType;
+  private final boolean web;
+
+  GrpcProtocol(String mediaType, boolean web) {
+    this.mediaType = mediaType;
+    this.web = web;
+  }
+
+  public boolean isWeb() {
+    return web;
+  }
+
+  public String mediaType() {
+    return mediaType;
+  }
+}

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -19,19 +19,16 @@ import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.spi.context.storage.AccessMode;
-import io.vertx.grpc.common.GrpcMediaType;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcLocal;
+import io.vertx.grpc.common.*;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
+import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerOptions;
 import io.vertx.grpc.server.GrpcServerRequest;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 
@@ -40,11 +37,13 @@ import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
  */
 public class GrpcServerImpl implements GrpcServer {
 
+  private static final Pattern CONTENT_TYPE_PATTERN = Pattern.compile("application/grpc(-web(-text)?)?(\\+(json|proto))?");
+
   private static final Logger log = LoggerFactory.getLogger(GrpcServer.class);
 
   private final GrpcServerOptions options;
   private Handler<GrpcServerRequest<Buffer, Buffer>> requestHandler;
-  private Map<String, MethodCallHandler<?, ?>> methodCallHandlers = new HashMap<>();
+  private final Map<String, List<MethodCallHandler<?, ?>>> methodCallHandlers = new HashMap<>();
 
   public GrpcServerImpl(Vertx vertx, GrpcServerOptions options) {
     this.options = new GrpcServerOptions(Objects.requireNonNull(options, "options is null"));
@@ -57,18 +56,59 @@ public class GrpcServerImpl implements GrpcServer {
       httpRequest.response().setStatusCode(errorCode).end();
       return;
     }
+    WireFormat format ;
+    String contentType = httpRequest.getHeader(CONTENT_TYPE);
+    GrpcProtocol protocol;
+    if (contentType != null) {
+      Matcher matcher = CONTENT_TYPE_PATTERN.matcher(contentType);
+      if (matcher.matches()) {
+        if (matcher.group(1) != null) {
+          protocol = matcher.group(2) == null ? GrpcProtocol.WEB : GrpcProtocol.WEB_TEXT;
+        } else {
+          protocol = GrpcProtocol.HTTP_2;
+        }
+        if (protocol.isWeb() && !options.isGrpcWebEnabled()) {
+          httpRequest.response().setStatusCode(415).end();
+          return;
+        }
+        if (matcher.group(3) != null) {
+          switch (matcher.group(4)) {
+            case "proto":
+              format = WireFormat.PROTOBUF;
+              break;
+            case "json":
+              format = WireFormat.JSON;
+              break;
+            default:
+              throw new UnsupportedOperationException("Not possible");
+          }
+        } else {
+          format = WireFormat.PROTOBUF;
+        }
+      } else {
+        httpRequest.response().setStatusCode(415).end();
+        return;
+      }
+    } else {
+      httpRequest.response().setStatusCode(415).end();
+      return;
+    }
     GrpcMethodCall methodCall = new GrpcMethodCall(httpRequest.path());
     String fmn = methodCall.fullMethodName();
-    MethodCallHandler<?, ?> method = methodCallHandlers.get(fmn);
-    if (method != null) {
-      handle(method, httpRequest, methodCall);
-    } else {
-      Handler<GrpcServerRequest<Buffer, Buffer>> handler = requestHandler;
-      if (handler != null) {
-        handle(httpRequest, methodCall, GrpcMessageDecoder.IDENTITY, GrpcMessageEncoder.IDENTITY, handler);
-      } else {
-        httpRequest.response().setStatusCode(500).end();
+    List<MethodCallHandler<?, ?>> methods = methodCallHandlers.get(fmn);
+    if (methods != null) {
+      for (MethodCallHandler<?, ?> method : methods) {
+        if (method.messageEncoder.format() == format && method.messageDecoder.format() == format) {
+          handle(method, httpRequest, methodCall, protocol, format);
+          return;
+        }
       }
+    }
+    Handler<GrpcServerRequest<Buffer, Buffer>> handler = requestHandler;
+    if (handler != null) {
+      handle(httpRequest, methodCall, protocol, format, GrpcMessageDecoder.IDENTITY, GrpcMessageEncoder.IDENTITY, handler);
+    } else {
+      httpRequest.response().setStatusCode(500).end();
     }
   }
 
@@ -86,18 +126,27 @@ public class GrpcServerImpl implements GrpcServer {
     return -1;
   }
 
-  private <Req, Resp> void handle(MethodCallHandler<Req, Resp> method, HttpServerRequest httpRequest, GrpcMethodCall methodCall) {
-    handle(httpRequest, methodCall, method.messageDecoder, method.messageEncoder, method);
+  private <Req, Resp> void handle(MethodCallHandler<Req, Resp> method, HttpServerRequest httpRequest, GrpcMethodCall methodCall, GrpcProtocol protocol, WireFormat format) {
+    handle(httpRequest, methodCall, protocol, format, method.messageDecoder, method.messageEncoder, method);
   }
 
   private <Req, Resp> void handle(HttpServerRequest httpRequest,
                                   GrpcMethodCall methodCall,
+                                  GrpcProtocol protocol,
+                                  WireFormat format,
                                   GrpcMessageDecoder<Req> messageDecoder,
                                   GrpcMessageEncoder<Resp> messageEncoder,
                                   Handler<GrpcServerRequest<Req, Resp>> handler) {
     io.vertx.core.internal.ContextInternal context = ((HttpServerRequestInternal) httpRequest).context();
-    GrpcServerRequestImpl<Req, Resp> grpcRequest = new GrpcServerRequestImpl<>(context, options.getScheduleDeadlineAutomatically(),
-      httpRequest, messageDecoder, messageEncoder, methodCall);
+    GrpcServerRequestImpl<Req, Resp> grpcRequest = new GrpcServerRequestImpl<>(
+      context,
+      options.getScheduleDeadlineAutomatically(),
+      protocol,
+      format,
+      httpRequest,
+      messageDecoder,
+      messageEncoder,
+      methodCall);
     if (options.getDeadlinePropagation() && grpcRequest.timeout() > 0L) {
       long deadline = System.currentTimeMillis() + grpcRequest.timeout;
       context.putLocal(GrpcLocal.CONTEXT_LOCAL_KEY, AccessMode.CONCURRENT, new GrpcLocal(deadline));
@@ -114,9 +163,37 @@ public class GrpcServerImpl implements GrpcServer {
   @Override
   public <Req, Resp> GrpcServer callHandler(ServiceMethod<Req, Resp> serviceMethod, Handler<GrpcServerRequest<Req, Resp>> handler) {
     if (handler != null) {
-      methodCallHandlers.put(serviceMethod.fullMethodName(), new MethodCallHandler<>(serviceMethod.decoder(), serviceMethod.encoder(), handler));
+      MethodCallHandler<Req, Resp> p = new MethodCallHandler<>(serviceMethod.decoder(), serviceMethod.encoder(), handler);
+      methodCallHandlers.compute(serviceMethod.fullMethodName(), (key, prev) -> {
+        if (prev == null) {
+          prev = new ArrayList<>();
+        }
+        for (int i = 0;i < prev.size();i++) {
+          MethodCallHandler<?, ?> a = prev.get(i);
+          if (a.messageDecoder.format() == serviceMethod.decoder().format() && a.messageEncoder.format() == serviceMethod.encoder().format()) {
+            prev.set(i, p);
+            return prev;
+          }
+        }
+        prev.add(p);
+        return prev;
+      });
     } else {
-      methodCallHandlers.remove(serviceMethod.fullMethodName());
+      methodCallHandlers.compute(serviceMethod.fullMethodName(), (key, prev) -> {
+        if (prev != null) {
+          for (int i = 0;i < prev.size();i++) {
+            MethodCallHandler<?, ?> a = prev.get(i);
+            if (a.messageDecoder.format() == serviceMethod.decoder().format() && a.messageEncoder.format() == serviceMethod.encoder().format()) {
+              prev.remove(i);
+              break;
+            }
+          }
+          if (prev.isEmpty()) {
+            prev = null;
+          }
+        }
+        return prev;
+      });
     }
     return this;
   }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerMessageEncodingTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerMessageEncodingTest.java
@@ -25,12 +25,7 @@ import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.StreamResetException;
+import io.vertx.core.http.*;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.GrpcError;
@@ -96,6 +91,7 @@ public class ServerMessageEncodingTest extends ServerTestBase {
       .request(HttpMethod.POST, 8080, "localhost", "/")
       .onComplete(should.asyncAssertSuccess(request -> {
       request.putHeader("grpc-encoding", "identity");
+      request.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
       request.send(Buffer
         .buffer()
         .appendByte((byte)1)
@@ -206,6 +202,7 @@ public class ServerMessageEncodingTest extends ServerTestBase {
 
     client.request(HttpMethod.POST, 8080, "localhost", "/").onComplete( should.asyncAssertSuccess(request -> {
       request.putHeader("grpc-encoding", "gzip");
+      request.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
       request.end(Buffer
         .buffer()
         .appendByte((byte)1)

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTestBase.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTestBase.java
@@ -16,6 +16,7 @@ import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.streaming.Empty;
 import io.grpc.examples.streaming.Item;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.grpc.common.*;
@@ -51,6 +52,7 @@ public abstract class ServerTestBase extends GrpcTestBase {
   public static final GrpcMessageDecoder<HelloReply> HELLO_REPLY_DEC = decoder(HelloReply.parser());
 
   public static final ServiceMethod<HelloRequest, HelloReply> GREETER_SAY_HELLO = ServiceMethod.server(GREETER, "SayHello", HELLO_REPLY_ENC, HELLO_REQUEST_DEC);
+  public static final ServiceMethod<JsonObject, JsonObject> GREETER_SAY_HELLO_JSON = ServiceMethod.server(GREETER, "SayHello", GrpcMessageEncoder.JSON_OBJECT, GrpcMessageDecoder.JSON_OBJECT);
   public static final ServiceMethod<Empty, Item> STREAMING_SOURCE = ServiceMethod.server(STREAMING, "Source", ITEM_ENC, EMPTY_DEC);
   public static final ServiceMethod<Item, Empty> STREAMING_SINK = ServiceMethod.server(STREAMING, "Sink", EMPTY_ENC, ITEM_DEC);
   public static final ServiceMethod<Item, Item> STREAMING_PIPE = ServiceMethod.server(STREAMING, "Pipe", ITEM_ENC, ITEM_DEC);

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/BinaryServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/BinaryServerTest.java
@@ -33,7 +33,7 @@ public class BinaryServerTest extends ServerTestBase {
 
   @Override
   protected CharSequence responseContentType() {
-    return GRPC_WEB_PROTO;
+    return "application/grpc-web";
   }
 
   @Override

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/ServerTestBase.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/ServerTestBase.java
@@ -318,7 +318,8 @@ public abstract class ServerTestBase extends GrpcTestBase {
 
         assertEquals(200, response.statusCode());
         MultiMap headers = response.headers();
-        assertTrue(headers.contains(CONTENT_TYPE, responseContentType(), true));
+        CharSequence value = responseContentType();
+        assertTrue(headers.contains(CONTENT_TYPE, value, true));
 
         Buffer body = decodeBody(response.body().result());
         int pos = 0;

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/TextServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/TextServerTest.java
@@ -43,7 +43,7 @@ public class TextServerTest extends ServerTestBase {
 
   @Override
   protected CharSequence responseContentType() {
-    return GRPC_WEB_TEXT_PROTO;
+    return "application/grpc-web-text";
   }
 
   @Override

--- a/vertx-grpcio-client/pom.xml
+++ b/vertx-grpcio-client/pom.xml
@@ -66,11 +66,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <!-- Self signed certificate generation -->
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/vertx-grpcio-common/pom.xml
+++ b/vertx-grpcio-common/pom.xml
@@ -46,11 +46,9 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
     </dependency>
   </dependencies>
 

--- a/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/BridgeMessageDecoder.java
+++ b/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/BridgeMessageDecoder.java
@@ -12,6 +12,7 @@ package io.vertx.grpcio.common.impl;
 
 import io.grpc.Decompressor;
 import io.grpc.MethodDescriptor;
+import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 
@@ -40,5 +41,10 @@ public class BridgeMessageDecoder<T> implements GrpcMessageDecoder<T> {
         throw new RuntimeException(e);
       }
     }
+  }
+
+  @Override
+  public WireFormat format() {
+    return WireFormat.PROTOBUF;
   }
 }


### PR DESCRIPTION
Support JSON wire format, documentation excerpts:

---

## Vert.x gRPC Server

### JSON wire format

gRPC implicitly assumes the usage of the [Protobuf](https://protobuf.dev) wire format.

The Vert.x gRPC server supports the JSON wire format as well.

You can use a JSON service method to bind a service method accepting requests carrying the `application/grpc+json` content-type.

```java
server.callHandler(VertxGreeterGrpcServer.SayHello_JSON, request -> {
  request.last().onSuccess(helloRequest -> {
    request.response().end(HelloReply.newBuilder()
      .setMessage("Hello " + helloRequest.getName()).build()
    );
  });
});
```

NOTE: JSON encoding/decoding is achieved by `com.google.protobuf:protobuf-java-util` library.

Anemic JSON is also supported with Vert.x `JsonObject`

```java
ServiceMethod<JsonObject, JsonObject> sayHello = ServiceMethod.server(
  ServiceName.create("helloworld", "Greeter"),
  "SayHello",
  GrpcMessageEncoder.JSON_OBJECT,
  GrpcMessageDecoder.JSON_OBJECT
);

server.callHandler(sayHello, request -> {
  request.last().onSuccess(helloRequest -> {
    request.response().end(new JsonObject().put("message", "Hello " + helloRequest.getString("name")));
  });
});
```

---

## Vert.x gRPC Client

### JSON wire format

gRPC implicitly assumes the usage of the [Protobuf](https://protobuf.dev) wire format.

The Vert.x gRPC client supports the JSON wire format as well.

You can call a JSON service method accepting requests carrying the `application/grpc+json` content-type.

```java
client
  .request(server, VertxGreeterGrpcClient.SayHello_JSON).compose(request -> {
    request.end(HelloRequest
      .newBuilder()
      .setName("Bob")
      .build());
    return request.response().compose(response -> response.last());
  }).onSuccess(reply -> {
    System.out.println("Received " + reply.getMessage());
  });
```

NOTE: JSON encoding/decoding is achieved by `com.google.protobuf:protobuf-java-util` library.

Anemic JSON is also supported with Vert.x `JsonObject`

```java
ServiceMethod<JsonObject, JsonObject> sayHello = ServiceMethod.client(
  ServiceName.create("helloworld", "Greeter"),
  "SayHello",
  GrpcMessageEncoder.JSON_OBJECT,
  GrpcMessageDecoder.JSON_OBJECT
);
client
  .request(server, sayHello).compose(request -> {
    request.end(new JsonObject().put("name", "Bob"));
    return request.response().compose(response -> response.last());
  }).onSuccess(reply -> {
    System.out.println("Received " + reply.getString("message"));
  });
```


