### PR TITLE
Set a configurable maximum payload size for the message decoder and add an invalid message handler to catch invalid messages

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientOptions.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClientOptions.java
@@ -36,9 +36,15 @@ public class GrpcClientOptions {
    */
   public static final TimeUnit DEFAULT_TIMEOUT_UNIT = TimeUnit.SECONDS;
 
+  /**
+   * The default maximum message size in bytes accepted from a server = {@code 256KB}
+   */
+  public static final long DEFAULT_MAX_MESSAGE_SIZE = 256 * 1024;
+
   private boolean scheduleDeadlineAutomatically;
   private int timeout;
   private TimeUnit timeoutUnit;
+  private long maxMessageSize;
 
   /**
    * Default constructor.
@@ -47,6 +53,7 @@ public class GrpcClientOptions {
     scheduleDeadlineAutomatically = DEFAULT_SCHEDULE_DEADLINE_AUTOMATICALLY;
     timeout = DEFAULT_TIMEOUT;
     timeoutUnit = DEFAULT_TIMEOUT_UNIT;
+    this.maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
   }
 
   /**
@@ -58,6 +65,7 @@ public class GrpcClientOptions {
     scheduleDeadlineAutomatically = other.scheduleDeadlineAutomatically;
     timeout = other.timeout;
     timeoutUnit = other.timeoutUnit;
+    maxMessageSize = other.maxMessageSize;
   }
 
   /**
@@ -125,6 +133,29 @@ public class GrpcClientOptions {
    */
   public GrpcClientOptions setTimeoutUnit(TimeUnit timeoutUnit) {
     this.timeoutUnit = Objects.requireNonNull(timeoutUnit);
+    return this;
+  }
+
+  /**
+   * @return the maximum message size in bytes accepted by the client
+   */
+  public long getMaxMessageSize() {
+    return maxMessageSize;
+  }
+
+  /**
+   * Set the maximum message size in bytes accepted from a server, the maximum value is {@code 0xFFFFFFFF}
+   * @param maxMessageSize the size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public GrpcClientOptions setMaxMessageSize(long maxMessageSize) {
+    if (maxMessageSize <= 0) {
+      throw new IllegalArgumentException("Max message size must be > 0");
+    }
+    if (maxMessageSize > 0xFFFFFFFFL) {
+      throw new IllegalArgumentException("Max message size must be <= 0xFFFFFFFF");
+    }
+    this.maxMessageSize = maxMessageSize;
     return this;
   }
 }

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
@@ -36,9 +36,10 @@ public class GrpcClientResponseImpl<Req, Resp> extends GrpcReadStreamBase<GrpcCl
   public GrpcClientResponseImpl(ContextInternal context,
                                 GrpcClientRequestImpl<Req, Resp> request,
                                 WireFormat format,
+                                long maxMessageSize,
                                 GrpcStatus status,
                                 HttpClientResponse httpResponse, GrpcMessageDecoder<Resp> messageDecoder) {
-    super(context, httpResponse, httpResponse.headers().get("grpc-encoding"), format, messageDecoder);
+    super(context, httpResponse, httpResponse.headers().get("grpc-encoding"), format, maxMessageSize, messageDecoder);
     this.request = request;
     this.httpResponse = httpResponse;
     this.status = status;

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageDecoder.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageDecoder.java
@@ -41,7 +41,7 @@ public interface GrpcMessageDecoder<T> {
         try {
           return parser.parseFrom(msg.payload().getBytes());
         } catch (InvalidProtocolBufferException e) {
-          return null;
+          throw new CodecException(e);
         }
       }
       @Override

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcReadStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcReadStream.java
@@ -1,6 +1,7 @@
 package io.vertx.grpc.common;
 
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
@@ -35,6 +36,19 @@ public interface GrpcReadStream<T> extends ReadStream<T> {
    */
   @Fluent
   GrpcReadStream<T> messageHandler(@Nullable Handler<GrpcMessage> handler);
+
+  /**
+   * Set a message handler that is reported with invalid message errors.
+   *
+   * <p>Warning: setting this handler overwrite the default handler which takes appropriate measure
+   * when an invalid message is encountered such as cancelling the stream. This handler should be set
+   * when control over invalid messages is required.</p>
+   *
+   * @param handler the invalid message handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  GrpcReadStream<T> invalidMessageHandler(@Nullable Handler<InvalidMessageException> handler);
 
   /**
    * Set a handler to be notified with gRPC errors.

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/InvalidMessageException.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/InvalidMessageException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.common;
+
+import io.vertx.core.VertxException;
+
+/**
+ * Signals an invalid message.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public abstract class InvalidMessageException extends VertxException {
+
+    InvalidMessageException() {
+        super((String) null, true);
+    }
+
+    InvalidMessageException(Throwable cause) {
+        super(cause, true);
+    }
+}

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/InvalidMessagePayloadException.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/InvalidMessagePayloadException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.common;
+
+/**
+ * Signals a message with an invalid payload, i.e. that could not be decoded by the protobuf codec.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public final class InvalidMessagePayloadException extends InvalidMessageException {
+
+    private GrpcMessage message;
+
+    public InvalidMessagePayloadException(GrpcMessage message, Throwable cause) {
+        super(cause);
+        this.message = message;
+    }
+
+    /**
+     * @return the invalid message that could not be decoded.
+     */
+    public GrpcMessage message() {
+        return message;
+    }
+}

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/MessageSizeOverflowException.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/MessageSizeOverflowException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.common;
+
+/**
+ * Signals a message that is longer than the maximum configured size.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public final class MessageSizeOverflowException extends InvalidMessageException {
+
+    private final long messageSize;
+
+    public MessageSizeOverflowException(long messageSize) {
+        this.messageSize = messageSize;
+    }
+
+    public long messageSize() {
+        return messageSize;
+    }
+}

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
@@ -48,22 +48,31 @@ public abstract class GrpcReadStreamBase<S extends GrpcReadStreamBase<S, T>, T> 
 
   protected final ContextInternal context;
   private final String encoding;
+  private final long maxMessageSize;
   private final WireFormat format;
   private final ReadStream<Buffer> stream;
   private final InboundMessageQueue<GrpcMessage> queue;
   private Buffer buffer;
+  private long bytesToSkip;
   private Handler<Throwable> exceptionHandler;
   private Handler<GrpcMessage> messageHandler;
   private Handler<Void> endHandler;
+  private Handler<InvalidMessageException> invalidMessageHandler;
   private GrpcMessage last;
   private final GrpcMessageDecoder<T> messageDecoder;
   private final Promise<Void> end;
   private GrpcWriteStreamBase<?, ?> ws;
 
-  protected GrpcReadStreamBase(Context context, ReadStream<Buffer> stream, String encoding, WireFormat format, GrpcMessageDecoder<T> messageDecoder) {
+  protected GrpcReadStreamBase(Context context,
+                               ReadStream<Buffer> stream,
+                               String encoding,
+                               WireFormat format,
+                               long maxMessageSize,
+                               GrpcMessageDecoder<T> messageDecoder) {
     ContextInternal ctx = (ContextInternal) context;
     this.context = ctx;
     this.encoding = encoding;
+    this.maxMessageSize = maxMessageSize;
     this.stream = stream;
     this.format = format;
     this.queue = new InboundMessageQueue<>(ctx.nettyEventLoop(), ctx, 8, 16) {
@@ -161,25 +170,83 @@ public abstract class GrpcReadStreamBase<S extends GrpcReadStreamBase<S, T>, T> 
   }
 
   @Override
+  public final S invalidMessageHandler(@Nullable Handler<InvalidMessageException> handler) {
+    invalidMessageHandler = handler;
+    return (S) this;
+  }
+
+  @Override
+  public S handler(@Nullable Handler<T> handler) {
+    if (handler != null) {
+      return messageHandler(msg -> {
+        T decoded;
+        try {
+          decoded = decodeMessage(msg);
+        } catch (CodecException e) {
+          Handler<InvalidMessageException> errorHandler = invalidMessageHandler;
+          if (errorHandler != null) {
+            InvalidMessagePayloadException impe = new InvalidMessagePayloadException(msg, e);
+            errorHandler.handle(impe);
+          }
+          return;
+        }
+        handler.handle(decoded);
+      });
+    } else {
+      return messageHandler(null);
+    }
+  }
+
+  @Override
   public final S endHandler(Handler<Void> endHandler) {
     this.endHandler = endHandler;
     return (S) this;
   }
 
   public void handle(Buffer chunk) {
+    if (bytesToSkip > 0L) {
+      int len = chunk.length();
+      if (len <= bytesToSkip) {
+        bytesToSkip -= len;
+        return;
+      }
+      chunk = chunk.slice((int)bytesToSkip, len);
+      bytesToSkip = 0L;
+    }
     if (buffer == null) {
       buffer = chunk;
     } else {
       buffer.appendBuffer(chunk);
     }
     int idx = 0;
-    int len;
-    while (idx + 5 <= buffer.length() && (idx + 5 + (len = buffer.getInt(idx + 1)))<= buffer.length()) {
+    while (true) {
+      if (idx + 5 > buffer.length()) {
+        break;
+      }
+      long len = ((long)buffer.getInt(idx + 1)) & 0xFFFFFFFFL;
+      if (len > maxMessageSize) {
+        Handler<InvalidMessageException> handler = invalidMessageHandler;
+        if (handler != null) {
+          MessageSizeOverflowException msoe = new MessageSizeOverflowException(len);
+          context.dispatch(msoe, handler);
+        }
+        if (buffer.length() < (len + 5)) {
+          bytesToSkip = (len + 5) - buffer.length();
+          buffer = null;
+          return;
+        } else {
+          buffer = buffer.slice((int)(len + 5), buffer.length());
+          continue;
+        }
+      }
+      if (len > buffer.length() - (idx + 5)) {
+        break;
+      }
       boolean compressed = buffer.getByte(idx) == 1;
       if (compressed && encoding == null) {
         throw new UnsupportedOperationException("Handle me");
       }
-      Buffer payload = buffer.slice(idx + 5, idx + 5 + len);
+      Buffer payload = buffer.slice(idx + 5, (int)(idx + 5 + len));
       GrpcMessage message = GrpcMessage.message(compressed ? encoding : "identity", format, payload);
       queue.write(message);
       idx += 5 + len;
@@ -207,7 +274,7 @@ public abstract class GrpcReadStreamBase<S extends GrpcReadStreamBase<S, T>, T> 
     }
   }
 
-  protected void handleMessage(GrpcMessage msg) {
+  private void handleMessage(GrpcMessage msg) {
     last = msg;
     Handler<GrpcMessage> handler = messageHandler;
     if (handler != null) {

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerOptions.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerOptions.java
@@ -38,9 +38,15 @@ public class GrpcServerOptions {
    */
   public static final boolean DEFAULT_PROPAGATE_DEADLINE = false;
 
+  /**
+   * The default maximum message size in bytes accepted from a client = {@code 256KB}
+   */
+  public static final long DEFAULT_MAX_MESSAGE_SIZE = 256 * 1024;
+
   private boolean grpcWebEnabled;
   private boolean scheduleDeadlineAutomatically;
   private boolean deadlinePropagation;
+  private long maxMessageSize;
 
   /**
    * Default options.
@@ -49,6 +55,7 @@ public class GrpcServerOptions {
     grpcWebEnabled = DEFAULT_GRPC_WEB_ENABLED;
     scheduleDeadlineAutomatically = DEFAULT_SCHEDULE_DEADLINE_AUTOMATICALLY;
     deadlinePropagation = DEFAULT_PROPAGATE_DEADLINE;
+    maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
   }
 
   /**
@@ -58,6 +65,7 @@ public class GrpcServerOptions {
     grpcWebEnabled = other.grpcWebEnabled;
     scheduleDeadlineAutomatically = other.scheduleDeadlineAutomatically;
     deadlinePropagation = other.deadlinePropagation;
+    maxMessageSize = other.maxMessageSize;
   }
 
   /**
@@ -127,6 +135,30 @@ public class GrpcServerOptions {
    */
   public GrpcServerOptions setDeadlinePropagation(boolean deadlinePropagation) {
     this.deadlinePropagation = deadlinePropagation;
+    return this;
+  }
+
+
+  /**
+   * @return the maximum message size in bytes accepted by the server
+   */
+  public long getMaxMessageSize() {
+    return maxMessageSize;
+  }
+
+  /**
+   * Set the maximum message size in bytes accepted from a client, the maximum value is {@code 0xFFFFFFFF}
+   * @param maxMessageSize the size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public GrpcServerOptions setMaxMessageSize(long maxMessageSize) {
+    if (maxMessageSize <= 0) {
+      throw new IllegalArgumentException("Max message size must be > 0");
+    }
+    if (maxMessageSize > 0xFFFFFFFFL) {
+      throw new IllegalArgumentException("Max message size must be <= 0xFFFFFFFF");
+    }
+    this.maxMessageSize = maxMessageSize;
     return this;
   }
 

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
@@ -83,11 +83,12 @@ public class GrpcServerRequestImpl<Req, Resp> extends GrpcReadStreamBase<GrpcSer
                                boolean scheduleDeadline,
                                GrpcProtocol protocol,
                                WireFormat format,
+                               long maxMessageSize,
                                HttpServerRequest httpRequest,
                                GrpcMessageDecoder<Req> messageDecoder,
                                GrpcMessageEncoder<Resp> messageEncoder,
                                GrpcMethodCall methodCall) {
-    super(context, httpRequest, httpRequest.headers().get("grpc-encoding"), format, messageDecoder);
+    super(context, httpRequest, httpRequest.headers().get("grpc-encoding"), format, maxMessageSize, messageDecoder);
     String timeoutHeader = httpRequest.getHeader("grpc-timeout");
     long timeout = timeoutHeader != null ? parseTimeout(timeoutHeader) : 0L;
 
@@ -153,7 +154,7 @@ public class GrpcServerRequestImpl<Req, Resp> extends GrpcReadStreamBase<GrpcSer
   }
 
   @Override
-  public GrpcServerRequest<Req, Resp> handler(Handler<Req> handler) {
+  public GrpcServerRequestImpl<Req, Resp> handler(Handler<Req> handler) {
     if (handler != null) {
       return messageHandler(msg -> {
         Req decoded;


### PR DESCRIPTION
Motivation:

The gRPC message decoder uses the default limit allowed by the gRPC HTTP/2 transport (2^32 bytes). The default maximum size should be smaller and configurable.

Changes:

Add options for configuring the maximum message size and use a lower default value (256KB) for both client and server. In addition an invalid message handler can be set on the GrpcReadStream to catch invalid message reports and let the application recover invalid messages. The invalid message handler can be triggered by a capacity overflow or a decoder exception.

Results:

gRPC server and client now uses a smaller default maximum message size which can be configured according to the application needs. Invalid message handler can also be set to catch invalid messages.
