### PR TITLE
Avoid masking invalid grpc status errors in GrpcClientResponse#last()

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/InvalidStatusException.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/InvalidStatusException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.client;
+
+import io.vertx.core.VertxException;
+import io.vertx.grpc.common.GrpcStatus;
+
+/**
+ * Denotes a failure due to an invalid status.
+ */
+public final class InvalidStatusException extends VertxException {
+
+  private final GrpcStatus expected;
+  private final GrpcStatus actual;
+
+  public InvalidStatusException(GrpcStatus expected, GrpcStatus actual) {
+    super("Invalid status: actual:" + actual.name() + ", expected:" + expected.name());
+    this.expected = expected;
+    this.actual = actual;
+  }
+
+  /**
+   * @return the expected status
+   */
+  public GrpcStatus expectedStatus() {
+    return expected;
+  }
+
+  /**
+   * @return the actual status
+   */
+  public GrpcStatus actualStatus() {
+    return actual;
+  }
+}

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
@@ -26,7 +26,9 @@ import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.client.InvalidStatusException;
 import io.vertx.grpc.common.GrpcReadStream;
+import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.GrpcWriteStream;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.client.GrpcClient;
@@ -156,7 +158,9 @@ public class ProtocPluginTest extends ProxyTestBase {
         .setFillUsername(true)
         .build())
       .onComplete(should.asyncAssertFailure(err -> {
-        should.assertEquals("Invalid gRPC status 13", err.getMessage());
+        should.assertTrue(err instanceof InvalidStatusException);
+        InvalidStatusException ise = (InvalidStatusException) err;
+        should.assertEquals(GrpcStatus.INTERNAL, ise.actualStatus());
         test.complete();
       }));
     test.awaitSuccess();
@@ -277,7 +281,9 @@ public class ProtocPluginTest extends ProxyTestBase {
         req.end();
       })
       .onComplete(should.asyncAssertFailure(err -> {
-        should.assertEquals("Invalid gRPC status 13", err.getMessage());
+        should.assertTrue(err instanceof InvalidStatusException);
+        InvalidStatusException ise = (InvalidStatusException) err;
+        should.assertEquals(GrpcStatus.INTERNAL, ise.actualStatus());
         test.complete();
       }));
     test.awaitSuccess();


### PR DESCRIPTION
Motivation

The current handling of some futures of `GrpcClientResponse` will map the end future to a failure when the status is not `OK` with a mere message error.

We can instead more precisely handle it by providing a custom exception.

Changes

Introduce `InvalidStateException` and use an expectation to map an invalid status to such exception