### PR TITLE
case insensitive grpc headers/metadata

### DIFF
--- a/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/Utils.java
+++ b/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/Utils.java
@@ -57,7 +57,7 @@ public class Utils {
     byte[][] array = new byte[entries.size() * 2][];
     int idx = 0;
     for (Map.Entry<String, String> entry : entries) {
-      String key = entry.getKey();
+      String key = entry.getKey().toLowerCase();
       array[idx++] = key.getBytes(StandardCharsets.UTF_8);
       String value = entry.getValue();
       byte[] data;

--- a/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/Utils.java
+++ b/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/Utils.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -57,7 +58,7 @@ public class Utils {
     byte[][] array = new byte[entries.size() * 2][];
     int idx = 0;
     for (Map.Entry<String, String> entry : entries) {
-      String key = entry.getKey().toLowerCase();
+      String key = entry.getKey().toLowerCase(Locale.ROOT);
       array[idx++] = key.getBytes(StandardCharsets.UTF_8);
       String value = entry.getValue();
       byte[] data;

--- a/vertx-grpcio-common/src/test/java/io/vertx/tests/common/UtilsTest.java
+++ b/vertx-grpcio-common/src/test/java/io/vertx/tests/common/UtilsTest.java
@@ -36,17 +36,32 @@ public class UtilsTest {
     headers.add("key0", "value2");
 
     Metadata metadata = Utils.readMetadata(headers);
-    assertEquals(metadata.keys().size(), 2);
+    assertEquals(2, metadata.keys().size());
 
     List<String> l = StreamSupport.stream(metadata.getAll(Metadata.Key.of("key0", Metadata.ASCII_STRING_MARSHALLER)).spliterator(), false)
       .collect(Collectors.toList());
-    assertEquals(l.size(), 2);
+    assertEquals(2, l.size());
     assertTrue(l.contains("value0"));
     assertTrue(l.contains("value2"));
 
     l = StreamSupport.stream(metadata.getAll(Metadata.Key.of("key1", Metadata.ASCII_STRING_MARSHALLER)).spliterator(), false)
       .collect(Collectors.toList());
-    assertEquals(l.size(), 1);
+    assertEquals(1, l.size());
     assertTrue(l.contains("value1"));
   }
+
+  @Test
+  public void lowercaseMetadata() {
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+
+    headers.add("Authorization", "test");
+
+    Metadata metadata = Utils.readMetadata(headers);
+    assertEquals(1, metadata.keys().size());
+
+    String authorization = metadata.get(Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER));
+
+    assertEquals("test", authorization);
+  }
+
 }


### PR DESCRIPTION
When using grpc web (with HTTP 1.1), the http headers are not lower cased when converting into grpc metadata. This means that they become inaccessible inside metadata since all the keys are converted to lower case on creation.

This erratic behaviour was observed in a couple of browsers that did not respect a lower case `authorization` header and transmitted upper case over the wire (confirmed on Wireshark).

This works fine for http2 since it's supposed to provide stronger case insensitive guarantees.

The test I added fails, if the `.toLowerCase()` is removed.
