### PR TITLE
A couple of types are VertxGen annotated and could be instead data object or permitted

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessage.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessage.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.grpc.common;
 
+import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.grpc.common.impl.GrpcMessageImpl;
@@ -19,7 +20,7 @@ import io.vertx.grpc.common.impl.GrpcMessageImpl;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-@VertxGen
+@DataObject
 public interface GrpcMessage {
 
   /**

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageDecoder.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageDecoder.java
@@ -14,8 +14,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.Parser;
 import com.google.protobuf.util.JsonFormat;
-import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
@@ -25,7 +23,6 @@ import io.vertx.core.json.JsonArray;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
-@VertxGen
 public interface GrpcMessageDecoder<T> {
 
   /**
@@ -33,7 +30,6 @@ public interface GrpcMessageDecoder<T> {
    * @param parser the parser that returns decoded messages of type {@code <T>}
    * @return the message decoder
    */
-  @GenIgnore
   static <T> GrpcMessageDecoder<T> decoder(Parser<T> parser) {
     return new GrpcMessageDecoder<T>() {
       @Override
@@ -67,7 +63,6 @@ public interface GrpcMessageDecoder<T> {
    * @param builder the supplier of a message builder
    * @return the message decoder
    */
-  @GenIgnore
   static <T> GrpcMessageDecoder<T> json(Supplier<Message.Builder> builder) {
     return new GrpcMessageDecoder<>() {
       @Override

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageEncoder.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageEncoder.java
@@ -5,12 +5,10 @@ import com.google.protobuf.MessageLite;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.util.JsonFormat;
 import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 
-@VertxGen
 public interface GrpcMessageEncoder<T> {
 
   /**

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/ServiceMethod.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/ServiceMethod.java
@@ -10,12 +10,12 @@
  */
 package io.vertx.grpc.common;
 
-import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.codegen.annotations.GenIgnore;
 
 /**
  * Bundle all the bits required to call or bind a grpc service method.
  */
-@VertxGen
+@GenIgnore(GenIgnore.PERMITTED_TYPE)
 public interface ServiceMethod<I, O> {
 
   static <Req, Resp> ServiceMethod<Resp, Req> client(ServiceName serviceName, String methodName, GrpcMessageEncoder<Req> encoder, GrpcMessageDecoder<Resp> decoder) {

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/ServiceName.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/ServiceName.java
@@ -11,13 +11,14 @@
 package io.vertx.grpc.common;
 
 import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.grpc.common.impl.ServiceNameImpl;
 
 /**
  * A gRPC service name.
  */
-@VertxGen
+@DataObject
 public interface ServiceName {
 
   /**
@@ -44,19 +45,16 @@ public interface ServiceName {
   /**
    * @return the name
    */
-  @CacheReturn
   String name();
 
   /**
    * @return the package name
    */
-  @CacheReturn
   String packageName();
 
   /**
    * @return the fully qualified name
    */
-  @CacheReturn
   String fullyQualifiedName();
 
   /**

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServer.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServer.java
@@ -11,7 +11,6 @@
 package io.vertx.grpc.server;
 
 import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -70,7 +69,6 @@ public interface GrpcServer extends Handler<HttpServerRequest> {
    * @param serviceMethod the service method
    * @return a reference to this, so the API can be used fluently
    */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   <Req, Resp> GrpcServer callHandler(ServiceMethod<Req, Resp> serviceMethod, Handler<GrpcServerRequest<Req, Resp>> handler);
 
 /*

--- a/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/TranscodingServiceMethod.java
+++ b/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/TranscodingServiceMethod.java
@@ -1,14 +1,14 @@
 package io.vertx.grpc.transcoding;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Unstable;
-import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.transcoding.impl.TranscodingServiceMethodImpl;
 
-@VertxGen
+@GenIgnore(GenIgnore.PERMITTED_TYPE)
 @Unstable("Transcoding is in tech preview")
 public interface TranscodingServiceMethod<I, O> extends ServiceMethod<I, O> {
 

--- a/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/GrpcIoClient.java
+++ b/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/GrpcIoClient.java
@@ -10,7 +10,6 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.net.Address;
 import io.vertx.grpc.client.*;
-import io.vertx.grpc.client.impl.GrpcClientBuilderImpl;
 import io.vertx.grpcio.client.impl.GrpcIoClientBuilder;
 import io.vertx.grpcio.client.impl.GrpcIoClientImpl;
 

--- a/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/Utils.java
+++ b/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/Utils.java
@@ -18,7 +18,6 @@ import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.netty.util.AsciiString;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
@@ -72,7 +71,6 @@ public class Utils {
     return InternalMetadata.newMetadata(array);
   }
 
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   public static <T> GrpcMessageDecoder<T> unmarshaller(MethodDescriptor.Marshaller<T> desc) {
     return new GrpcMessageDecoder<T>() {
       @Override
@@ -94,7 +92,6 @@ public class Utils {
     };
   }
 
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   public static <T> GrpcMessageEncoder<T> marshaller(MethodDescriptor.Marshaller<T> desc) {
     return new GrpcMessageEncoder<T>() {
       @Override


### PR DESCRIPTION
- `ServiceMethod`
- `TranscodingServiceMethod`
- `ServiceName`
- `GrpcMessage`
