### PR TITLE
Better streaming input client generation.

### DIFF
--- a/vertx-grpc-docs/src/main/java/examples/GreeterClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/GreeterClient.java
@@ -1,6 +1,7 @@
 package examples;
 
 import io.vertx.core.Future;
+import io.vertx.core.Completable;
 import io.vertx.core.Handler;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
@@ -24,11 +25,7 @@ public interface GreeterClient {
    * SayHello protobuf RPC client service method.
    */
   @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
-  ServiceMethod<examples.HelloReply, examples.HelloRequest> SayHello = ServiceMethod.client(
-    ServiceName.create("helloworld", "Greeter"),
-    "SayHello",
-    GrpcMessageEncoder.encoder(),
-    GrpcMessageDecoder.decoder(examples.HelloReply.parser()));
+  ServiceMethod<examples.HelloReply, examples.HelloRequest> SayHello = ServiceMethod.client(ServiceName.create("helloworld", "Greeter"), "SayHello", GrpcMessageEncoder.encoder(), GrpcMessageDecoder.decoder(examples.HelloReply.parser()));
 
   /**
    * Json client service methods.
@@ -39,11 +36,7 @@ public interface GreeterClient {
     /**
      * SayHello json RPC client service method.
      */
-    public static final ServiceMethod<examples.HelloReply, examples.HelloRequest> SayHello = ServiceMethod.client(
-      ServiceName.create("helloworld", "Greeter"),
-      "SayHello",
-      GrpcMessageEncoder.json(),
-      GrpcMessageDecoder.json(() -> examples.HelloReply.newBuilder()));
+    public static final ServiceMethod<examples.HelloReply, examples.HelloRequest> SayHello = ServiceMethod.client(ServiceName.create("helloworld", "Greeter"), "SayHello", GrpcMessageEncoder.json(), GrpcMessageDecoder.json(() -> examples.HelloReply.newBuilder()));
   }
 
   /**
@@ -98,6 +91,7 @@ class GreeterClientImpl implements GreeterClient {
     this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
   }
 
+
   public Future<examples.HelloReply> sayHello(examples.HelloRequest request) {
     ServiceMethod<examples.HelloReply, examples.HelloRequest> serviceMethod;
     switch (wireFormat) {
@@ -115,5 +109,4 @@ class GreeterClientImpl implements GreeterClient {
       return req.response().compose(resp -> resp.last());
     });
   }
-
 }

--- a/vertx-grpc-docs/src/main/java/examples/GrpcClientExamples.java
+++ b/vertx-grpc-docs/src/main/java/examples/GrpcClientExamples.java
@@ -299,7 +299,7 @@ public class GrpcClientExamples {
   }
 
   public void streamingRequestStub(StreamingClient client) {
-    Future<Empty> response = client.sink(stream -> {
+    Future<Empty> response = client.sink((stream, err) -> {
       stream.write(Item.newBuilder().setValue("Value 1").build());
       stream.write(Item.newBuilder().setValue("Value 2").build());
       stream.end(Item.newBuilder().setValue("Value 3").build());

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
@@ -194,7 +194,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
-    client.streamingInputCall(req -> {
+    client.streamingInputCall((req, err) -> {
         req.write(Messages.StreamingInputCallRequest.newBuilder()
           .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingInputRequest-1", StandardCharsets.UTF_8)).build())
           .build());
@@ -238,7 +238,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
-    client.streamingInputCall(req -> {
+    client.streamingInputCall((req, err) -> {
         req.write(Messages.StreamingInputCallRequest.newBuilder()
           .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingInputRequest-1", StandardCharsets.UTF_8)).build())
           .build());
@@ -273,7 +273,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
-    client.streamingInputCall(req -> {
+    client.streamingInputCall((req, err) -> {
         req.write(Messages.StreamingInputCallRequest.newBuilder()
           .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingInputRequest-1", StandardCharsets.UTF_8)).build())
           .build());
@@ -433,7 +433,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
-    client.fullDuplexCall(req -> {
+    client.fullDuplexCall((req, err) -> {
         req.write(Messages.StreamingOutputCallRequest.newBuilder()
           .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputRequest-1", StandardCharsets.UTF_8)).build())
           .build());
@@ -483,7 +483,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
-    client.fullDuplexCall(req -> {
+    client.fullDuplexCall((req, err) -> {
         req.write(Messages.StreamingOutputCallRequest.newBuilder()
           .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputRequest-1", StandardCharsets.UTF_8)).build())
           .build());
@@ -523,7 +523,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
-    client.fullDuplexCall(req -> {
+    client.fullDuplexCall((req, err) -> {
         req.write(Messages.StreamingOutputCallRequest.newBuilder()
           .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputRequest-1", StandardCharsets.UTF_8)).build())
           .build());

--- a/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
@@ -3,6 +3,7 @@ package {{vertxPackageName}};
 {{/vertxPackageName}}
 
 import io.vertx.core.Future;
+import io.vertx.core.Completable;
 import io.vertx.core.Handler;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
@@ -101,22 +102,40 @@ public interface {{className}} {
   /**
    * Calls the {{methodName}} RPC service method.
    *
-   * @param a handler that will be passed a stream to which the {{inputType}} request messages can be written to.
+   * @param completable a completable that will be passed a stream to which the {{inputType}} request messages can be written to.
+   * @return a future of the {{outputType}} response message
+   */
+  @io.vertx.codegen.annotations.GenIgnore
+  Future<{{outputType}}> {{vertxMethodName}}(Completable<GrpcWriteStream<{{inputType}}>> completable);
+
+  /**
+   * Calls the {{methodName}} RPC service method.
+   *
+   * @param streamOfMessages a stream of messages to be sent to the service
    * @return a future of the {{outputType}} response message
    */
   @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
-  Future<{{outputType}}> {{vertxMethodName}}(Handler<GrpcWriteStream<{{inputType}}>> handler);
+  Future<{{outputType}}> {{vertxMethodName}}(ReadStream<{{inputType}}> streamOfMessages);
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
 
   /**
    * Calls the {{methodName}} RPC service method.
    *
-   * @param a handler that will be passed a stream to which the {{inputType}} request messages can be written to.
+   * @param compltable a completable that will be passed a stream to which the {{inputType}} request messages can be written to.
+   * @return a future of the {{outputType}} response messages
+   */
+  @io.vertx.codegen.annotations.GenIgnore
+  Future<GrpcReadStream<{{outputType}}>> {{vertxMethodName}}(Completable<GrpcWriteStream<{{inputType}}>> completable);
+
+  /**
+   * Calls the {{methodName}} RPC service method.
+   *
+    * @param streamOfMessages a stream of messages to be sent to the service
    * @return a future of the {{outputType}} response messages
    */
   @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
-  Future<GrpcReadStream<{{outputType}}>> {{vertxMethodName}}(Handler<GrpcWriteStream<{{inputType}}>> request);
+  Future<GrpcReadStream<{{outputType}}>> {{vertxMethodName}}(ReadStream<{{inputType}}> streamOfMessages);
 {{/manyManyMethods}}
 }
 
@@ -138,8 +157,8 @@ class {{className}}Impl implements {{className}} {
     this.socketAddress = java.util.Objects.requireNonNull(socketAddress);
     this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
   }
-
 {{#unaryMethods}}
+
   public Future<{{outputType}}> {{vertxMethodName}}({{inputType}} request) {
     ServiceMethod<{{outputType}}, {{inputType}}> serviceMethod;
     switch (wireFormat) {
@@ -157,9 +176,9 @@ class {{className}}Impl implements {{className}} {
       return req.response().compose(resp -> resp.last());
     });
   }
-
 {{/unaryMethods}}
 {{#unaryManyMethods}}
+
   public Future<GrpcReadStream<{{outputType}}>> {{vertxMethodName}}({{inputType}} request) {
     ServiceMethod<{{outputType}}, {{inputType}}> serviceMethod;
     switch (wireFormat) {
@@ -183,10 +202,10 @@ class {{className}}Impl implements {{className}} {
       });
     });
   }
-
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
-  public Future<{{outputType}}> {{vertxMethodName}}(Handler<GrpcWriteStream<{{inputType}}>> request) {
+
+  public Future<{{outputType}}> {{vertxMethodName}}(Completable<GrpcWriteStream<{{inputType}}>> completable) {
     ServiceMethod<{{outputType}}, {{inputType}}> serviceMethod;
     switch (wireFormat) {
       case PROTOBUF:
@@ -198,15 +217,27 @@ class {{className}}Impl implements {{className}} {
       default:
         throw new AssertionError();
     }
-    return client.request(socketAddress, serviceMethod).compose(req -> {
-      request.handle(req);
-      return req.response().compose(resp -> resp.last());
+    return client.request(socketAddress, serviceMethod)
+      .andThen(completable)
+      .compose(request -> {
+      return request.response().compose(response -> response.last());
     });
   }
 
+  public Future<{{outputType}}> {{vertxMethodName}}(ReadStream<{{inputType}}> request) {
+    io.vertx.core.streams.Pipe<{{inputType}}> pipe = request.pipe();
+    return {{vertxMethodName}}((result, error) -> {
+        if (error == null) {
+          pipe.to(result);
+        } else {
+          pipe.close();
+        }
+    });
+  }
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
-  public Future<GrpcReadStream<{{outputType}}>> {{vertxMethodName}}(Handler<GrpcWriteStream<{{inputType}}>> request) {
+
+  public Future<GrpcReadStream<{{outputType}}>> {{vertxMethodName}}(Completable<GrpcWriteStream<{{inputType}}>> completable) {
     ServiceMethod<{{outputType}}, {{inputType}}> serviceMethod;
     switch (wireFormat) {
       case PROTOBUF:
@@ -218,17 +249,28 @@ class {{className}}Impl implements {{className}} {
       default:
         throw new AssertionError();
     }
-    return client.request(socketAddress, serviceMethod).compose(req -> {
-      request.handle(req);
-      return req.response().flatMap(resp -> {
-        if (resp.status() != null && resp.status() != GrpcStatus.OK) {
-          return Future.failedFuture("Invalid gRPC status " + resp.status());
-        } else {
-          return Future.succeededFuture(resp);
-        }
-      });
+    return client.request(socketAddress, serviceMethod)
+      .andThen(completable)
+      .compose(req -> {
+        return req.response().flatMap(resp -> {
+          if (resp.status() != null && resp.status() != GrpcStatus.OK) {
+            return Future.failedFuture("Invalid gRPC status " + resp.status());
+          } else {
+            return Future.succeededFuture(resp);
+          }
+        });
     });
   }
 
+  public Future<GrpcReadStream<{{outputType}}>> {{vertxMethodName}}(ReadStream<{{inputType}}> request) {
+    io.vertx.core.streams.Pipe<{{inputType}}> pipe = request.pipe();
+    return {{vertxMethodName}}((result, error) -> {
+        if (error == null) {
+          pipe.to(result);
+        } else {
+          pipe.close();
+        }
+    });
+  }
 {{/manyManyMethods}}
 }


### PR DESCRIPTION
Motivation:

The generated streaming input client code generates a method consuming a handler of `GrpcReadStream` of messages.

This is not correct nor sufficient, error is not signaled and this is not Rx/Mutiny friendly.

Changes:

Change the handler of `GrpcReadStream` for a completable, so the error is properly signalled.

Add an alternative method that consumes directly a `ReadStream` of messages, so this will be clearly identified by Rx/Mutiny generators that will have the opportunity to use a Flowable/Multi instead.
