### PR TITLE
Virtual thread friendly client proxy generation

### DIFF
--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterBlockingClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterBlockingClient.java
@@ -5,6 +5,7 @@ import io.vertx.core.Completable;
 import io.vertx.core.Handler;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.client.GrpcClientRequest;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.grpc.common.GrpcStatus;
@@ -12,22 +13,27 @@ import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
+import java.util.stream.Stream;
 
 /**
  * <p>A client for invoking the Greeter gRPC service.</p>
  */
-@io.vertx.codegen.annotations.VertxGen
-public interface GreeterClient extends Greeter {
+public interface GreeterBlockingClient {
 
-  /**
-   * Calls the SayHello RPC service method.
-   *
-   * @param request the examples.grpc.HelloRequest request message
-   * @return a future of the examples.grpc.HelloReply response message
-   */
-  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
-  Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request);
+  static GreeterBlockingClient create(GreeterClient client) {
+    return new GreeterBlockingClientImpl(client);
+  }
+
 }
 
-interface GreeterClientInternal extends GreeterClient {
+/**
+ * The proxy implementation.
+ */
+class GreeterBlockingClientImpl implements GreeterBlockingClient {
+
+  private final GreeterClientInternal client;
+
+  GreeterBlockingClientImpl(Greeter client) {
+    this.client = (GreeterClientInternal)java.util.Objects.requireNonNull(client);
+  }
 }

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
@@ -56,7 +56,7 @@ public interface GreeterGrpcClient extends GreeterClient {
 /**
  * The proxy implementation.
  */
-class GreeterGrpcClientImpl implements GreeterGrpcClient {
+class GreeterGrpcClientImpl implements GreeterGrpcClient, GreeterClientInternal {
 
   private final GrpcClient client;
   private final SocketAddress socketAddress;
@@ -70,6 +70,10 @@ class GreeterGrpcClientImpl implements GreeterGrpcClient {
     this.client = java.util.Objects.requireNonNull(client);
     this.socketAddress = java.util.Objects.requireNonNull(socketAddress);
     this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
+  }
+
+  public GrpcClient grpcClient() {
+    return client;
   }
 
   public Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request) {

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcIo.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcIo.java
@@ -35,7 +35,7 @@ public final class GreeterGrpcIo {
   }
 
   
-  public static final class GreeterStub extends io.grpc.stub.AbstractStub<GreeterStub> implements GreeterClient {
+  public static final class GreeterStub extends io.grpc.stub.AbstractStub<GreeterStub> implements GreeterClientInternal {
     private final io.vertx.core.internal.ContextInternal context;
     private GreeterGrpc.GreeterStub delegateStub;
 

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingBlockingClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingBlockingClient.java
@@ -1,0 +1,72 @@
+package examples.grpc;
+
+import io.vertx.core.Future;
+import io.vertx.core.Completable;
+import io.vertx.core.Handler;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.client.GrpcClientRequest;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+import java.util.stream.Stream;
+
+/**
+ * <p>A client for invoking the Streaming gRPC service.</p>
+ */
+public interface StreamingBlockingClient {
+
+  static StreamingBlockingClient create(StreamingClient client) {
+    return new StreamingBlockingClientImpl(client);
+  }
+
+
+  @io.vertx.codegen.annotations.GenIgnore
+  Stream<examples.grpc.Item> source(examples.grpc.Empty request);
+
+  @io.vertx.codegen.annotations.GenIgnore
+  default examples.grpc.Empty sink(java.util.List<examples.grpc.Item> streamOfMessages) {
+    return sink(streamOfMessages.iterator());
+  }
+
+  @io.vertx.codegen.annotations.GenIgnore
+  examples.grpc.Empty sink(java.util.Iterator<examples.grpc.Item> streamOfMessages);
+}
+
+/**
+ * The proxy implementation.
+ */
+class StreamingBlockingClientImpl implements StreamingBlockingClient {
+
+  private final StreamingClientInternal client;
+
+  StreamingBlockingClientImpl(Streaming client) {
+    this.client = (StreamingClientInternal)java.util.Objects.requireNonNull(client);
+  }
+
+  public Stream<examples.grpc.Item> source(examples.grpc.Empty request) {
+    /*
+    Stream<examples.grpc.Item> iterator = client.source(request)
+      .compose(req -> {
+        req.end(request);
+        return req.response().compose(resp -> {
+          if (resp.status() != null && resp.status() != GrpcStatus.OK) {
+            return Future.failedFuture("Invalid gRPC status " + resp.status());
+          } else {
+            return Future.succeededFuture(resp.blockingStream());
+          }
+        });
+      }).await();
+    return iterator;
+    */
+    throw new UnsupportedOperationException();
+  }
+
+  public examples.grpc.Empty sink(java.util.Iterator<examples.grpc.Item> request) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingClient.java
@@ -82,3 +82,7 @@ public interface StreamingClient extends Streaming {
     });
   }
 }
+
+interface StreamingClientInternal extends StreamingClient {
+  void source(examples.grpc.Empty request, Completable<ReadStream<examples.grpc.Item>> completable);
+}

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
@@ -76,7 +76,7 @@ public interface StreamingGrpcClient extends StreamingClient {
 /**
  * The proxy implementation.
  */
-class StreamingGrpcClientImpl implements StreamingGrpcClient {
+class StreamingGrpcClientImpl implements StreamingGrpcClient, StreamingClientInternal {
 
   private final GrpcClient client;
   private final SocketAddress socketAddress;
@@ -92,6 +92,10 @@ class StreamingGrpcClientImpl implements StreamingGrpcClient {
     this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
   }
 
+  public GrpcClient grpcClient() {
+    return client;
+  }
+
   public Future<ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request) {
     return client.request(socketAddress, Source).compose(req -> {
       req.format(wireFormat);
@@ -104,6 +108,10 @@ class StreamingGrpcClientImpl implements StreamingGrpcClient {
         }
       });
     });
+  }
+
+  public void source(examples.grpc.Empty request, Completable<ReadStream<examples.grpc.Item>> completable) {
+    throw new UnsupportedOperationException();
   }
 
   public Future<examples.grpc.Empty> sink(Completable<WriteStream<examples.grpc.Item>> completable) {

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcIo.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcIo.java
@@ -35,7 +35,7 @@ public final class StreamingGrpcIo {
   }
 
   
-  public static final class StreamingStub extends io.grpc.stub.AbstractStub<StreamingStub> implements StreamingClient {
+  public static final class StreamingStub extends io.grpc.stub.AbstractStub<StreamingStub> implements StreamingClientInternal {
     private final io.vertx.core.internal.ContextInternal context;
     private StreamingGrpc.StreamingStub delegateStub;
 
@@ -61,6 +61,9 @@ public final class StreamingGrpcIo {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.oneToMany(context, request, delegateStub::source);
     }
 
+    public void source(examples.grpc.Empty request, io.vertx.core.Completable<io.vertx.core.streams.ReadStream<examples.grpc.Item>> completable) {
+      io.vertx.grpcio.common.impl.stub.ClientCalls.oneToMany(context, request, completable, delegateStub::source);
+    }
     
     public io.vertx.core.Future<examples.grpc.Empty> sink(io.vertx.core.Completable<io.vertx.core.streams.WriteStream<examples.grpc.Item>> handler) {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.manyToOne(context, handler, delegateStub::sink);

--- a/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGeneratorImpl.java
+++ b/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGeneratorImpl.java
@@ -333,6 +333,7 @@ public class VertxGrpcGeneratorImpl extends Generator {
     if (generateGrpcClient) {
       files.add(buildClientFile(context));
       files.add(buildGrpcClientFile(context));
+      files.add(buildBlockingClientFile(context));;
     }
     if (generateGrpcService) {
       files.add(buildServiceFile(context));
@@ -360,6 +361,12 @@ public class VertxGrpcGeneratorImpl extends Generator {
     context.fileName = context.serviceName + "GrpcClient.java";
     context.className = context.serviceName + "GrpcClient";
     return buildFile(context, applyTemplate("grpc-client.mustache", context));
+  }
+
+  private PluginProtos.CodeGeneratorResponse.File buildBlockingClientFile(ServiceContext context) {
+    context.fileName = context.serviceName + "BlockingClient.java";
+    context.className = context.serviceName + "BlockingClient";
+    return buildFile(context, applyTemplate("blocking-client.mustache", context));
   }
 
   private PluginProtos.CodeGeneratorResponse.File buildServiceFile(ServiceContext context) {

--- a/vertx-grpc-protoc-plugin2/src/main/resources/blocking-client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/blocking-client.mustache
@@ -1,0 +1,80 @@
+{{#javaPackageName}}
+package {{javaPackageName}};
+{{/javaPackageName}}
+
+import io.vertx.core.Future;
+import io.vertx.core.Completable;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.client.GrpcClientRequest;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+import java.util.stream.Stream;
+
+/**
+ * <p>A client for invoking the {{serviceName}} gRPC service.</p>
+ */
+public interface {{className}} {
+
+  static {{className}} create({{serviceName}}Client client) {
+    return new {{className}}Impl(client);
+  }
+
+{{#unaryUnaryMethods}}
+  {{outputType}} {{vertxMethodName}}({{inputType}} request);
+{{/unaryUnaryMethods}}
+{{#unaryManyMethods}}
+  Stream<{{outputType}}> {{vertxMethodName}}({{inputType}} request);
+{{/unaryManyMethods}}
+{{#manyUnaryMethods}}
+  default {{outputType}} {{vertxMethodName}}(java.util.List<{{inputType}}> streamOfMessages) {
+    return {{vertxMethodName}}(streamOfMessages.iterator());
+  }
+  {{outputType}} {{vertxMethodName}}(java.util.Iterator<{{inputType}}> streamOfMessages);
+{{/manyUnaryMethods}}
+}
+
+/**
+ * The proxy implementation.
+ */
+class {{className}}Impl implements {{className}} {
+
+  private final {{serviceName}}ClientInternal client;
+
+  {{className}}Impl({{serviceName}} client) {
+    this.client = ({{serviceName}}ClientInternal)java.util.Objects.requireNonNull(client);
+  }
+{{#unaryUnaryMethods}}
+
+  public {{outputType}} {{vertxMethodName}}({{inputType}} request) {
+    return client.{{vertxMethodName}}(request).await();
+  }
+{{/unaryUnaryMethods}}
+{{#unaryManyMethods}}
+
+  public Stream<{{outputType}}> {{vertxMethodName}}({{inputType}} request) {
+    Promise<Stream<{{outputType}}>> promise = Promise.promise();
+    client.{{vertxMethodName}}(request, (resp, err) -> {
+      if (err == null) {
+        promise.complete(resp.blockingStream());
+      } else {
+        // Todo
+      }
+    });
+    return promise.future().await();
+  }
+{{/unaryManyMethods}}
+{{#manyUnaryMethods}}
+
+  public {{outputType}} {{vertxMethodName}}(java.util.Iterator<{{inputType}}> request) {
+    throw new UnsupportedOperationException();
+  }
+{{/manyUnaryMethods}}
+}

--- a/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
@@ -101,3 +101,9 @@ public interface {{className}} extends {{serviceName}} {
   }
 {{/manyManyMethods}}
 }
+
+interface {{className}}Internal extends {{className}} {
+{{#unaryManyMethods}}
+  void {{vertxMethodName}}({{inputType}} request, Completable<ReadStream<{{outputType}}>> completable);
+{{/unaryManyMethods}}
+}

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
@@ -60,7 +60,7 @@ public interface {{className}} extends {{serviceName}}Client {
 /**
  * The proxy implementation.
  */
-class {{className}}Impl implements {{className}} {
+class {{className}}Impl implements {{className}}, {{serviceName}}ClientInternal {
 
   private final GrpcClient client;
   private final SocketAddress socketAddress;
@@ -74,6 +74,10 @@ class {{className}}Impl implements {{className}} {
     this.client = java.util.Objects.requireNonNull(client);
     this.socketAddress = java.util.Objects.requireNonNull(socketAddress);
     this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
+  }
+
+  public GrpcClient grpcClient() {
+    return client;
   }
 {{#unaryUnaryMethods}}
 
@@ -100,6 +104,30 @@ class {{className}}Impl implements {{className}} {
       });
     });
   }
+
+  public void {{vertxMethodName}}({{inputType}} request, Completable<ReadStream<{{outputType}}>> completable) {
+    client
+     .request(socketAddress, {{methodName}})
+     .onComplete((req, err1) -> {
+       if (err1 == null) {
+         req.format(wireFormat);
+         req.end(request);
+         req.response().onComplete((resp, err2) -> {
+           if (err2 == null) {
+             if (resp.status() != null && resp.status() != GrpcStatus.OK) {
+               completable.fail(new io.vertx.grpc.client.InvalidStatusException(GrpcStatus.OK, resp.status()));
+             } else {
+               completable.succeed(resp);
+             }
+           } else {
+             completable.fail(err2);
+           }
+         });
+       } else {
+         completable.fail(err1);
+       }
+     });
+ }
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
 

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-io.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-io.mustache
@@ -37,7 +37,7 @@ public final class {{className}} {
   }
 
   {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
-  public static final class {{serviceName}}Stub extends io.grpc.stub.AbstractStub<{{serviceName}}Stub> implements {{serviceName}}Client {
+  public static final class {{serviceName}}Stub extends io.grpc.stub.AbstractStub<{{serviceName}}Stub> implements {{serviceName}}ClientInternal {
     private final io.vertx.core.internal.ContextInternal context;
     private {{serviceName}}Grpc.{{serviceName}}Stub delegateStub;
 
@@ -71,6 +71,9 @@ public final class {{className}} {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.{{vertxCallsMethodName}}(context, request, delegateStub::{{vertxMethodName}});
     }
 
+    public void {{vertxMethodName}}({{inputType}} request, io.vertx.core.Completable<io.vertx.core.streams.ReadStream<{{outputType}}>> completable) {
+      io.vertx.grpcio.common.impl.stub.ClientCalls.{{vertxCallsMethodName}}(context, request, completable, delegateStub::{{vertxMethodName}});
+    }
     {{/unaryManyMethods}}
     {{#manyUnaryMethods}}
     {{{methodHeader}}}


### PR DESCRIPTION
Provide a virtual thread friendly client proxy generation.

- [x] unary/unary interactions
- [x] unary/multi interactions
- [ ] multi/unary interactions
- [ ] multi/multi interactions
- [ ] proxy API design
- [ ] documentation

```java
Stream<Messages.StreamingOutputCallResponse> stream = client.streamingOutputCall_sync(request);
stream.forEach(msg -> ...);
HelloReply reply = client.sayHello_sync(request);
```