### PR TITLE
The generator should generate a common base interface for a service extended by the service and the client.

### DIFF
--- a/vertx-grpc-docs/src/main/java/examples/GrpcServerExamples.java
+++ b/vertx-grpc-docs/src/main/java/examples/GrpcServerExamples.java
@@ -297,14 +297,14 @@ public class GrpcServerExamples {
     server.addService(stub);
   }
 
-  private ReadStream<Item> streamOfItems() {
+  private Future<ReadStream<Item>> streamOfItems() {
     throw new UnsupportedOperationException();
   }
 
   public void streamingResponseStub1() {
     StreamingService stub = new StreamingService() {
       @Override
-      public ReadStream<Item> source(Empty request) {
+      public Future<ReadStream<Item>> source(Empty request) {
         return streamOfItems();
       }
     };

--- a/vertx-grpc-docs/src/main/java/examples/grpc/Greeter.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/Greeter.java
@@ -1,0 +1,34 @@
+package examples.grpc;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.Service;
+import io.vertx.grpc.server.ServiceBuilder;
+import io.vertx.codegen.annotations.GenIgnore;
+
+import com.google.protobuf.Descriptors;
+
+import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>Base definition Greeter service.</p>
+ */
+public interface Greeter {
+
+
+  Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request);
+
+}

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterClient.java
@@ -17,7 +17,7 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
  * <p>A client for invoking the Greeter gRPC service.</p>
  */
 @io.vertx.codegen.annotations.VertxGen
-public interface GreeterClient {
+public interface GreeterClient extends Greeter {
 
   /**
    * SayHello protobuf RPC client service method.

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
@@ -1,0 +1,117 @@
+package examples.grpc;
+
+import io.vertx.core.Future;
+import io.vertx.core.Completable;
+import io.vertx.core.Handler;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+
+/**
+ * <p>A client for invoking the Greeter gRPC service.</p>
+ */
+@io.vertx.codegen.annotations.VertxGen
+public interface GreeterGrpcClient extends Greeter {
+
+  /**
+   * SayHello protobuf RPC client service method.
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  ServiceMethod<examples.grpc.HelloReply, examples.grpc.HelloRequest> SayHello = ServiceMethod.client(
+    ServiceName.create("examples.grpc", "Greeter"),
+    "SayHello",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.grpc.HelloReply.parser()));
+
+  /**
+   * Json client service methods.
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  final class Json {
+
+    /**
+     * SayHello json RPC client service method.
+     */
+    public static final ServiceMethod<examples.grpc.HelloReply, examples.grpc.HelloRequest> SayHello = ServiceMethod.client(
+      ServiceName.create("examples.grpc", "Greeter"),
+      "SayHello",
+      GrpcMessageEncoder.json(),
+      GrpcMessageDecoder.json(() -> examples.grpc.HelloReply.newBuilder()));
+  }
+
+  /**
+   * Create and return a Greeter gRPC service client. The assumed wire format is Protobuf.
+   *
+   * @param client the gRPC client
+   * @param host   the host providing the service
+   * @return the configured client
+   */
+  static GreeterGrpcClient create(GrpcClient client, SocketAddress host) {
+    return new GreeterGrpcClientImpl(client, host);
+  }
+
+  /**
+   * Create and return a Greeter gRPC service client.
+   *
+   * @param client     the gRPC client
+   * @param host       the host providing the service
+   * @param wireFormat the wire format
+   * @return the configured client
+   */
+  static GreeterGrpcClient create(GrpcClient client, SocketAddress host, io.vertx.grpc.common.WireFormat wireFormat) {
+    return new GreeterGrpcClientImpl(client, host, wireFormat);
+  }
+
+  /**
+   * Calls the SayHello RPC service method.
+   *
+   * @param request the examples.grpc.HelloRequest request message
+   * @return a future of the examples.grpc.HelloReply response message
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request);
+}
+
+/**
+ * The proxy implementation.
+ */
+class GreeterGrpcClientImpl implements GreeterGrpcClient {
+
+  private final GrpcClient client;
+  private final SocketAddress socketAddress;
+  private final io.vertx.grpc.common.WireFormat wireFormat;
+
+  GreeterGrpcClientImpl(GrpcClient client, SocketAddress socketAddress) {
+    this(client, socketAddress, io.vertx.grpc.common.WireFormat.PROTOBUF);
+  }
+
+  GreeterGrpcClientImpl(GrpcClient client, SocketAddress socketAddress, io.vertx.grpc.common.WireFormat wireFormat) {
+    this.client = java.util.Objects.requireNonNull(client);
+    this.socketAddress = java.util.Objects.requireNonNull(socketAddress);
+    this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
+  }
+
+  public Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request) {
+    ServiceMethod<examples.grpc.HelloReply, examples.grpc.HelloRequest> serviceMethod;
+    switch (wireFormat) {
+      case PROTOBUF:
+        serviceMethod = SayHello;
+        break;
+      case JSON:
+        serviceMethod = Json.SayHello;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod).compose(req -> {
+      req.end(request);
+      return req.response().compose(resp -> resp.last());
+    });
+  }
+}

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
@@ -1,0 +1,250 @@
+package examples.grpc;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.Service;
+import io.vertx.grpc.server.ServiceBuilder;
+
+import com.google.protobuf.Descriptors;
+
+import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>Provides support for RPC methods implementations of the Greeter gRPC service.</p>
+ *
+ * <p>The following methods of this class should be overridden to provide an implementation of the service:</p>
+ * <ul>
+ *   <li>SayHello</li>
+ * </ul>
+ */
+public class GreeterGrpcService implements Greeter, Service {
+
+  /**
+   * Greeter service name.
+   */
+  public static final ServiceName SERVICE_NAME = ServiceName.create("examples.grpc", "Greeter");
+
+  /**
+   * Greeter service descriptor.
+   */
+  public static final Descriptors.ServiceDescriptor SERVICE_DESCRIPTOR = Docs.getDescriptor().findServiceByName("Greeter");
+
+  @Override
+  public ServiceName name() {
+    return SERVICE_NAME;
+  }
+
+  @Override
+  public Descriptors.ServiceDescriptor descriptor() {
+    return SERVICE_DESCRIPTOR;
+  }
+
+  @Override
+  public void bind(GrpcServer server) {
+    builder().bind(all()).build().bind(server);
+  }
+
+  /**
+   * SayHello protobuf RPC server service method.
+   */
+  public static final ServiceMethod<examples.grpc.HelloRequest, examples.grpc.HelloReply> SayHello = ServiceMethod.server(
+    SERVICE_NAME,
+    "SayHello",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.grpc.HelloRequest.parser()));
+
+  /**
+   * @return a mutable list of the known protobuf RPC server service methods.
+   */
+  public static java.util.List<ServiceMethod<?, ?>> all() {
+    java.util.List<ServiceMethod<?, ?>> all = new java.util.ArrayList<>();
+    all.add(SayHello);
+    return all;
+  }
+
+  /**
+   * Json server service methods.
+   */
+  public static final class Json {
+
+    /**
+     * SayHello json RPC server service method.
+     */
+    public static final ServiceMethod<examples.grpc.HelloRequest, examples.grpc.HelloReply> SayHello = ServiceMethod.server(
+      SERVICE_NAME,
+      "SayHello",
+      GrpcMessageEncoder.json(),
+      GrpcMessageDecoder.json(() -> examples.grpc.HelloRequest.newBuilder()));
+
+    /**
+     * @return a mutable list of the known json RPC server service methods.
+     */
+    public static java.util.List<ServiceMethod<?, ?>> all() {
+      java.util.List<ServiceMethod<?, ?>> all = new java.util.ArrayList<>();
+      all.add(SayHello);
+      return all;
+    }
+  }
+
+  /**
+   * Transcoded server service methods.
+   */
+  public static final class Transcoding {
+
+    private static final io.vertx.grpc.transcoding.MethodTranscodingOptions SayHello_OPTIONS = new io.vertx.grpc.transcoding.MethodTranscodingOptions()
+      .setSelector("")
+      .setHttpMethod(HttpMethod.valueOf("GET"))
+      .setPath("/v1/hello/{name}")
+      .setBody("")
+      .setResponseBody("")
+    ;
+
+    /**
+     * SayHello transcoded RPC server service method.
+     */
+    public static final io.vertx.grpc.transcoding.TranscodingServiceMethod<examples.grpc.HelloRequest, examples.grpc.HelloReply> SayHello = io.vertx.grpc.transcoding.TranscodingServiceMethod.server(
+      SERVICE_NAME,
+      "SayHello",
+      GrpcMessageEncoder.json(),
+      GrpcMessageDecoder.json(() -> examples.grpc.HelloRequest.newBuilder()),
+      SayHello_OPTIONS);
+
+    /**
+     * @return a mutable list of the known transcoded RPC server service methods.
+     */
+    public static java.util.List<ServiceMethod<?, ?>> all() {
+      java.util.List<ServiceMethod<?, ?>> all = new java.util.ArrayList<>();
+      all.add(SayHello);
+      return all;
+    }
+  }
+
+
+  /**
+   * Override this method to implement the SayHello RPC.
+   */
+  public Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  protected void sayHello(examples.grpc.HelloRequest request, Promise<examples.grpc.HelloReply> response) {
+    sayHello(request)
+      .onSuccess(msg -> response.complete(msg))
+      .onFailure(error -> response.fail(error));
+  }
+
+  private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
+    if (SayHello == serviceMethod || Json.SayHello == serviceMethod) {
+      Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.HelloRequest, examples.grpc.HelloReply>> handler = GreeterGrpcService.this::handle_sayHello;
+      Handler<?> handler2 = handler;
+      return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
+    }
+    return null;
+  }
+
+  /**
+   * @return a free form builder that gives the opportunity to bind only certain methods of a service
+   */
+  public Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Service builder.
+   */
+  public class Builder implements ServiceBuilder {
+
+    private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>();
+
+    private void validate() {
+      for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+        if (resolveHandler(serviceMethod) == null) {
+          throw new IllegalArgumentException("Invalid service method:" + serviceMethod);
+        }
+      }
+    }
+
+    private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
+      if (SayHello == serviceMethod || Json.SayHello == serviceMethod) {
+        Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.HelloRequest, examples.grpc.HelloReply>> handler = GreeterGrpcService.this::handle_sayHello;
+        Handler<?> handler2 = handler;
+        return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
+      }
+      return null;
+    }
+
+    /**
+     * Throws {@code UnsupportedOperationException}.
+     */
+    public <Req, Resp> ServiceBuilder bind(ServiceMethod<Req, Resp> serviceMethod, Handler<GrpcServerRequest<Req, Resp>> handler) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return this builder
+     */
+    public Builder bind(List<ServiceMethod<?, ?>> methods) {
+      serviceMethods.addAll(methods);
+      return this;
+    }
+
+    /**
+     * @return this builder
+     */
+    public Builder bind(ServiceMethod<?, ?>... methods) {
+      return bind(java.util.Arrays.asList(methods));
+    }
+
+    public Service build() {
+      // Defensive copy
+      List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>(Builder.this.serviceMethods);
+      return new Service() {
+        public ServiceName name() {
+          return SERVICE_NAME;
+        }
+        public Descriptors.ServiceDescriptor descriptor() {
+          return SERVICE_DESCRIPTOR;
+        }
+        /**
+         * Bind the contained service methods to the {@code server}.
+         */
+        public void bind(GrpcServer server) {
+          for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+            bindHandler(serviceMethod, server);
+          }
+        }
+        private <Req, Resp> void bindHandler(ServiceMethod<Req, Resp> serviceMethod, GrpcServer server) {
+          Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> handler = resolveHandler(serviceMethod);
+          server.callHandler(serviceMethod, handler);
+        }
+      };
+    }
+  }
+
+  private void handle_sayHello(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.HelloRequest, examples.grpc.HelloReply> request) {
+    Promise<examples.grpc.HelloReply> promise = Promise.promise();
+    request.handler(msg -> {
+      try {
+        sayHello(msg, promise);
+      } catch (RuntimeException err) {
+        promise.tryFail(err);
+      }
+    });
+    promise.future()
+      .onFailure(err -> request.response().status(GrpcStatus.INTERNAL).end())
+      .onSuccess(resp -> request.response().end(resp));
+  }
+}

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterService.java
@@ -30,7 +30,7 @@ import java.util.List;
  *   <li>SayHello</li>
  * </ul>
  */
-public class GreeterService implements Service {
+public class GreeterService implements Greeter, Service {
 
   /**
    * Greeter service name.
@@ -136,7 +136,7 @@ public class GreeterService implements Service {
   /**
    * Override this method to implement the SayHello RPC.
    */
-  protected Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request) {
+  public Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request) {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/vertx-grpc-docs/src/main/java/examples/grpc/Streaming.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/Streaming.java
@@ -1,0 +1,38 @@
+package examples.grpc;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.Service;
+import io.vertx.grpc.server.ServiceBuilder;
+import io.vertx.codegen.annotations.GenIgnore;
+
+import com.google.protobuf.Descriptors;
+
+import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>Base definition Streaming service.</p>
+ */
+public interface Streaming {
+
+
+  Future<ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request);
+
+  Future<examples.grpc.Empty> sink(ReadStream<examples.grpc.Item> request);
+
+  Future<ReadStream<examples.grpc.Item>> pipe(ReadStream<examples.grpc.Item> request);
+
+}

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingClient.java
@@ -17,7 +17,7 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
  * <p>A client for invoking the Streaming gRPC service.</p>
  */
 @io.vertx.codegen.annotations.VertxGen
-public interface StreamingClient {
+public interface StreamingClient extends Streaming {
 
   /**
    * Source protobuf RPC client service method.

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
@@ -1,0 +1,263 @@
+package examples.grpc;
+
+import io.vertx.core.Future;
+import io.vertx.core.Completable;
+import io.vertx.core.Handler;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+
+/**
+ * <p>A client for invoking the Streaming gRPC service.</p>
+ */
+@io.vertx.codegen.annotations.VertxGen
+public interface StreamingGrpcClient extends Streaming {
+
+  /**
+   * Source protobuf RPC client service method.
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  ServiceMethod<examples.grpc.Item, examples.grpc.Empty> Source = ServiceMethod.client(
+    ServiceName.create("examples.grpc", "Streaming"),
+    "Source",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.grpc.Item.parser()));
+
+  /**
+   * Sink protobuf RPC client service method.
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  ServiceMethod<examples.grpc.Empty, examples.grpc.Item> Sink = ServiceMethod.client(
+    ServiceName.create("examples.grpc", "Streaming"),
+    "Sink",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.grpc.Empty.parser()));
+
+  /**
+   * Pipe protobuf RPC client service method.
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  ServiceMethod<examples.grpc.Item, examples.grpc.Item> Pipe = ServiceMethod.client(
+    ServiceName.create("examples.grpc", "Streaming"),
+    "Pipe",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.grpc.Item.parser()));
+
+  /**
+   * Json client service methods.
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  final class Json {
+
+    /**
+     * Source json RPC client service method.
+     */
+    public static final ServiceMethod<examples.grpc.Item, examples.grpc.Empty> Source = ServiceMethod.client(
+      ServiceName.create("examples.grpc", "Streaming"),
+      "Source",
+      GrpcMessageEncoder.json(),
+      GrpcMessageDecoder.json(() -> examples.grpc.Item.newBuilder()));
+
+    /**
+     * Sink json RPC client service method.
+     */
+    public static final ServiceMethod<examples.grpc.Empty, examples.grpc.Item> Sink = ServiceMethod.client(
+      ServiceName.create("examples.grpc", "Streaming"),
+      "Sink",
+      GrpcMessageEncoder.json(),
+      GrpcMessageDecoder.json(() -> examples.grpc.Empty.newBuilder()));
+
+    /**
+     * Pipe json RPC client service method.
+     */
+    public static final ServiceMethod<examples.grpc.Item, examples.grpc.Item> Pipe = ServiceMethod.client(
+      ServiceName.create("examples.grpc", "Streaming"),
+      "Pipe",
+      GrpcMessageEncoder.json(),
+      GrpcMessageDecoder.json(() -> examples.grpc.Item.newBuilder()));
+  }
+
+  /**
+   * Create and return a Streaming gRPC service client. The assumed wire format is Protobuf.
+   *
+   * @param client the gRPC client
+   * @param host   the host providing the service
+   * @return the configured client
+   */
+  static StreamingGrpcClient create(GrpcClient client, SocketAddress host) {
+    return new StreamingGrpcClientImpl(client, host);
+  }
+
+  /**
+   * Create and return a Streaming gRPC service client.
+   *
+   * @param client     the gRPC client
+   * @param host       the host providing the service
+   * @param wireFormat the wire format
+   * @return the configured client
+   */
+  static StreamingGrpcClient create(GrpcClient client, SocketAddress host, io.vertx.grpc.common.WireFormat wireFormat) {
+    return new StreamingGrpcClientImpl(client, host, wireFormat);
+  }
+
+  /**
+   * Calls the Source RPC service method.
+   *
+   * @param request the examples.grpc.Empty request message
+   * @return a future of the examples.grpc.Item response messages
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  Future<ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request);
+
+  /**
+   * Calls the Sink RPC service method.
+   *
+   * @param completable a completable that will be passed a stream to which the examples.grpc.Item request messages can be written to.
+   * @return a future of the examples.grpc.Empty response message
+   */
+  @io.vertx.codegen.annotations.GenIgnore
+  Future<examples.grpc.Empty> sink(Completable<WriteStream<examples.grpc.Item>> completable);
+
+  /**
+   * Calls the Sink RPC service method.
+   *
+   * @param streamOfMessages a stream of messages to be sent to the service
+   * @return a future of the examples.grpc.Empty response message
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  Future<examples.grpc.Empty> sink(ReadStream<examples.grpc.Item> streamOfMessages);
+
+  /**
+   * Calls the Pipe RPC service method.
+   *
+   * @param compltable a completable that will be passed a stream to which the examples.grpc.Item request messages can be written to.
+   * @return a future of the examples.grpc.Item response messages
+   */
+  @io.vertx.codegen.annotations.GenIgnore
+  Future<ReadStream<examples.grpc.Item>> pipe(Completable<WriteStream<examples.grpc.Item>> completable);
+
+  /**
+   * Calls the Pipe RPC service method.
+   *
+    * @param streamOfMessages a stream of messages to be sent to the service
+   * @return a future of the examples.grpc.Item response messages
+   */
+  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
+  Future<ReadStream<examples.grpc.Item>> pipe(ReadStream<examples.grpc.Item> streamOfMessages);
+}
+
+/**
+ * The proxy implementation.
+ */
+class StreamingGrpcClientImpl implements StreamingGrpcClient {
+
+  private final GrpcClient client;
+  private final SocketAddress socketAddress;
+  private final io.vertx.grpc.common.WireFormat wireFormat;
+
+  StreamingGrpcClientImpl(GrpcClient client, SocketAddress socketAddress) {
+    this(client, socketAddress, io.vertx.grpc.common.WireFormat.PROTOBUF);
+  }
+
+  StreamingGrpcClientImpl(GrpcClient client, SocketAddress socketAddress, io.vertx.grpc.common.WireFormat wireFormat) {
+    this.client = java.util.Objects.requireNonNull(client);
+    this.socketAddress = java.util.Objects.requireNonNull(socketAddress);
+    this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
+  }
+
+  public Future<ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request) {
+    ServiceMethod<examples.grpc.Item, examples.grpc.Empty> serviceMethod;
+    switch (wireFormat) {
+      case PROTOBUF:
+        serviceMethod = Source;
+        break;
+      case JSON:
+        serviceMethod = Json.Source;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod).compose(req -> {
+      req.end(request);
+      return req.response().flatMap(resp -> {
+        if (resp.status() != null && resp.status() != GrpcStatus.OK) {
+          return Future.failedFuture("Invalid gRPC status " + resp.status());
+        } else {
+          return Future.succeededFuture(resp);
+        }
+      });
+    });
+  }
+
+  public Future<examples.grpc.Empty> sink(Completable<WriteStream<examples.grpc.Item>> completable) {
+    ServiceMethod<examples.grpc.Empty, examples.grpc.Item> serviceMethod;
+    switch (wireFormat) {
+      case PROTOBUF:
+        serviceMethod = Sink;
+        break;
+      case JSON:
+        serviceMethod = Json.Sink;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod)
+      .andThen(completable)
+      .compose(request -> {
+      return request.response().compose(response -> response.last());
+    });
+  }
+
+  public Future<examples.grpc.Empty> sink(ReadStream<examples.grpc.Item> request) {
+    io.vertx.core.streams.Pipe<examples.grpc.Item> pipe = request.pipe();
+    return sink((result, error) -> {
+        if (error == null) {
+          pipe.to(result);
+        } else {
+          pipe.close();
+        }
+    });
+  }
+
+  public Future<ReadStream<examples.grpc.Item>> pipe(Completable<WriteStream<examples.grpc.Item>> completable) {
+    ServiceMethod<examples.grpc.Item, examples.grpc.Item> serviceMethod;
+    switch (wireFormat) {
+      case PROTOBUF:
+        serviceMethod = Pipe;
+        break;
+      case JSON:
+        serviceMethod = Json.Pipe;
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return client.request(socketAddress, serviceMethod)
+      .andThen(completable)
+      .compose(req -> {
+        return req.response().flatMap(resp -> {
+          if (resp.status() != null && resp.status() != GrpcStatus.OK) {
+            return Future.failedFuture("Invalid gRPC status " + resp.status());
+          } else {
+            return Future.succeededFuture(resp);
+          }
+        });
+    });
+  }
+
+  public Future<ReadStream<examples.grpc.Item>> pipe(ReadStream<examples.grpc.Item> request) {
+    io.vertx.core.streams.Pipe<examples.grpc.Item> pipe = request.pipe();
+    return pipe((result, error) -> {
+        if (error == null) {
+          pipe.to(result);
+        } else {
+          pipe.close();
+        }
+    });
+  }
+}

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
@@ -1,0 +1,347 @@
+package examples.grpc;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.Service;
+import io.vertx.grpc.server.ServiceBuilder;
+
+import com.google.protobuf.Descriptors;
+
+import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>Provides support for RPC methods implementations of the Streaming gRPC service.</p>
+ *
+ * <p>The following methods of this class should be overridden to provide an implementation of the service:</p>
+ * <ul>
+ *   <li>Source</li>
+ *   <li>Sink</li>
+ *   <li>Pipe</li>
+ * </ul>
+ */
+public class StreamingGrpcService implements Streaming, Service {
+
+  /**
+   * Streaming service name.
+   */
+  public static final ServiceName SERVICE_NAME = ServiceName.create("examples.grpc", "Streaming");
+
+  /**
+   * Streaming service descriptor.
+   */
+  public static final Descriptors.ServiceDescriptor SERVICE_DESCRIPTOR = Docs.getDescriptor().findServiceByName("Streaming");
+
+  @Override
+  public ServiceName name() {
+    return SERVICE_NAME;
+  }
+
+  @Override
+  public Descriptors.ServiceDescriptor descriptor() {
+    return SERVICE_DESCRIPTOR;
+  }
+
+  @Override
+  public void bind(GrpcServer server) {
+    builder().bind(all()).build().bind(server);
+  }
+
+  /**
+   * Source protobuf RPC server service method.
+   */
+  public static final ServiceMethod<examples.grpc.Empty, examples.grpc.Item> Source = ServiceMethod.server(
+    SERVICE_NAME,
+    "Source",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.grpc.Empty.parser()));
+
+  /**
+   * Sink protobuf RPC server service method.
+   */
+  public static final ServiceMethod<examples.grpc.Item, examples.grpc.Empty> Sink = ServiceMethod.server(
+    SERVICE_NAME,
+    "Sink",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.grpc.Item.parser()));
+
+  /**
+   * Pipe protobuf RPC server service method.
+   */
+  public static final ServiceMethod<examples.grpc.Item, examples.grpc.Item> Pipe = ServiceMethod.server(
+    SERVICE_NAME,
+    "Pipe",
+    GrpcMessageEncoder.encoder(),
+    GrpcMessageDecoder.decoder(examples.grpc.Item.parser()));
+
+  /**
+   * @return a mutable list of the known protobuf RPC server service methods.
+   */
+  public static java.util.List<ServiceMethod<?, ?>> all() {
+    java.util.List<ServiceMethod<?, ?>> all = new java.util.ArrayList<>();
+    all.add(Source);
+    all.add(Sink);
+    all.add(Pipe);
+    return all;
+  }
+
+  /**
+   * Json server service methods.
+   */
+  public static final class Json {
+
+    /**
+     * Source json RPC server service method.
+     */
+    public static final ServiceMethod<examples.grpc.Empty, examples.grpc.Item> Source = ServiceMethod.server(
+      SERVICE_NAME,
+      "Source",
+      GrpcMessageEncoder.json(),
+      GrpcMessageDecoder.json(() -> examples.grpc.Empty.newBuilder()));
+
+    /**
+     * Sink json RPC server service method.
+     */
+    public static final ServiceMethod<examples.grpc.Item, examples.grpc.Empty> Sink = ServiceMethod.server(
+      SERVICE_NAME,
+      "Sink",
+      GrpcMessageEncoder.json(),
+      GrpcMessageDecoder.json(() -> examples.grpc.Item.newBuilder()));
+
+    /**
+     * Pipe json RPC server service method.
+     */
+    public static final ServiceMethod<examples.grpc.Item, examples.grpc.Item> Pipe = ServiceMethod.server(
+      SERVICE_NAME,
+      "Pipe",
+      GrpcMessageEncoder.json(),
+      GrpcMessageDecoder.json(() -> examples.grpc.Item.newBuilder()));
+
+    /**
+     * @return a mutable list of the known json RPC server service methods.
+     */
+    public static java.util.List<ServiceMethod<?, ?>> all() {
+      java.util.List<ServiceMethod<?, ?>> all = new java.util.ArrayList<>();
+      all.add(Source);
+      all.add(Sink);
+      all.add(Pipe);
+      return all;
+    }
+  }
+
+  /**
+   * Transcoded server service methods.
+   */
+  public static final class Transcoding {
+
+    /**
+     * @return a mutable list of the known transcoded RPC server service methods.
+     */
+    public static java.util.List<ServiceMethod<?, ?>> all() {
+      java.util.List<ServiceMethod<?, ?>> all = new java.util.ArrayList<>();
+      return all;
+    }
+  }
+
+
+  /**
+   * Override this method to implement the Source RPC.
+   */
+  public Future<ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  protected void source(examples.grpc.Empty request, WriteStream<examples.grpc.Item> response) {
+    source(request)
+      .onComplete(ar -> {
+        if (ar.succeeded()) {
+          ReadStream<examples.grpc.Item> stream = ar.result();
+          stream.pipeTo(response);
+        } else {
+          // Todo
+        }
+      });
+  }
+
+  /**
+   * Override this method to implement the Sink RPC.
+   */
+  public Future<examples.grpc.Empty> sink(ReadStream<examples.grpc.Item> request) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  protected void sink(ReadStream<examples.grpc.Item> request, Promise<examples.grpc.Empty> response) {
+    sink(request)
+      .onSuccess(msg -> response.complete(msg))
+      .onFailure(error -> response.fail(error));
+  }
+
+  /**
+   * Override this method to implement the Pipe RPC.
+   */
+  public Future<ReadStream<examples.grpc.Item>> pipe(ReadStream<examples.grpc.Item> request) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  protected void pipe(ReadStream<examples.grpc.Item> request, WriteStream<examples.grpc.Item> response) {
+    pipe(request)
+      .onComplete(ar -> {
+        if (ar.succeeded()) {
+          ReadStream<examples.grpc.Item> stream = ar.result();
+          stream.pipeTo(response);
+        } else {
+          // Todo
+        }
+      });
+  }
+
+  private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
+    if (Source == serviceMethod || Json.Source == serviceMethod) {
+      Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Empty, examples.grpc.Item>> handler = StreamingGrpcService.this::handle_source;
+      Handler<?> handler2 = handler;
+      return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
+    }
+    if (Sink == serviceMethod || Json.Sink == serviceMethod) {
+      Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Empty>> handler = StreamingGrpcService.this::handle_sink;
+      Handler<?> handler2 = handler;
+      return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
+    }
+    if (Pipe == serviceMethod || Json.Pipe == serviceMethod) {
+      Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Item>> handler = StreamingGrpcService.this::handle_pipe;
+      Handler<?> handler2 = handler;
+      return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
+    }
+    return null;
+  }
+
+  /**
+   * @return a free form builder that gives the opportunity to bind only certain methods of a service
+   */
+  public Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Service builder.
+   */
+  public class Builder implements ServiceBuilder {
+
+    private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>();
+
+    private void validate() {
+      for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+        if (resolveHandler(serviceMethod) == null) {
+          throw new IllegalArgumentException("Invalid service method:" + serviceMethod);
+        }
+      }
+    }
+
+    private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
+      if (Source == serviceMethod || Json.Source == serviceMethod) {
+        Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Empty, examples.grpc.Item>> handler = StreamingGrpcService.this::handle_source;
+        Handler<?> handler2 = handler;
+        return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
+      }
+      if (Sink == serviceMethod || Json.Sink == serviceMethod) {
+        Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Empty>> handler = StreamingGrpcService.this::handle_sink;
+        Handler<?> handler2 = handler;
+        return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
+      }
+      if (Pipe == serviceMethod || Json.Pipe == serviceMethod) {
+        Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Item>> handler = StreamingGrpcService.this::handle_pipe;
+        Handler<?> handler2 = handler;
+        return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
+      }
+      return null;
+    }
+
+    /**
+     * Throws {@code UnsupportedOperationException}.
+     */
+    public <Req, Resp> ServiceBuilder bind(ServiceMethod<Req, Resp> serviceMethod, Handler<GrpcServerRequest<Req, Resp>> handler) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return this builder
+     */
+    public Builder bind(List<ServiceMethod<?, ?>> methods) {
+      serviceMethods.addAll(methods);
+      return this;
+    }
+
+    /**
+     * @return this builder
+     */
+    public Builder bind(ServiceMethod<?, ?>... methods) {
+      return bind(java.util.Arrays.asList(methods));
+    }
+
+    public Service build() {
+      // Defensive copy
+      List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>(Builder.this.serviceMethods);
+      return new Service() {
+        public ServiceName name() {
+          return SERVICE_NAME;
+        }
+        public Descriptors.ServiceDescriptor descriptor() {
+          return SERVICE_DESCRIPTOR;
+        }
+        /**
+         * Bind the contained service methods to the {@code server}.
+         */
+        public void bind(GrpcServer server) {
+          for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+            bindHandler(serviceMethod, server);
+          }
+        }
+        private <Req, Resp> void bindHandler(ServiceMethod<Req, Resp> serviceMethod, GrpcServer server) {
+          Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> handler = resolveHandler(serviceMethod);
+          server.callHandler(serviceMethod, handler);
+        }
+      };
+    }
+  }
+
+  private void handle_source(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Empty, examples.grpc.Item> request) {
+    request.handler(msg -> {
+      try {
+        source(msg, request.response());
+      } catch (RuntimeException err) {
+        request.response().status(GrpcStatus.INTERNAL).end();
+      }
+    });
+  }
+
+  private void handle_sink(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Empty> request) {
+    Promise<examples.grpc.Empty> promise = Promise.promise();
+    promise.future()
+      .onFailure(err -> request.response().status(GrpcStatus.INTERNAL).end())
+      .onSuccess(resp -> request.response().end(resp));
+    try {
+      sink(request, promise);
+    } catch (RuntimeException err) {
+      promise.tryFail(err);
+    }
+  }
+
+  private void handle_pipe(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Item> request) {
+    try {
+      pipe(request, request.response());
+    } catch (RuntimeException err) {
+      request.response().status(GrpcStatus.INTERNAL).end();
+    }
+  }
+}

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingService.java
@@ -32,7 +32,7 @@ import java.util.List;
  *   <li>Pipe</li>
  * </ul>
  */
-public class StreamingService implements Service {
+public class StreamingService implements Streaming, Service {
 
   /**
    * Streaming service name.
@@ -159,21 +159,26 @@ public class StreamingService implements Service {
   /**
    * Override this method to implement the Source RPC.
    */
-  protected ReadStream<examples.grpc.Item> source(examples.grpc.Empty request) {
+  public Future<ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   protected void source(examples.grpc.Empty request, WriteStream<examples.grpc.Item> response) {
     source(request)
-      .handler(msg -> response.write(msg))
-      .endHandler(msg -> response.end())
-      .resume();
+      .onComplete(ar -> {
+        if (ar.succeeded()) {
+          ReadStream<examples.grpc.Item> stream = ar.result();
+          stream.pipeTo(response);
+        } else {
+          // Todo
+        }
+      });
   }
 
   /**
    * Override this method to implement the Sink RPC.
    */
-  protected Future<examples.grpc.Empty> sink(ReadStream<examples.grpc.Item> request) {
+  public Future<examples.grpc.Empty> sink(ReadStream<examples.grpc.Item> request) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -186,15 +191,20 @@ public class StreamingService implements Service {
   /**
    * Override this method to implement the Pipe RPC.
    */
-  protected ReadStream<examples.grpc.Item> pipe(ReadStream<examples.grpc.Item> request) {
+  public Future<ReadStream<examples.grpc.Item>> pipe(ReadStream<examples.grpc.Item> request) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   protected void pipe(ReadStream<examples.grpc.Item> request, WriteStream<examples.grpc.Item> response) {
     pipe(request)
-      .handler(msg -> response.write(msg))
-      .endHandler(msg -> response.end())
-      .resume();
+      .onComplete(ar -> {
+        if (ar.succeeded()) {
+          ReadStream<examples.grpc.Item> stream = ar.result();
+          stream.pipeTo(response);
+        } else {
+          // Todo
+        }
+      });
   }
 
   private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/JsonWireFormatTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/JsonWireFormatTest.java
@@ -10,8 +10,8 @@
  */
 package io.vertx.grpc.it;
 
-import io.grpc.examples.helloworld.GreeterClient;
-import io.grpc.examples.helloworld.GreeterService;
+import io.grpc.examples.helloworld.GreeterGrpcClient;
+import io.grpc.examples.helloworld.GreeterGrpcService;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.vertx.core.Future;
@@ -36,7 +36,7 @@ public class JsonWireFormatTest extends ProxyTestBase {
 
     GrpcClient client = GrpcClient.client(vertx);
 
-    Future<HttpServer> server = vertx.createHttpServer().requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Json.SayHello, call -> {
+    Future<HttpServer> server = vertx.createHttpServer().requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Json.SayHello, call -> {
       call.handler(helloRequest -> {
         HelloReply helloReply = HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName()).build();
         call.response().end(helloReply);
@@ -45,7 +45,7 @@ public class JsonWireFormatTest extends ProxyTestBase {
 
     Async test = should.async();
     server.onComplete(should.asyncAssertSuccess(v -> {
-      client.request(SocketAddress.inetSocketAddress(8080, "localhost"), GreeterClient.Json.SayHello)
+      client.request(SocketAddress.inetSocketAddress(8080, "localhost"), GreeterGrpcClient.Json.SayHello)
         .onComplete(should.asyncAssertSuccess(callRequest -> {
           callRequest.response().onComplete(should.asyncAssertSuccess(callResponse -> {
             AtomicInteger count = new AtomicInteger();
@@ -70,7 +70,7 @@ public class JsonWireFormatTest extends ProxyTestBase {
 
     GrpcClient client = GrpcClient.client(vertx);
 
-    GreeterService greeter = new GreeterService() {
+    GreeterGrpcService greeter = new GreeterGrpcService() {
       @Override
       public Future<HelloReply> sayHello(HelloRequest request) {
         return Future.succeededFuture(HelloReply.newBuilder().setMessage("Hello " + request.getName()).build());
@@ -79,14 +79,14 @@ public class JsonWireFormatTest extends ProxyTestBase {
 
     GrpcServer grpcServer = GrpcServer.server(vertx);
 
-    grpcServer.addService(greeter.builder().bind(GreeterService.Json.SayHello).build());
+    grpcServer.addService(greeter.builder().bind(GreeterGrpcService.Json.SayHello).build());
 
     Future<HttpServer> server = vertx
       .createHttpServer()
       .requestHandler(grpcServer)
       .listen(8080, "localhost");
 
-    GreeterClient stub = GreeterClient.create(client, SocketAddress.inetSocketAddress(8080, "localhost"), WireFormat.JSON);
+    GreeterGrpcClient stub = GreeterGrpcClient.create(client, SocketAddress.inetSocketAddress(8080, "localhost"), WireFormat.JSON);
 
     Async test = should.async();
     server.onComplete(should.asyncAssertSuccess(v -> {

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
@@ -335,9 +335,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     GrpcServer grpcServer = GrpcServer.server(vertx);
     grpcServer.addService(new TestServiceService() {
       @Override
-      public ReadStream<Messages.StreamingOutputCallResponse> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
-        FakeStream<Messages.StreamingOutputCallResponse> response = new FakeStream<>();
-        response.pause();
+      protected void streamingOutputCall(Messages.StreamingOutputCallRequest request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         response.write(Messages.StreamingOutputCallResponse.newBuilder()
           .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-1", StandardCharsets.UTF_8)).build())
           .build());
@@ -345,7 +343,6 @@ public class ProtocPluginTest extends ProxyTestBase {
           .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-2", StandardCharsets.UTF_8)).build())
           .build());
         response.end();
-        return response;
       }
     });
     HttpServer httpServer = vertx.createHttpServer();
@@ -379,7 +376,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     GrpcServer grpcServer = GrpcServer.server(vertx);
     grpcServer.addService(new TestServiceService() {
       @Override
-      public ReadStream<Messages.StreamingOutputCallResponse> streamingOutputCall(Messages.StreamingOutputCallRequest request) {
+      protected void streamingOutputCall(Messages.StreamingOutputCallRequest request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         throw new RuntimeException("Simulated error");
       }
     });
@@ -457,8 +454,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     GrpcServer grpcServer = GrpcServer.server(vertx);
     grpcServer.addService(new TestServiceService() {
       @Override
-      public ReadStream<Messages.StreamingOutputCallResponse> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
-        FakeStream<Messages.StreamingOutputCallResponse> response = new FakeStream<>();
+      protected void fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         request.endHandler($ -> {
           response.write(Messages.StreamingOutputCallResponse.newBuilder()
             .setPayload(Messages.Payload.newBuilder().setBody(ByteString.copyFrom("StreamingOutputResponse-1", StandardCharsets.UTF_8)).build())
@@ -468,7 +464,6 @@ public class ProtocPluginTest extends ProxyTestBase {
             .build());
           response.end();
         });
-        return response;
       }
     });
     HttpServer httpServer = vertx.createHttpServer();
@@ -507,7 +502,7 @@ public class ProtocPluginTest extends ProxyTestBase {
     GrpcServer grpcServer = GrpcServer.server(vertx);
     grpcServer.addService(new TestServiceService() {
       @Override
-      public GrpcReadStream<Messages.StreamingOutputCallResponse> fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request) {
+      protected void fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         throw new RuntimeException("Simulated error");
       }
     });

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProtocPluginTest.java
@@ -11,13 +11,13 @@
 package io.vertx.grpc.it;
 
 import com.google.protobuf.ByteString;
-import io.grpc.examples.helloworld.GreeterClient;
-import io.grpc.examples.helloworld.GreeterService;
+import io.grpc.examples.helloworld.GreeterGrpcClient;
+import io.grpc.examples.helloworld.GreeterGrpcService;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.testing.integration.Messages;
-import io.grpc.testing.integration.TestServiceClient;
-import io.grpc.testing.integration.TestServiceService;
+import io.grpc.testing.integration.TestServiceGrpcClient;
+import io.grpc.testing.integration.TestServiceGrpcService;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
@@ -27,11 +27,9 @@ import io.vertx.core.streams.WriteStream;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.client.InvalidStatusException;
-import io.vertx.grpc.common.GrpcReadStream;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.client.GrpcClient;
-import io.vertx.test.fakestream.FakeStream;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -45,7 +43,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testHelloWorld(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new GreeterService() {
+    grpcServer.addService(new GreeterGrpcService() {
       @Override
       public Future<HelloReply> sayHello(HelloRequest request) {
         return Future.succeededFuture(HelloReply.newBuilder()
@@ -59,7 +57,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    GreeterClient client = GreeterClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    GreeterGrpcClient client = GreeterGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.sayHello(HelloRequest.newBuilder()
@@ -76,7 +74,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testUnary_PromiseArg(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       public void unaryCall(Messages.SimpleRequest request, Promise<Messages.SimpleResponse> response) {
         response.complete(Messages.SimpleResponse.newBuilder()
@@ -90,7 +88,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.unaryCall(Messages.SimpleRequest.newBuilder()
@@ -107,7 +105,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testUnary_FutureReturn(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
         return Future.succeededFuture(Messages.SimpleResponse.newBuilder()
@@ -121,7 +119,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.unaryCall(Messages.SimpleRequest.newBuilder()
@@ -138,7 +136,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testUnary_FutureReturn_ErrorHandling(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       public Future<Messages.SimpleResponse> unaryCall(Messages.SimpleRequest request) {
         throw new RuntimeException("Simulated error");
@@ -150,7 +148,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.unaryCall(Messages.SimpleRequest.newBuilder()
@@ -169,7 +167,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testManyUnary_PromiseArg(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       public void streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request, Promise<Messages.StreamingInputCallResponse> response) {
         List<Messages.StreamingInputCallRequest> list = new ArrayList<>();
@@ -188,7 +186,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.streamingInputCall((req, err) -> {
@@ -211,7 +209,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testManyUnary_FutureReturn(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
         Promise<Messages.StreamingInputCallResponse> promise = Promise.promise();
@@ -232,7 +230,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.streamingInputCall((req, err) -> {
@@ -255,7 +253,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testManyUnary_FutureReturn_ErrorHandling(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       public Future<Messages.StreamingInputCallResponse> streamingInputCall(ReadStream<Messages.StreamingInputCallRequest> request) {
         throw new RuntimeException("Simulated error");
@@ -267,7 +265,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.streamingInputCall((req, err) -> {
@@ -292,7 +290,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testUnaryMany_WriteStreamArg(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       public void streamingOutputCall(Messages.StreamingOutputCallRequest request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         response.write(Messages.StreamingOutputCallResponse.newBuilder()
@@ -310,7 +308,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     Messages.StreamingOutputCallRequest request = Messages.StreamingOutputCallRequest.newBuilder()
@@ -333,7 +331,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testUnaryMany_ReadStreamReturn(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       protected void streamingOutputCall(Messages.StreamingOutputCallRequest request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         response.write(Messages.StreamingOutputCallResponse.newBuilder()
@@ -351,7 +349,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     Messages.StreamingOutputCallRequest request = Messages.StreamingOutputCallRequest.newBuilder()
@@ -374,7 +372,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testUnaryMany_ReadStreamReturn_ErrorHandling(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       protected void streamingOutputCall(Messages.StreamingOutputCallRequest request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         throw new RuntimeException("Simulated error");
@@ -386,7 +384,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     Messages.StreamingOutputCallRequest request = Messages.StreamingOutputCallRequest.newBuilder()
@@ -404,7 +402,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testmanyMany_WriteStreamArg(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       public void fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         request.endHandler($ -> {
@@ -424,7 +422,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.fullDuplexCall((req, err) -> {
@@ -452,7 +450,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testmanyMany_ReadStreamReturn(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       protected void fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         request.endHandler($ -> {
@@ -472,7 +470,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.fullDuplexCall((req, err) -> {
@@ -500,7 +498,7 @@ public class ProtocPluginTest extends ProxyTestBase {
   public void testmanyMany_ReadStreamReturn_ErrorHandling(TestContext should) throws Exception {
     // Create gRPC Server
     GrpcServer grpcServer = GrpcServer.server(vertx);
-    grpcServer.addService(new TestServiceService() {
+    grpcServer.addService(new TestServiceGrpcService() {
       @Override
       protected void fullDuplexCall(ReadStream<Messages.StreamingOutputCallRequest> request, WriteStream<Messages.StreamingOutputCallResponse> response) {
         throw new RuntimeException("Simulated error");
@@ -512,7 +510,7 @@ public class ProtocPluginTest extends ProxyTestBase {
 
     // Create gRPC Client
     GrpcClient grpcClient = GrpcClient.client(vertx);
-    TestServiceClient client = TestServiceClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
+    TestServiceGrpcClient client = TestServiceGrpcClient.create(grpcClient, SocketAddress.inetSocketAddress(port, "localhost"));
 
     Async test = should.async();
     client.fullDuplexCall((req, err) -> {

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProxyTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ProxyTest.java
@@ -10,8 +10,8 @@
  */
 package io.vertx.grpc.it;
 
-import io.grpc.examples.helloworld.GreeterClient;
-import io.grpc.examples.helloworld.GreeterService;
+import io.grpc.examples.helloworld.GreeterGrpcClient;
+import io.grpc.examples.helloworld.GreeterGrpcService;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.vertx.core.Future;
@@ -37,7 +37,7 @@ public class ProxyTest extends ProxyTestBase {
 
     GrpcClient client = GrpcClient.client(vertx);
 
-    Future<HttpServer> server = vertx.createHttpServer().requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.SayHello, call -> {
+    Future<HttpServer> server = vertx.createHttpServer().requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.SayHello, call -> {
       call.handler(helloRequest -> {
         HelloReply helloReply = HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName()).build();
         call.response().end(helloReply);
@@ -61,7 +61,7 @@ public class ProxyTest extends ProxyTestBase {
 
     Async test = should.async();
     server.flatMap(v -> proxy).onComplete(should.asyncAssertSuccess(v -> {
-      client.request(SocketAddress.inetSocketAddress(8081, "localhost"), GreeterClient.SayHello)
+      client.request(SocketAddress.inetSocketAddress(8081, "localhost"), GreeterGrpcClient.SayHello)
         .onComplete(should.asyncAssertSuccess(callRequest -> {
           callRequest.response().onComplete(should.asyncAssertSuccess(callResponse -> {
             AtomicInteger count = new AtomicInteger();

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ReflectionTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/ReflectionTest.java
@@ -10,7 +10,7 @@
  */
 package io.vertx.grpc.it;
 
-import io.grpc.examples.helloworld.GreeterService;
+import io.grpc.examples.helloworld.GreeterGrpcService;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloWorldProto;
 import io.vertx.core.Future;
@@ -19,7 +19,6 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.reflection.ReflectionService;
 import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.GrpcServerOptions;
 import io.vertx.grpc.server.Service;
 import io.vertx.tests.common.GrpcTestBase;
 import org.junit.Test;
@@ -43,13 +42,13 @@ public class ReflectionTest extends GrpcTestBase {
   public void setUp(TestContext should) {
     super.setUp(should);
 
-    Service greeterService = Service.service(GreeterService.SERVICE_NAME, HelloWorldProto.getDescriptor().findServiceByName("Greeter")).build();
+    Service greeterService = Service.service(GreeterGrpcService.SERVICE_NAME, HelloWorldProto.getDescriptor().findServiceByName("Greeter")).build();
     GrpcServer grpcServer = GrpcServer.server(vertx);
 
     grpcServer.addService(ReflectionService.v1());
     grpcServer.addService(greeterService);
 
-    grpcServer.callHandler(GreeterService.SayHello, call -> {
+    grpcServer.callHandler(GreeterGrpcService.SayHello, call -> {
       call.handler(helloRequest -> {
         HelloReply helloReply = HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName()).build();
         call.response().end(helloReply);

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/TranscodingTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/TranscodingTest.java
@@ -1,7 +1,6 @@
 package io.vertx.grpc.it;
 
-import io.grpc.examples.helloworld.GreeterService;
-import io.grpc.examples.helloworld.GreeterService;
+import io.grpc.examples.helloworld.GreeterGrpcService;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpMethod;
@@ -12,8 +11,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.GrpcServerOptions;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Map;
@@ -25,7 +22,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHello, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHello, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName())
             .build();
@@ -60,7 +57,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHelloAgain, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHelloAgain, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName())
             .build();
@@ -95,7 +92,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHello, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHello, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName())
             .build();
@@ -128,7 +125,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHello, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHello, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName())
             .build();
@@ -163,7 +160,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHello, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHello, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName())
             .build();
@@ -196,7 +193,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHello, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHello, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName())
             .build();
@@ -229,7 +226,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHelloCustom, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHelloCustom, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName())
             .build();
@@ -264,7 +261,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHelloWithBody, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHelloWithBody, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getRequest().getName())
             .build();
@@ -299,7 +296,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHelloNested, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHelloNested, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName())
             .build();
@@ -337,7 +334,7 @@ public class TranscodingTest extends ProxyTestBase {
     HttpClient client = vertx.createHttpClient();
 
     Future<HttpServer> server = vertx.createHttpServer()
-      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterService.Transcoding.SayHelloWithResponseBOdy, call -> {
+      .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Transcoding.SayHelloWithResponseBOdy, call -> {
         call.handler(helloRequest -> {
           io.grpc.examples.helloworld.HelloReply helloReply = io.grpc.examples.helloworld.HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName())
             .build();

--- a/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGeneratorImpl.java
+++ b/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGeneratorImpl.java
@@ -325,6 +325,7 @@ public class VertxGrpcGeneratorImpl extends Generator {
 
   private List<PluginProtos.CodeGeneratorResponse.File> buildFiles(ServiceContext context) {
     List<PluginProtos.CodeGeneratorResponse.File> files = new ArrayList<>();
+    files.add(buildBaseFile(context));
     if (generateClient) {
       files.add(buildClientFile(context));
     }
@@ -332,6 +333,12 @@ public class VertxGrpcGeneratorImpl extends Generator {
       files.add(buildServerFile(context));
     }
     return files;
+  }
+
+  private PluginProtos.CodeGeneratorResponse.File buildBaseFile(ServiceContext context) {
+    context.fileName = context.serviceName + ".java";
+    context.className = context.serviceName;
+    return buildFile(context, applyTemplate("base.mustache", context));
   }
 
   private PluginProtos.CodeGeneratorResponse.File buildClientFile(ServiceContext context) {

--- a/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGeneratorImpl.java
+++ b/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGeneratorImpl.java
@@ -342,14 +342,14 @@ public class VertxGrpcGeneratorImpl extends Generator {
   }
 
   private PluginProtos.CodeGeneratorResponse.File buildClientFile(ServiceContext context) {
-    context.fileName = context.serviceName + "Client.java";
-    context.className = context.serviceName + "Client";
+    context.fileName = context.serviceName + "GrpcClient.java";
+    context.className = context.serviceName + "GrpcClient";
     return buildFile(context, applyTemplate("client.mustache", context));
   }
 
   private PluginProtos.CodeGeneratorResponse.File buildServerFile(ServiceContext context) {
-    context.fileName = context.serviceName + "Service.java";
-    context.className = context.serviceName + "Service";
+    context.fileName = context.serviceName + "GrpcService.java";
+    context.className = context.serviceName + "GrpcService";
     return buildFile(context, applyTemplate("server.mustache", context));
   }
 

--- a/vertx-grpc-protoc-plugin2/src/main/resources/base.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/base.mustache
@@ -1,0 +1,50 @@
+{{#vertxPackageName}}
+package {{vertxPackageName}};
+{{/vertxPackageName}}
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.GrpcMessageDecoder;
+import io.vertx.grpc.common.GrpcMessageEncoder;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.Service;
+import io.vertx.grpc.server.ServiceBuilder;
+import io.vertx.codegen.annotations.GenIgnore;
+
+import com.google.protobuf.Descriptors;
+
+import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>Base definition {{serviceName}} service.</p>
+ */
+public interface {{className}} {
+
+{{#unaryMethods}}
+
+  Future<{{outputType}}> {{vertxMethodName}}({{inputType}} request);
+{{/unaryMethods}}
+{{#unaryManyMethods}}
+
+  Future<ReadStream<{{outputType}}>> {{vertxMethodName}}({{inputType}} request);
+{{/unaryManyMethods}}
+{{#manyUnaryMethods}}
+
+  Future<{{outputType}}> {{vertxMethodName}}(ReadStream<{{inputType}}> request);
+{{/manyUnaryMethods}}
+{{#manyManyMethods}}
+
+  Future<ReadStream<{{outputType}}>> {{vertxMethodName}}(ReadStream<{{inputType}}> request);
+{{/manyManyMethods}}
+
+}

--- a/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
@@ -19,7 +19,7 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
  * <p>A client for invoking the {{serviceName}} gRPC service.</p>
  */
 @io.vertx.codegen.annotations.VertxGen
-public interface {{className}} {
+public interface {{className}} extends {{serviceName}} {
 {{#allMethods}}
 
   /**

--- a/vertx-grpc-protoc-plugin2/src/main/resources/server.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/server.mustache
@@ -34,7 +34,7 @@ import java.util.List;
 {{/allMethods}}
  * </ul>
  */
-public class {{className}} implements Service {
+public class {{className}} implements {{serviceName}}, Service {
 
   /**
    * {{serviceName}} service name.
@@ -163,7 +163,7 @@ public class {{className}} implements Service {
   /**
    * Override this method to implement the {{methodName}} RPC.
    */
-  protected Future<{{outputType}}> {{vertxMethodName}}({{inputType}} request) {
+  public Future<{{outputType}}> {{vertxMethodName}}({{inputType}} request) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -178,15 +178,20 @@ public class {{className}} implements Service {
   /**
    * Override this method to implement the {{methodName}} RPC.
    */
-  protected ReadStream<{{outputType}}> {{vertxMethodName}}({{inputType}} request) {
+  public Future<ReadStream<{{outputType}}>> {{vertxMethodName}}({{inputType}} request) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   protected void {{vertxMethodName}}({{inputType}} request, WriteStream<{{outputType}}> response) {
     {{vertxMethodName}}(request)
-      .handler(msg -> response.write(msg))
-      .endHandler(msg -> response.end())
-      .resume();
+      .onComplete(ar -> {
+        if (ar.succeeded()) {
+          ReadStream<{{outputType}}> stream = ar.result();
+          stream.pipeTo(response);
+        } else {
+          // Todo
+        }
+      });
   }
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
@@ -194,7 +199,7 @@ public class {{className}} implements Service {
   /**
    * Override this method to implement the {{methodName}} RPC.
    */
-  protected Future<{{outputType}}> {{vertxMethodName}}(ReadStream<{{inputType}}> request) {
+  public Future<{{outputType}}> {{vertxMethodName}}(ReadStream<{{inputType}}> request) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
@@ -209,15 +214,20 @@ public class {{className}} implements Service {
   /**
    * Override this method to implement the {{methodName}} RPC.
    */
-  protected ReadStream<{{outputType}}> {{vertxMethodName}}(ReadStream<{{inputType}}> request) {
+  public Future<ReadStream<{{outputType}}>> {{vertxMethodName}}(ReadStream<{{inputType}}> request) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   protected void {{vertxMethodName}}(ReadStream<{{inputType}}> request, WriteStream<{{outputType}}> response) {
     {{vertxMethodName}}(request)
-      .handler(msg -> response.write(msg))
-      .endHandler(msg -> response.end())
-      .resume();
+      .onComplete(ar -> {
+        if (ar.succeeded()) {
+          ReadStream<{{outputType}}> stream = ar.result();
+          stream.pipeTo(response);
+        } else {
+          // Todo
+        }
+      });
   }
 {{/manyManyMethods}}
 


### PR DESCRIPTION
This implies to modify the streaming pattern of the server to align with the client pattern which is to return a `Future<ReadStream<T>>`.
