### PR TITLE
Remove unnecessary proto plugin from modules where it's not used

### DIFF
--- a/vertx-grpc-transcoding/pom.xml
+++ b/vertx-grpc-transcoding/pom.xml
@@ -82,22 +82,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
-        <artifactId>protobuf-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>test-compile</id>
-            <goals>
-              <goal>test-compile</goal>
-              <goal>test-compile-custom</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/vertx-grpcio-common/pom.xml
+++ b/vertx-grpcio-common/pom.xml
@@ -48,24 +48,6 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
-        <artifactId>protobuf-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>test-compile</id>
-            <goals>
-              <goal>test-compile</goal>
-              <goal>test-compile-custom</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>sonatype-oss-release</id>


### PR DESCRIPTION
This PR removes unnecessary proto plugin from modules where it's not used as there are no proto files.
