### PR TITLE
Message codec should be capable to handle two wire formats.

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcWriteStreamBase.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcWriteStreamBase.java
@@ -153,12 +153,20 @@ public abstract class GrpcWriteStreamBase<S extends GrpcWriteStreamBase<S, T>, T
 
   @Override
   public final Future<Void> write(T message) {
-    return writeMessage(messageEncoder.encode(message));
+    return writeMessage(encodeMessage(message));
   }
 
   @Override
   public final Future<Void> end(T message) {
-    return endMessage(messageEncoder.encode(message));
+    return endMessage(encodeMessage(message));
+  }
+
+  private GrpcMessage encodeMessage(T message) {
+    WireFormat f = format;
+    if (f == null) {
+      f = WireFormat.PROTOBUF;
+    }
+    return messageEncoder.encode(message, f);
   }
 
   @Override

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/WriteStreamAdapter.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/WriteStreamAdapter.java
@@ -12,6 +12,7 @@ package io.vertx.grpc.common.impl;
 
 import io.vertx.grpc.common.GrpcWriteStream;
 import io.vertx.grpc.common.GrpcMessageEncoder;
+import io.vertx.grpc.common.WireFormat;
 
 /**
  * An adapter between gRPC and Vert.x back-pressure.
@@ -44,7 +45,7 @@ public class WriteStreamAdapter<T> {
   }
 
   public final void write(T msg) {
-    stream.writeMessage(encoder.encode(msg));
+    stream.writeMessage(encoder.encode(msg, WireFormat.PROTOBUF));
     synchronized (this) {
       ready = !stream.writeQueueFull();
     }

--- a/vertx-grpc-common/src/test/java/io/vertx/tests/common/grpc/TestConstants.java
+++ b/vertx-grpc-common/src/test/java/io/vertx/tests/common/grpc/TestConstants.java
@@ -21,11 +21,11 @@ public final class TestConstants {
 
   public static final ServiceName TEST_SERVICE = ServiceName.create("io.vertx.tests.common.grpc.tests.TestService");
   public static final GrpcMessageEncoder<Empty> EMPTY_ENC = encoder();
-  public static final GrpcMessageDecoder<Empty> EMPTY_DEC = decoder(Empty.parser());
+  public static final GrpcMessageDecoder<Empty> EMPTY_DEC = decoder(Empty.newBuilder());
   public static final GrpcMessageEncoder<Request> REQUEST_ENC = encoder();
-  public static final GrpcMessageDecoder<Request> REQUEST_DEC = decoder(Request.parser());
+  public static final GrpcMessageDecoder<Request> REQUEST_DEC = decoder(Request.newBuilder());
   public static final GrpcMessageEncoder<Reply> REPLY_ENC = encoder();
-  public static final GrpcMessageDecoder<Reply> REPLY_DEC = decoder(Reply.parser());
+  public static final GrpcMessageDecoder<Reply> REPLY_DEC = decoder(Reply.newBuilder());
 
   private TestConstants() {
   }

--- a/vertx-grpc-docs/src/main/java/examples/GrpcClientExamples.java
+++ b/vertx-grpc-docs/src/main/java/examples/GrpcClientExamples.java
@@ -176,7 +176,8 @@ public class GrpcClientExamples {
 
   public void jsonWireFormat01(GrpcClient client, SocketAddress server) {
     client
-      .request(server, GreeterGrpcClient.Json.SayHello).compose(request -> {
+      .request(server, GreeterGrpcClient.SayHello).compose(request -> {
+        request.format(WireFormat.JSON);
         request.end(HelloRequest
           .newBuilder()
           .setName("Bob")

--- a/vertx-grpc-docs/src/main/java/examples/GrpcServerExamples.java
+++ b/vertx-grpc-docs/src/main/java/examples/GrpcServerExamples.java
@@ -136,7 +136,7 @@ public class GrpcServerExamples {
   }
 
   public void jsonWireFormat01(GrpcServer server) {
-    server.callHandler(GreeterGrpcService.Json.SayHello, request -> {
+    server.callHandler(GreeterGrpcService.SayHello, request -> {
       request.last().onSuccess(helloRequest -> {
         request.response().end(HelloReply.newBuilder()
           .setMessage("Hello " + helloRequest.getName()).build()

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
@@ -27,23 +27,7 @@ public interface GreeterGrpcClient extends GreeterClient {
     ServiceName.create("examples.grpc", "Greeter"),
     "SayHello",
     GrpcMessageEncoder.encoder(),
-    GrpcMessageDecoder.decoder(examples.grpc.HelloReply.parser()));
-
-  /**
-   * Json client service methods.
-   */
-  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
-  final class Json {
-
-    /**
-     * SayHello json RPC client service method.
-     */
-    public static final ServiceMethod<examples.grpc.HelloReply, examples.grpc.HelloRequest> SayHello = ServiceMethod.client(
-      ServiceName.create("examples.grpc", "Greeter"),
-      "SayHello",
-      GrpcMessageEncoder.json(),
-      GrpcMessageDecoder.json(() -> examples.grpc.HelloReply.newBuilder()));
-  }
+    GrpcMessageDecoder.decoder(examples.grpc.HelloReply.newBuilder()));
 
   /**
    * Create and return a Greeter gRPC service client. The assumed wire format is Protobuf.
@@ -89,18 +73,8 @@ class GreeterGrpcClientImpl implements GreeterGrpcClient {
   }
 
   public Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request) {
-    ServiceMethod<examples.grpc.HelloReply, examples.grpc.HelloRequest> serviceMethod;
-    switch (wireFormat) {
-      case PROTOBUF:
-        serviceMethod = SayHello;
-        break;
-      case JSON:
-        serviceMethod = Json.SayHello;
-        break;
-      default:
-        throw new AssertionError();
-    }
-    return client.request(socketAddress, serviceMethod).compose(req -> {
+    return client.request(socketAddress, SayHello).compose(req -> {
+      req.format(wireFormat);
       req.end(request);
       return req.response().compose(resp -> resp.last());
     });

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/JsonWireFormatTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/JsonWireFormatTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.grpc.examples.helloworld.GreeterGrpcService.SayHello;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -36,7 +38,7 @@ public class JsonWireFormatTest extends ProxyTestBase {
 
     GrpcClient client = GrpcClient.client(vertx);
 
-    Future<HttpServer> server = vertx.createHttpServer().requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.Json.SayHello, call -> {
+    Future<HttpServer> server = vertx.createHttpServer().requestHandler(GrpcServer.server(vertx).callHandler(SayHello, call -> {
       call.handler(helloRequest -> {
         HelloReply helloReply = HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName()).build();
         call.response().end(helloReply);
@@ -45,8 +47,9 @@ public class JsonWireFormatTest extends ProxyTestBase {
 
     Async test = should.async();
     server.onComplete(should.asyncAssertSuccess(v -> {
-      client.request(SocketAddress.inetSocketAddress(8080, "localhost"), GreeterGrpcClient.Json.SayHello)
+      client.request(SocketAddress.inetSocketAddress(8080, "localhost"), GreeterGrpcClient.SayHello)
         .onComplete(should.asyncAssertSuccess(callRequest -> {
+          callRequest.format(WireFormat.JSON);
           callRequest.response().onComplete(should.asyncAssertSuccess(callResponse -> {
             AtomicInteger count = new AtomicInteger();
             callResponse.handler(reply -> {
@@ -79,7 +82,7 @@ public class JsonWireFormatTest extends ProxyTestBase {
 
     GrpcServer grpcServer = GrpcServer.server(vertx);
 
-    grpcServer.addService(GreeterGrpcService.Json.of(greeter));
+    grpcServer.addService(GreeterGrpcService.of(greeter));
 
     Future<HttpServer> server = vertx
       .createHttpServer()

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
@@ -30,26 +30,8 @@ public interface {{className}} extends {{serviceName}}Client {
     ServiceName.create("{{packageName}}", "{{serviceName}}"),
     "{{methodName}}",
     GrpcMessageEncoder.encoder(),
-    GrpcMessageDecoder.decoder({{outputType}}.parser()));
+    GrpcMessageDecoder.decoder({{outputType}}.newBuilder()));
 {{/allMethods}}
-
-  /**
-   * Json client service methods.
-   */
-  @io.vertx.codegen.annotations.GenIgnore(io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE)
-  final class Json {
-{{#allMethods}}
-
-    /**
-     * {{methodName}} json RPC client service method.
-     */
-    public static final ServiceMethod<{{outputType}}, {{inputType}}> {{methodName}} = ServiceMethod.client(
-      ServiceName.create("{{packageName}}", "{{serviceName}}"),
-      "{{methodName}}",
-      GrpcMessageEncoder.json(),
-      GrpcMessageDecoder.json(() -> {{outputType}}.newBuilder()));
-{{/allMethods}}
-  }
 
   /**
    * Create and return a {{serviceName}} gRPC service client. The assumed wire format is Protobuf.
@@ -96,18 +78,8 @@ class {{className}}Impl implements {{className}} {
 {{#unaryUnaryMethods}}
 
   public Future<{{outputType}}> {{vertxMethodName}}({{inputType}} request) {
-    ServiceMethod<{{outputType}}, {{inputType}}> serviceMethod;
-    switch (wireFormat) {
-      case PROTOBUF:
-        serviceMethod = {{methodName}};
-        break;
-      case JSON:
-        serviceMethod = Json.{{methodName}};
-        break;
-      default:
-        throw new AssertionError();
-    }
-    return client.request(socketAddress, serviceMethod).compose(req -> {
+    return client.request(socketAddress, {{methodName}}).compose(req -> {
+      req.format(wireFormat);
       req.end(request);
       return req.response().compose(resp -> resp.last());
     });
@@ -116,18 +88,8 @@ class {{className}}Impl implements {{className}} {
 {{#unaryManyMethods}}
 
   public Future<ReadStream<{{outputType}}>> {{vertxMethodName}}({{inputType}} request) {
-    ServiceMethod<{{outputType}}, {{inputType}}> serviceMethod;
-    switch (wireFormat) {
-      case PROTOBUF:
-        serviceMethod = {{methodName}};
-        break;
-      case JSON:
-        serviceMethod = Json.{{methodName}};
-        break;
-      default:
-        throw new AssertionError();
-    }
-    return client.request(socketAddress, serviceMethod).compose(req -> {
+    return client.request(socketAddress, {{methodName}}).compose(req -> {
+      req.format(wireFormat);
       req.end(request);
       return req.response().flatMap(resp -> {
         if (resp.status() != null && resp.status() != GrpcStatus.OK) {
@@ -142,41 +104,29 @@ class {{className}}Impl implements {{className}} {
 {{#manyUnaryMethods}}
 
   public Future<{{outputType}}> {{vertxMethodName}}(Completable<WriteStream<{{inputType}}>> completable) {
-    ServiceMethod<{{outputType}}, {{inputType}}> serviceMethod;
-    switch (wireFormat) {
-      case PROTOBUF:
-        serviceMethod = {{methodName}};
-        break;
-      case JSON:
-        serviceMethod = Json.{{methodName}};
-        break;
-      default:
-        throw new AssertionError();
-    }
-    return client.request(socketAddress, serviceMethod)
-      .andThen(completable)
+    return client.request(socketAddress, {{methodName}})
+      .andThen((res, err) -> {
+        if (err == null) {
+          res.format(wireFormat);
+        }
+        completable.complete(res, err);
+      })
       .compose(request -> {
-      return request.response().compose(response -> response.last());
-    });
+        return request.response().compose(response -> response.last());
+      });
   }
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
 
   public Future<ReadStream<{{outputType}}>> {{vertxMethodName}}(Completable<WriteStream<{{inputType}}>> completable) {
-    ServiceMethod<{{outputType}}, {{inputType}}> serviceMethod;
-    switch (wireFormat) {
-      case PROTOBUF:
-        serviceMethod = {{methodName}};
-        break;
-      case JSON:
-        serviceMethod = Json.{{methodName}};
-        break;
-      default:
-        throw new AssertionError();
-    }
-    return client.request(socketAddress, serviceMethod)
-      .andThen(completable)
-      .compose(req -> {
+    return client.request(socketAddress, {{methodName}})
+       .andThen((res, err) -> {
+        if (err == null) {
+          res.format(wireFormat);
+        }
+        completable.complete(res, err);
+      })
+     .compose(req -> {
         return req.response().flatMap(resp -> {
           if (resp.status() != null && resp.status() != GrpcStatus.OK) {
             return Future.failedFuture(new io.vertx.grpc.client.InvalidStatusException(GrpcStatus.OK, resp.status()));

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
@@ -69,7 +69,7 @@ public class {{className}} extends {{serviceName}}Service implements Service {
     SERVICE_NAME,
     "{{methodName}}",
     GrpcMessageEncoder.encoder(),
-    GrpcMessageDecoder.decoder({{inputType}}.parser()));
+    GrpcMessageDecoder.decoder({{inputType}}.newBuilder()));
 {{/allMethods}}
 
   /**
@@ -81,40 +81,6 @@ public class {{className}} extends {{serviceName}}Service implements Service {
     all.add({{methodName}});
 {{/allMethods}}
     return all;
-  }
-
-  /**
-   * Json server service methods.
-   */
-  public static final class Json {
-
-    /**
-     * @return a service binding all methods of the given {@code service} using json wire format
-     */
-    public static Service of({{serviceName}}Service service) {
-      return builder(service).bind(all()).build();
-    }
-{{#allMethods}}
-    /**
-     * {{methodName}} json RPC server service method.
-     */
-    public static final ServiceMethod<{{inputType}}, {{outputType}}> {{methodName}} = ServiceMethod.server(
-      SERVICE_NAME,
-      "{{methodName}}",
-      GrpcMessageEncoder.json(),
-      GrpcMessageDecoder.json(() -> {{inputType}}.newBuilder()));
-{{/allMethods}}
-
-    /**
-     * @return a mutable list of the known json RPC server service methods.
-     */
-    public static java.util.List<ServiceMethod<?, ?>> all() {
-      java.util.List<ServiceMethod<?, ?>> all = new java.util.ArrayList<>();
-{{#allMethods}}
-      all.add({{methodName}});
-{{/allMethods}}
-      return all;
-    }
   }
 
   /**
@@ -260,7 +226,7 @@ public class {{className}} extends {{serviceName}}Service implements Service {
 
       private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
 {{#methods}}
-        if ({{methodName}} == serviceMethod || Json.{{methodName}} == serviceMethod) {
+        if ({{methodName}} == serviceMethod) {
           Handler<io.vertx.grpc.server.GrpcServerRequest<{{inputType}}, {{outputType}}>> handler = this::handle_{{vertxMethodName}};
           Handler<?> handler2 = handler;
           return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;

--- a/vertx-grpc-reflection/src/main/java/io/vertx/grpc/reflection/GrpcServerReflectionV1Handler.java
+++ b/vertx-grpc-reflection/src/main/java/io/vertx/grpc/reflection/GrpcServerReflectionV1Handler.java
@@ -31,7 +31,7 @@ class GrpcServerReflectionV1Handler implements Handler<GrpcServerRequest<ServerR
     ServiceName.create("grpc.reflection.v1.ServerReflection"),
     "ServerReflectionInfo",
     GrpcMessageEncoder.encoder(),
-    GrpcMessageDecoder.decoder(ServerReflectionRequest.parser()));
+    GrpcMessageDecoder.decoder(ServerReflectionRequest.newBuilder()));
 
   private final GrpcServer server;
 

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
@@ -30,6 +30,7 @@ import io.vertx.tests.common.grpc.Empty;
 import io.vertx.tests.common.grpc.Reply;
 import io.vertx.tests.common.grpc.Request;
 import io.vertx.tests.common.grpc.TestServiceGrpc;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
@@ -31,6 +31,7 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.common.impl.GrpcMessageImpl;
 import io.vertx.tests.common.grpc.*;
 import org.junit.Test;
@@ -355,7 +356,7 @@ public abstract class ServerTest extends ServerTestBase {
           should.assertEquals(String.valueOf(GrpcStatus.DEADLINE_EXCEEDED.code), status);
           async.complete();
         }));
-        GrpcMessage msg = TestConstants.REQUEST_ENC.encode(Request.newBuilder().setName("test").build());
+        GrpcMessage msg = TestConstants.REQUEST_ENC.encode(Request.newBuilder().setName("test").build(), WireFormat.PROTOBUF);
         req.end(GrpcMessageImpl.encode(msg));
       }));
 

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/ServerTestBase.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/ServerTestBase.java
@@ -42,11 +42,11 @@ import static org.junit.Assert.*;
  */
 public abstract class ServerTestBase extends GrpcTestBase {
 
-  public static GrpcMessageDecoder<Empty> EMPTY_DECODER = GrpcMessageDecoder.decoder(Empty.parser());
+  public static GrpcMessageDecoder<Empty> EMPTY_DECODER = GrpcMessageDecoder.decoder(Empty.newBuilder());
   public static GrpcMessageEncoder<Empty> EMPTY_ENCODER = GrpcMessageEncoder.encoder();
-  public static GrpcMessageDecoder<EchoRequest> ECHO_REQUEST_DECODER = GrpcMessageDecoder.decoder(EchoRequest.parser());
+  public static GrpcMessageDecoder<EchoRequest> ECHO_REQUEST_DECODER = GrpcMessageDecoder.decoder(EchoRequest.newBuilder());
   public static GrpcMessageEncoder<EchoResponse> ECHO_RESPONSE_ENCODER = GrpcMessageEncoder.encoder();
-  public static GrpcMessageDecoder<StreamingRequest> STREAMING_REQUEST_DECODER = GrpcMessageDecoder.decoder(StreamingRequest.parser());
+  public static GrpcMessageDecoder<StreamingRequest> STREAMING_REQUEST_DECODER = GrpcMessageDecoder.decoder(StreamingRequest.newBuilder());
   public static GrpcMessageEncoder<StreamingResponse> STREAMING_RESPONSE_ENCODER = GrpcMessageEncoder.encoder();
 
   public static final ServiceName TEST_SERVICE_NAME = ServiceName.create("io.vertx.grpcweb.TestService");

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/interop/InteropServer.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/interop/InteropServer.java
@@ -34,11 +34,11 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  */
 public class InteropServer extends AbstractVerticle {
 
-  public static GrpcMessageDecoder<Empty> EMPTY_DECODER = GrpcMessageDecoder.decoder(Empty.parser());
+  public static GrpcMessageDecoder<Empty> EMPTY_DECODER = GrpcMessageDecoder.decoder(Empty.newBuilder());
   public static GrpcMessageEncoder<Empty> EMPTY_ENCODER = GrpcMessageEncoder.encoder();
-  public static GrpcMessageDecoder<SimpleRequest> ECHO_REQUEST_DECODER = GrpcMessageDecoder.decoder(SimpleRequest.parser());
+  public static GrpcMessageDecoder<SimpleRequest> ECHO_REQUEST_DECODER = GrpcMessageDecoder.decoder(SimpleRequest.newBuilder());
   public static GrpcMessageEncoder<SimpleResponse> ECHO_RESPONSE_ENCODER = GrpcMessageEncoder.encoder();
-  public static GrpcMessageDecoder<StreamingOutputCallRequest> STREAMING_REQUEST_DECODER = GrpcMessageDecoder.decoder(StreamingOutputCallRequest.parser());
+  public static GrpcMessageDecoder<StreamingOutputCallRequest> STREAMING_REQUEST_DECODER = GrpcMessageDecoder.decoder(StreamingOutputCallRequest.newBuilder());
   public static GrpcMessageEncoder<StreamingOutputCallResponse> STREAMING_RESPONSE_ENCODER = GrpcMessageEncoder.encoder();
 
   public static final ServiceName TEST_SERVICE_NAME = ServiceName.create("grpc.testing.TestService");

--- a/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingGrpcServerRequest.java
+++ b/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingGrpcServerRequest.java
@@ -43,8 +43,8 @@ public class TranscodingGrpcServerRequest<Req, Resp> extends GrpcServerRequestIm
         return messageDecoder.decode(GrpcMessage.message("identity", WireFormat.JSON, transcoded));
       }
       @Override
-      public WireFormat format() {
-        return messageDecoder.format();
+      public boolean accepts(WireFormat format) {
+        return messageDecoder.accepts(format);
       }
     }, methodCall);
 

--- a/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/BridgeMessageDecoder.java
+++ b/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/BridgeMessageDecoder.java
@@ -49,6 +49,7 @@ public class BridgeMessageDecoder<T> implements GrpcMessageDecoder<T> {
 
   @Override
   public T decode(GrpcMessage msg) {
+    assert msg.format() == WireFormat.PROTOBUF;
     try (KnownLengthStream kls = new KnownLengthStream(msg.payload())) {
       if (msg.encoding().equals("identity")) {
         return marshaller.parse(kls);
@@ -63,7 +64,7 @@ public class BridgeMessageDecoder<T> implements GrpcMessageDecoder<T> {
   }
 
   @Override
-  public WireFormat format() {
-    return WireFormat.PROTOBUF;
+  public boolean accepts(WireFormat format) {
+    return format == WireFormat.PROTOBUF;
   }
 }

--- a/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/BridgeMessageEncoder.java
+++ b/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/BridgeMessageEncoder.java
@@ -14,6 +14,7 @@ import io.grpc.Compressor;
 import io.grpc.Drainable;
 import io.grpc.MethodDescriptor;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.grpc.common.CodecException;
 import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.GrpcMessageEncoder;
@@ -34,12 +35,13 @@ public class BridgeMessageEncoder<T> implements GrpcMessageEncoder<T> {
   }
 
   @Override
-  public WireFormat format() {
-    return WireFormat.PROTOBUF;
+  public boolean accepts(WireFormat format) {
+    return format == WireFormat.PROTOBUF;
   }
 
   @Override
-  public GrpcMessage encode(T msg) {
+  public GrpcMessage encode(T msg, WireFormat format) throws CodecException {
+    assert format == WireFormat.PROTOBUF;
     return new GrpcMessage() {
       private Buffer encoded;
       @Override


### PR DESCRIPTION
Motivation:

The initial design of message codec assumed a single wire format that is protobuf.

We can reasonnably let codec supports multiple wireformats in order to simplify deployment of call handlers and the generated code.

Changes:

Message codec are now capable of handling the two wire formats.

Code generator and client/server changes have been implemented to support this.
