### PR TITLE
Update CI workflow to install grpcurl and adjust test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,14 @@ jobs:
         with:
           java-version: ${{ inputs.jdk }}
           distribution: temurin
+      - name: Install grpcurl (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          curl -L https://github.com/fullstorydev/grpcurl/releases/download/v1.9.3/grpcurl_1.9.3_linux_x86_64.tar.gz | tar -xz
+          sudo mv grpcurl /usr/local/bin/
       - name: Run tests
+        if: runner.os != 'Linux'
         run: mvn -s .github/maven-ci-settings.xml -q clean verify -B
+      - name: Run tests with grpcurl profile (Linux only)
+        if: runner.os == 'Linux'
+        run: mvn -s .github/maven-ci-settings.xml -q clean verify -B -Pgrpcurl


### PR DESCRIPTION
Motivation:

Added grpcurl installation for Linux runners and updated test execution to use a grpcurl-specific Maven profile on Linux. Non-Linux runners continue running standard Maven tests without changes.