### PR TITLE
Introduced `GrpcHeaderNames`

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.grpc.client.impl;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Timer;
@@ -62,7 +63,7 @@ public class GrpcClientRequestImpl<Req, Resp> extends GrpcWriteStreamBase<GrpcCl
       .response()
       .compose(httpResponse -> {
         String msg = null;
-        String statusHeader = httpResponse.getHeader("grpc-status");
+        String statusHeader = httpResponse.getHeader(GrpcHeaderNames.GRPC_STATUS);
         GrpcStatus status = statusHeader != null ? GrpcStatus.valueOf(Integer.parseInt(statusHeader)) : null;
         WireFormat format = null;
         if (status == null) {
@@ -174,15 +175,15 @@ public class GrpcClientRequestImpl<Req, Resp> extends GrpcWriteStreamBase<GrpcCl
       }
     }
     if (timeout > 0L) {
-      httpRequest.putHeader("grpc-timeout", timeoutHeader);
+      httpRequest.putHeader(GrpcHeaderNames.GRPC_TIMEOUT, timeoutHeader);
     }
     String uri = serviceName.pathOf(methodName);
     httpRequest.putHeader(HttpHeaders.CONTENT_TYPE, contentType);
     if (encoding != null) {
-      httpRequest.putHeader("grpc-encoding", encoding);
+      httpRequest.putHeader(GrpcHeaderNames.GRPC_ENCODING, encoding);
     }
-    httpRequest.putHeader("grpc-accept-encoding", "gzip");
-    httpRequest.putHeader("te", "trailers");
+    httpRequest.putHeader(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, "gzip");
+    httpRequest.putHeader(HttpHeaderNames.TE, "trailers");
     httpRequest.setChunked(true);
     httpRequest.setURI(uri);
     if (scheduleDeadline && timeout > 0L) {

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
@@ -88,7 +88,7 @@ public class GrpcClientResponseImpl<Req, Resp> extends GrpcReadStreamBase<GrpcCl
   @Override
   public String statusMessage() {
     if (status != null && status != GrpcStatus.OK) {
-      String msg = httpResponse.getHeader("grpc-message");
+      String msg = httpResponse.getHeader(GrpcHeaderNames.GRPC_MESSAGE);
       if (msg != null) {
         statusMessage = QueryStringDecoder.decodeComponent(msg, StandardCharsets.UTF_8);
       }

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
@@ -45,9 +45,9 @@ public class GrpcClientResponseImpl<Req, Resp> extends GrpcReadStreamBase<GrpcCl
     super(
       context,
       httpResponse,
-      httpResponse.headers().get("grpc-encoding"),
+      httpResponse.headers().get(GrpcHeaderNames.GRPC_ENCODING),
       format,
-      new Http2GrpcMessageDeframer(maxMessageSize, httpResponse.headers().get("grpc-encoding"), format),
+      new Http2GrpcMessageDeframer(maxMessageSize, httpResponse.headers().get(GrpcHeaderNames.GRPC_ENCODING), format),
       messageDecoder);
     this.request = request;
     this.httpResponse = httpResponse;

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientMessageEncodingTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientMessageEncodingTest.java
@@ -22,6 +22,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.client.GrpcClient;
 import io.vertx.grpc.client.GrpcClientResponse;
 import io.vertx.grpc.common.GrpcError;
+import io.vertx.grpc.common.GrpcHeaderNames;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.tests.common.grpc.TestServiceGrpc;
@@ -72,7 +73,7 @@ public class ClientMessageEncodingTest extends ClientTestBase {
         }
         should.assertEquals(expected, payload);
         req.response()
-          .putHeader("grpc-status", "" + GrpcStatus.CANCELLED.code)
+          .putHeader(GrpcHeaderNames.GRPC_STATUS, "" + GrpcStatus.CANCELLED.code)
           .end();
       });
     }).listen(8080, "localhost")
@@ -167,9 +168,9 @@ public class ClientMessageEncodingTest extends ClientTestBase {
     vertx.createHttpServer().requestHandler(req -> {
         req.endHandler(v -> {
           HttpServerResponse resp = req.response();
-          resp.putHeader("grpc-encoding", "gzip");
+          resp.putHeader(GrpcHeaderNames.GRPC_ENCODING, "gzip");
           resp.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
-          resp.putTrailer("grpc-status", "" + GrpcStatus.OK.code);
+          resp.putTrailer(GrpcHeaderNames.GRPC_STATUS, "" + GrpcStatus.OK.code);
           resp.write(Buffer.buffer()
             .appendByte((byte)1)
             .appendInt(payload.length())

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
@@ -418,7 +418,7 @@ public class ClientRequestTest extends ClientTest {
     Async test = should.async();
     vertx.createHttpServer().requestHandler(req -> {
       req.response()
-        .putHeader("grpc-status", "" + GrpcStatus.OK.code)
+        .putHeader(GrpcHeaderNames.GRPC_STATUS, "" + GrpcStatus.OK.code)
         .end();
       req.exceptionHandler(err -> {
         if (err instanceof StreamResetException) {

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientTest.java
@@ -22,6 +22,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.common.GrpcHeaderNames;
 import io.vertx.tests.common.grpc.Empty;
 import io.vertx.tests.common.grpc.Reply;
 import io.vertx.tests.common.grpc.Request;
@@ -392,7 +393,7 @@ public abstract class ClientTest extends ClientTestBase {
     HttpServer server = vertx.createHttpServer();
     server
       .requestHandler(request -> {
-        String timeout = request.getHeader("grpc-timeout");
+        String timeout = request.getHeader(GrpcHeaderNames.GRPC_TIMEOUT);
         should.assertNotNull(timeout);
         request.response().exceptionHandler(err -> {
           should.assertEquals(StreamResetException.class, err.getClass());
@@ -436,7 +437,7 @@ public abstract class ClientTest extends ClientTestBase {
         Buffer json = helloReply.toBuffer();
         req.response()
           .putHeader(HttpHeaders.CONTENT_TYPE, expectedContentType)
-          .putTrailer("grpc-status", "0")
+          .putTrailer(GrpcHeaderNames.GRPC_STATUS, "0")
           .end(Buffer
             .buffer()
             .appendByte((byte)0)

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcHeaderNames.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcHeaderNames.java
@@ -39,4 +39,16 @@ public final class GrpcHeaderNames {
    * Values are defined in the gRPC protocol specification.
    */
   public static final AsciiString GRPC_STATUS = AsciiString.cached("grpc-status");
+
+  /**
+   * Header containing the error message when a request fails.
+   * The message is percent-encoded.
+   */
+  public static final AsciiString GRPC_MESSAGE = AsciiString.cached("grpc-message");
+
+  /**
+   * Header containing additional error details when a request fails.
+   * The value is base64 encoded.
+   */
+  public static final AsciiString GRPC_STATUS_DETAILS_BIN = AsciiString.cached("grpc-status-details-bin");
 }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcHeaderNames.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcHeaderNames.java
@@ -1,0 +1,42 @@
+package io.vertx.grpc.common;
+
+import io.netty.util.AsciiString;
+
+/**
+ * Header names used by gRPC.
+ *
+ * @see <a href="https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests">gRPC HTTP/2 requests</a>
+ */
+public final class GrpcHeaderNames {
+
+  /**
+   * Header for specifying the timeout for a gRPC call.
+   * Format is an integer followed by a time unit: 'S', 'M', 'H' (seconds, minutes, hours).
+   * Example: "10S" for a 10-second timeout.
+   */
+  public static final AsciiString GRPC_TIMEOUT = AsciiString.cached("grpc-timeout");
+
+  /**
+   * Header indicating the compression algorithm used for the message payload.
+   * Common values include "gzip", "snappy", and "identity" (no compression).
+   */
+  public static final AsciiString GRPC_ENCODING = AsciiString.cached("grpc-encoding");
+
+  /**
+   * Header specifying which compression algorithms the client or server supports.
+   * Multiple algorithms can be specified as a comma-separated list.
+   */
+  public static final AsciiString GRPC_ACCEPT_ENCODING = AsciiString.cached("grpc-accept-encoding");
+
+  /**
+   * Header specifying the type of the message being transmitted.
+   */
+  public static final AsciiString GRPC_MESSAGE_TYPE = AsciiString.cached("grpc-message-type");
+
+  /**
+   * Header containing the status code of a gRPC response.
+   * This is used to communicate error conditions from the server to the client.
+   * Values are defined in the gRPC protocol specification.
+   */
+  public static final AsciiString GRPC_STATUS = AsciiString.cached("grpc-status");
+}

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
@@ -75,8 +75,8 @@ public abstract class GrpcServerRequestImpl<Req, Resp> extends GrpcReadStreamBas
                                GrpcMessageDeframer messageDeframer,
                                GrpcMessageDecoder<Req> messageDecoder,
                                GrpcMethodCall methodCall) {
-    super(context, httpRequest, httpRequest.headers().get("grpc-encoding"), format, messageDeframer, messageDecoder);
-    String timeoutHeader = httpRequest.getHeader("grpc-timeout");
+    super(context, httpRequest, httpRequest.headers().get(GrpcHeaderNames.GRPC_ENCODING), format, messageDeframer, messageDecoder);
+    String timeoutHeader = httpRequest.getHeader(GrpcHeaderNames.GRPC_TIMEOUT);
     long timeout = timeoutHeader != null ? parseTimeout(timeoutHeader) : 0L;
 
     this.protocol = protocol;

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -16,6 +16,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.grpc.common.GrpcError;
+import io.vertx.grpc.common.GrpcHeaderNames;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.impl.GrpcMessageImpl;
@@ -131,8 +132,8 @@ public abstract class GrpcServerResponseImpl<Req, Resp> extends GrpcWriteStreamB
         httpTrailers.add(trailer.getKey(), trailer.getValue());
       }
     }
-    if (!httpHeaders.contains("grpc-status")) {
-      httpTrailers.set("grpc-status", status.toString());
+    if (!httpHeaders.contains(GrpcHeaderNames.GRPC_STATUS)) {
+      httpTrailers.set(GrpcHeaderNames.GRPC_STATUS, status.toString());
     }
     if (status != GrpcStatus.OK) {
       String msg = statusMessage;

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -137,11 +137,11 @@ public abstract class GrpcServerResponseImpl<Req, Resp> extends GrpcWriteStreamB
     }
     if (status != GrpcStatus.OK) {
       String msg = statusMessage;
-      if (msg != null && !httpHeaders.contains("grpc-message")) {
-        httpTrailers.set("grpc-message", Utils.utf8PercentEncode(msg));
+      if (msg != null && !httpHeaders.contains(GrpcHeaderNames.GRPC_MESSAGE)) {
+        httpTrailers.set(GrpcHeaderNames.GRPC_MESSAGE, Utils.utf8PercentEncode(msg));
       }
     } else {
-      httpTrailers.remove("grpc-message");
+      httpTrailers.remove(GrpcHeaderNames.GRPC_MESSAGE);
     }
   }
 

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/Http2GrpcServerRequest.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/Http2GrpcServerRequest.java
@@ -12,6 +12,7 @@ package io.vertx.grpc.server.impl;
 
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.grpc.common.GrpcHeaderNames;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
@@ -21,6 +22,6 @@ import io.vertx.grpc.server.GrpcProtocol;
 public class Http2GrpcServerRequest<Req, Resp> extends GrpcServerRequestImpl<Req, Resp> {
 
     public Http2GrpcServerRequest(ContextInternal context, GrpcProtocol protocol, WireFormat format, long maxMessageSize, HttpServerRequest httpRequest, GrpcMessageDecoder<Req> messageDecoder, GrpcMethodCall methodCall) {
-        super(context, protocol, format, httpRequest, new Http2GrpcMessageDeframer(maxMessageSize, httpRequest.headers().get("grpc-encoding"), format), messageDecoder, methodCall);
+        super(context, protocol, format, httpRequest, new Http2GrpcMessageDeframer(maxMessageSize, httpRequest.headers().get(GrpcHeaderNames.GRPC_ENCODING), format), messageDecoder, methodCall);
     }
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/Http2GrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/Http2GrpcServerResponse.java
@@ -13,6 +13,7 @@ package io.vertx.grpc.server.impl;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.grpc.common.GrpcHeaderNames;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.server.GrpcProtocol;
 
@@ -29,8 +30,8 @@ public class Http2GrpcServerResponse<Req, Resp> extends GrpcServerResponseImpl<R
   @Override
   protected void encodeGrpcHeaders(MultiMap grpcHeaders, MultiMap httpHeaders) {
     super.encodeGrpcHeaders(grpcHeaders, httpHeaders);
-    httpHeaders.set("grpc-encoding", encoding);
-    httpHeaders.set("grpc-accept-encoding", "gzip");
+    httpHeaders.set(GrpcHeaderNames.GRPC_ENCODING, encoding);
+    httpHeaders.set(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, "gzip");
   }
 
   @Override

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcServerRequest.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcServerRequest.java
@@ -16,10 +16,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
-import io.vertx.grpc.common.GrpcMediaType;
-import io.vertx.grpc.common.GrpcMessage;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.common.*;
 import io.vertx.grpc.common.impl.GrpcMessageDeframer;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
 import io.vertx.grpc.common.impl.Http2GrpcMessageDeframer;
@@ -78,6 +75,6 @@ public class WebGrpcServerRequest<Req, Resp> extends GrpcServerRequestImpl<Req, 
   }
 
   public WebGrpcServerRequest(ContextInternal context, GrpcProtocol protocol, WireFormat format, long maxMessageSize, HttpServerRequest httpRequest, GrpcMessageDecoder<Req> messageDecoder, GrpcMethodCall methodCall) {
-    super(context, protocol, format, httpRequest, httpRequest.version() != HttpVersion.HTTP_2 && GrpcMediaType.isGrpcWebText(httpRequest.getHeader(CONTENT_TYPE)) ? new TextMessageDeframer() : new Http2GrpcMessageDeframer(maxMessageSize, httpRequest.headers().get("grpc-encoding"), format), messageDecoder, methodCall);
+    super(context, protocol, format, httpRequest, httpRequest.version() != HttpVersion.HTTP_2 && GrpcMediaType.isGrpcWebText(httpRequest.getHeader(CONTENT_TYPE)) ? new TextMessageDeframer() : new Http2GrpcMessageDeframer(maxMessageSize, httpRequest.headers().get(GrpcHeaderNames.GRPC_ENCODING), format), messageDecoder, methodCall);
   }
 }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerMessageEncodingTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerMessageEncodingTest.java
@@ -27,6 +27,7 @@ import io.vertx.core.http.*;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.GrpcError;
+import io.vertx.grpc.common.GrpcHeaderNames;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerRequest;
@@ -90,7 +91,7 @@ public class ServerMessageEncodingTest extends ServerTestBase {
     client
       .request(HttpMethod.POST, 8080, "localhost", "/")
       .onComplete(should.asyncAssertSuccess(request -> {
-      request.putHeader("grpc-encoding", "identity");
+      request.putHeader(GrpcHeaderNames.GRPC_ENCODING, "identity");
       request.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
       request.send(Buffer
         .buffer()
@@ -201,7 +202,7 @@ public class ServerMessageEncodingTest extends ServerTestBase {
     );
 
     client.request(HttpMethod.POST, 8080, "localhost", "/").onComplete( should.asyncAssertSuccess(request -> {
-      request.putHeader("grpc-encoding", "gzip");
+      request.putHeader(GrpcHeaderNames.GRPC_ENCODING, "gzip");
       request.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
       request.end(Buffer
         .buffer()
@@ -220,8 +221,8 @@ public class ServerMessageEncodingTest extends ServerTestBase {
 
     vertx.createHttpServer().requestHandler(req -> {
         req.response()
-          .putHeader("content-type", "application/grpc")
-          .putHeader("grpc-encoding", "gzip")
+          .putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc")
+          .putHeader(GrpcHeaderNames.GRPC_ENCODING, "gzip")
           .write(Buffer.buffer()
             .appendByte((byte) 1)
             .appendInt(11)

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
@@ -378,7 +378,7 @@ public class ServerRequestTest extends ServerTest {
     Async async = should.async();
     client.request(HttpMethod.POST, port, "localhost", "/io.vertx.tests.common.grpc.tests.TestService/Unary")
       .onComplete(should.asyncAssertSuccess(req -> {
-        req.putHeader("grpc-timeout", TimeUnit.SECONDS.toMillis(1) + "m");
+        req.putHeader(GrpcHeaderNames.GRPC_TIMEOUT, TimeUnit.SECONDS.toMillis(1) + "m");
         req.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
         req.response().onComplete(should.asyncAssertSuccess(resp -> {
           resp.endHandler(v -> {
@@ -409,7 +409,7 @@ public class ServerRequestTest extends ServerTest {
     Async async = should.async();
     client.request(HttpMethod.POST, port, "localhost", "/helloworld.Greeter/SayHello")
       .onComplete(should.asyncAssertSuccess(req -> {
-        req.putHeader("grpc-timeout", "10S");
+        req.putHeader(GrpcHeaderNames.GRPC_TIMEOUT, "10S");
         req.response().onComplete(should.asyncAssertSuccess(resp -> {
           resp.endHandler(v -> {
             async.complete();
@@ -528,7 +528,7 @@ public class ServerRequestTest extends ServerTest {
 
     client.request(HttpMethod.POST, 8080, "localhost", "/" + TestServiceGrpc.SERVICE_NAME + "/Sink")
       .onComplete(should.asyncAssertSuccess(request -> {
-        request.putHeader("grpc-encoding", "gzip");
+        request.putHeader(GrpcHeaderNames.GRPC_ENCODING, "gzip");
         request.setChunked(true);
         messages.forEach(msg -> {
           Buffer buffer = Buffer.buffer();

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
@@ -29,6 +29,7 @@ import io.vertx.core.http.*;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.common.GrpcHeaderNames;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.WireFormat;
@@ -349,10 +350,10 @@ public abstract class ServerTest extends ServerTestBase {
     Async async = should.async();
     client.request(HttpMethod.POST, port, "localhost", "/io.vertx.tests.common.grpc.tests.TestService/Unary")
       .onComplete(should.asyncAssertSuccess(req -> {
-        req.putHeader("grpc-timeout", TimeUnit.SECONDS.toMillis(1) + "m");
+        req.putHeader(GrpcHeaderNames.GRPC_TIMEOUT, TimeUnit.SECONDS.toMillis(1) + "m");
         req.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
         req.response().onComplete(should.asyncAssertSuccess(resp -> {
-          String status = resp.getHeader("grpc-status");
+          String status = resp.getHeader(GrpcHeaderNames.GRPC_STATUS);
           should.assertEquals(String.valueOf(GrpcStatus.DEADLINE_EXCEEDED.code), status);
           async.complete();
         }));

--- a/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
+++ b/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
@@ -24,6 +24,7 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.common.GrpcHeaderNames;
 import io.vertx.grpcio.client.GrpcIoClient;
 import io.vertx.grpcio.client.GrpcIoClientChannel;
 import io.vertx.grpcio.common.impl.Utils;
@@ -503,7 +504,7 @@ public class ClientBridgeTest extends ClientTest {
   public void testGrpcResponseInvalidHttpCode(TestContext should) {
     testGrpcResponseHttpError(should, req -> {
       req.endHandler(v -> {
-        req.response().putHeader("grpc-status", "0").setStatusCode(500).end();
+        req.response().putHeader(GrpcHeaderNames.GRPC_STATUS, "0").setStatusCode(500).end();
       });
     }, Status.Code.INTERNAL);
   }
@@ -512,7 +513,7 @@ public class ClientBridgeTest extends ClientTest {
   public void testGrpcResponseInvalidHttpCode__(TestContext should) {
     testGrpcResponseHttpError(should, req -> {
       req.endHandler(v -> {
-        req.response().putHeader("grpc-status", "0").setStatusCode(500).end();
+        req.response().putHeader(GrpcHeaderNames.GRPC_STATUS, "0").setStatusCode(500).end();
       });
     }, Status.Code.INTERNAL);
   }


### PR DESCRIPTION
Motivation:

Introduced `GrpcHeaderNames` to standardize gRPC header names across the codebase, replacing strings.

Conformance: