### PR TITLE
Improve transcoding integration.

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcWriteStreamBase.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcWriteStreamBase.java
@@ -188,6 +188,21 @@ public abstract class GrpcWriteStreamBase<S extends GrpcWriteStreamBase<S, T>, T
   protected abstract Future<Void> sendMessage(Buffer message, boolean compressed);
   protected abstract Future<Void> sendEnd();
 
+  protected String contentType(WireFormat wireFormat) {
+    if (wireFormat != null) {
+      switch (wireFormat) {
+        case JSON:
+          if (!mediaType.endsWith("/json")) {
+            return mediaType + "+json";
+          }
+        case PROTOBUF:
+          // contentType = mediaType + "+proto";
+          break;
+      }
+    }
+    return mediaType;
+  }
+
   private Future<Void> writeMessage(GrpcMessage message, boolean end) {
     if (error != null) {
       throw new IllegalStateException("The stream is failed: " + error);
@@ -253,17 +268,7 @@ public abstract class GrpcWriteStreamBase<S extends GrpcWriteStreamBase<S, T>, T
     }
     if (!headersSent) {
       headersSent = true;
-      String contentType = mediaType;
-      if (format != null) {
-        switch (format) {
-          case JSON:
-            contentType = mediaType + "+json";
-            break;
-          case PROTOBUF:
-            // contentType = mediaType + "+proto";
-            break;
-        }
-      }
+      String contentType = contentType(format);
       setHeaders(contentType, headers, end);
     }
     if (end) {

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
@@ -108,8 +108,8 @@ public class GreeterGrpcService extends GreeterService implements Service {
     public static final io.vertx.grpc.transcoding.TranscodingServiceMethod<examples.grpc.HelloRequest, examples.grpc.HelloReply> SayHello = io.vertx.grpc.transcoding.TranscodingServiceMethod.server(
       SERVICE_NAME,
       "SayHello",
-      GrpcMessageEncoder.json(),
-      GrpcMessageDecoder.json(() -> examples.grpc.HelloRequest.newBuilder()),
+      GrpcMessageEncoder.encoder(),
+      GrpcMessageDecoder.decoder(examples.grpc.HelloRequest.newBuilder()),
       SayHello_OPTIONS);
 
     /**

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
@@ -127,8 +127,8 @@ public class {{className}} extends {{serviceName}}Service implements Service {
     public static final io.vertx.grpc.transcoding.TranscodingServiceMethod<{{inputType}}, {{outputType}}> {{methodName}} = io.vertx.grpc.transcoding.TranscodingServiceMethod.server(
       SERVICE_NAME,
       "{{methodName}}",
-      GrpcMessageEncoder.json(),
-      GrpcMessageDecoder.json(() -> {{inputType}}.newBuilder()),
+      GrpcMessageEncoder.encoder(),
+      GrpcMessageDecoder.decoder({{inputType}}.newBuilder()),
       {{methodName}}_OPTIONS);
 {{/transcodingMethods}}
 

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcHttpInvoker.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcHttpInvoker.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.server.impl;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.grpc.common.ServiceMethod;
+
+public interface GrpcHttpInvoker {
+
+  <Req, Resp> GrpcInvocation<Req, Resp> accept(HttpServerRequest request, ServiceMethod<Req, Resp> serviceMethod);
+
+}

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/MountPoint.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/MountPoint.java
@@ -1,9 +1,9 @@
 package io.vertx.grpc.server.impl;
 
-import io.vertx.core.http.HttpServerRequest;
+import java.util.List;
 
 public interface MountPoint<I, O> {
 
-  GrpcInvocation<I, O> accept(HttpServerRequest request);
+  List<String> paths();
 
 }

--- a/vertx-grpc-server/src/main/java/module-info.java
+++ b/vertx-grpc-server/src/main/java/module-info.java
@@ -11,6 +11,8 @@ module io.vertx.grpc.server {
   requires io.netty.buffer;
   requires com.google.protobuf;
 
+  uses io.vertx.grpc.server.impl.GrpcHttpInvoker;
+
   exports io.vertx.grpc.server;
   exports io.vertx.grpc.server.impl to io.vertx.grpc.transcoding;
 }

--- a/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingGrpcServerResponse.java
+++ b/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingGrpcServerResponse.java
@@ -18,6 +18,7 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.impl.GrpcServerRequestImpl;
 import io.vertx.grpc.server.impl.GrpcServerResponseImpl;

--- a/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingInvoker.java
+++ b/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingInvoker.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.transcoding.impl;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.server.impl.GrpcHttpInvoker;
+import io.vertx.grpc.server.impl.GrpcInvocation;
+import io.vertx.grpc.transcoding.TranscodingServiceMethod;
+
+public class TranscodingInvoker implements GrpcHttpInvoker {
+
+  @Override
+  public <Req, Resp> GrpcInvocation<Req, Resp> accept(HttpServerRequest request, ServiceMethod<Req, Resp> serviceMethod) {
+    if (serviceMethod instanceof TranscodingServiceMethod) {
+      TranscodingServiceMethodImpl<Req, Resp> transcodingServiceMethod = (TranscodingServiceMethodImpl<Req, Resp>) serviceMethod;
+      return transcodingServiceMethod.accept(request);
+    }
+    return null;
+  }
+}

--- a/vertx-grpc-transcoding/src/main/java/module-info.java
+++ b/vertx-grpc-transcoding/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import io.vertx.grpc.server.impl.GrpcHttpInvoker;
+
 module io.vertx.grpc.transcoding {
   requires com.google.protobuf;
   requires com.google.protobuf.util;
@@ -9,4 +11,5 @@ module io.vertx.grpc.transcoding {
   exports io.vertx.grpc.transcoding;
   exports io.vertx.grpc.transcoding.impl.config to io.vertx.tests.transcoding;
   exports io.vertx.grpc.transcoding.impl to io.vertx.tests.transcoding;
+  provides GrpcHttpInvoker with io.vertx.grpc.transcoding.impl.TranscodingInvoker;
 }

--- a/vertx-grpc-transcoding/src/main/resources/META-INF/services/io.vertx.grpc.server.impl.GrpcHttpInvoker
+++ b/vertx-grpc-transcoding/src/main/resources/META-INF/services/io.vertx.grpc.server.impl.GrpcHttpInvoker
@@ -1,0 +1,1 @@
+io.vertx.grpc.transcoding.impl.TranscodingInvoker


### PR DESCRIPTION
Motivation:

Transcoding server requests are currently handled with a specific mount point acceptor for specific transcoding service methods.

We can make the mountpoint handle only the grpc server router mounting and leave the transcoding invocation in a separate SPI for creating transcoding invocation.

This will allow the transcoding invoker to handle transcoded requests without the need of specific metadata and simplify the deployment of transcoded handlers.

Changes:

The mount point now provides a list of paths to mount in the server internal router. When a transcoded request comes in, the invoker provides a transcoded using the service method metadata to handle the request/response messages.

Transcoded requests also now uses the new unified message encoder/decoder so they can decode protobuf as well as json.