### PR TITLE
Replace gRPC server options gRPC-Web flag with a generic set of supported protocols.

### DIFF
--- a/vertx-grpc-docs/src/main/asciidoc/server.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/server.adoc
@@ -221,8 +221,6 @@ In addition, Vert.x gRPC server also supports https://github.com/grpc/grpc-web[g
 
 The Vert.x gRPC Server supports the gRPC-Web protocol by default.
 
-To disable the gRPC-Web protocol support, configure options with {@link io.vertx.grpc.server.GrpcServerOptions#setGrpcWebEnabled GrpcServerOptions#setGrpcWebEnabled(false)} and then create a server with {@link io.vertx.grpc.server.GrpcServer#server(io.vertx.core.Vertx, io.vertx.grpc.server.GrpcServerOptions) GrpcServer#server(vertx, options)}.
-
 If your website server and the gRPC server are different, you have to configure the gRPC server for CORS.
 This can be done with a Vert.x Web router and the CORS handler:
 
@@ -238,6 +236,18 @@ router.route("/com.mycompany.MyService/*").handler(corsHandler);
 ==== gRPC Transcoding
 
 The Vert.x gRPC server supports <<grpc-transcoding,gRPC transcoding>> that enables mapping between HTTP/JSON requests and gRPC services.
+
+==== Protocol configuration
+
+By default, a gRPC server accepts all protocols.
+
+To disable a specific protocol support, configure options with {@link io.vertx.grpc.server.GrpcServerOptions#removeEnabledProtocol} and then create a server with {@link io.vertx.grpc.server.GrpcServer#server(io.vertx.core.Vertx, io.vertx.grpc.server.GrpcServerOptions) GrpcServer#server(vertx, options)}.
+
+.Removing gRPC-Web support
+[source,java]
+----
+{@link examples.GrpcServerExamples#disablingGrpcWeb}
+----
 
 === Flow control
 

--- a/vertx-grpc-docs/src/main/java/examples/GrpcServerExamples.java
+++ b/vertx-grpc-docs/src/main/java/examples/GrpcServerExamples.java
@@ -99,6 +99,13 @@ public class GrpcServerExamples {
     });
   }
 
+  public void disablingGrpcWeb(Vertx vertx) {
+    GrpcServer server = GrpcServer.server(vertx, new GrpcServerOptions()
+      .removeEnabledProtocol(GrpcProtocol.WEB)
+      .removeEnabledProtocol(GrpcProtocol.WEB_TEXT)
+    );
+  }
+
   public void requestFlowControl(Vertx vertx, GrpcServerRequest<Item, Empty> request, Item item) {
     // Pause the response
     request.pause();

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
@@ -75,8 +75,7 @@ class GreeterGrpcClientImpl implements GreeterGrpcClient {
   public Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request) {
     return client.request(socketAddress, SayHello).compose(req -> {
       req.format(wireFormat);
-      req.end(request);
-      return req.response().compose(resp -> resp.last());
+      return req.end(request).compose(v -> req.response().compose(resp -> resp.last()));
     });
   }
 }

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
@@ -95,14 +95,13 @@ class StreamingGrpcClientImpl implements StreamingGrpcClient {
   public Future<ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request) {
     return client.request(socketAddress, Source).compose(req -> {
       req.format(wireFormat);
-      req.end(request);
-      return req.response().flatMap(resp -> {
+      return req.end(request).compose(v -> req.response().flatMap(resp -> {
         if (resp.status() != null && resp.status() != GrpcStatus.OK) {
           return Future.failedFuture(new io.vertx.grpc.client.InvalidStatusException(GrpcStatus.OK, resp.status()));
         } else {
           return Future.succeededFuture(resp);
         }
-      });
+      }));
     });
   }
 

--- a/vertx-grpc-server/src/main/generated/io/vertx/grpc/server/GrpcServerOptionsConverter.java
+++ b/vertx-grpc-server/src/main/generated/io/vertx/grpc/server/GrpcServerOptionsConverter.java
@@ -14,9 +14,12 @@ public class GrpcServerOptionsConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, GrpcServerOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "grpcWebEnabled":
-          if (member.getValue() instanceof Boolean) {
-            obj.setGrpcWebEnabled((Boolean)member.getValue());
+        case "enabledProtocols":
+          if (member.getValue() instanceof JsonArray) {
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                obj.addEnabledProtocol(io.vertx.grpc.server.GrpcProtocol.valueOf((String)item));
+            });
           }
           break;
         case "scheduleDeadlineAutomatically":
@@ -43,7 +46,11 @@ public class GrpcServerOptionsConverter {
   }
 
    static void toJson(GrpcServerOptions obj, java.util.Map<String, Object> json) {
-    json.put("grpcWebEnabled", obj.isGrpcWebEnabled());
+    if (obj.getEnabledProtocols() != null) {
+      JsonArray array = new JsonArray();
+      obj.getEnabledProtocols().forEach(item -> array.add(item.name()));
+      json.put("enabledProtocols", array);
+    }
     json.put("scheduleDeadlineAutomatically", obj.getScheduleDeadlineAutomatically());
     json.put("deadlinePropagation", obj.getDeadlinePropagation());
     json.put("maxMessageSize", obj.getMaxMessageSize());

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerOptions.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerOptions.java
@@ -15,6 +15,10 @@ import io.vertx.codegen.annotations.Unstable;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
 /**
  * Configuration for a {@link GrpcServer}.
  */
@@ -24,9 +28,9 @@ import io.vertx.core.json.JsonObject;
 public class GrpcServerOptions {
 
   /**
-   * Whether the gRPC-Web protocol should be enabled, by default = {@code true}.
+   *
    */
-  public static final boolean DEFAULT_GRPC_WEB_ENABLED = true;
+  public static final Set<GrpcProtocol> DEFAULT_ENABLED_PROTOCOLS = Collections.unmodifiableSet(EnumSet.allOf(GrpcProtocol.class));
 
   /**
    * Whether the server schedule deadline automatically when a request carrying a timeout is received, by default = {@code false}
@@ -43,7 +47,7 @@ public class GrpcServerOptions {
    */
   public static final long DEFAULT_MAX_MESSAGE_SIZE = 256 * 1024;
 
-  private boolean grpcWebEnabled;
+  private Set<GrpcProtocol> enabledProtocols;
   private boolean scheduleDeadlineAutomatically;
   private boolean deadlinePropagation;
   private long maxMessageSize;
@@ -52,7 +56,7 @@ public class GrpcServerOptions {
    * Default options.
    */
   public GrpcServerOptions() {
-    grpcWebEnabled = DEFAULT_GRPC_WEB_ENABLED;
+    enabledProtocols = EnumSet.copyOf(DEFAULT_ENABLED_PROTOCOLS);
     scheduleDeadlineAutomatically = DEFAULT_SCHEDULE_DEADLINE_AUTOMATICALLY;
     deadlinePropagation = DEFAULT_PROPAGATE_DEADLINE;
     maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
@@ -62,7 +66,7 @@ public class GrpcServerOptions {
    * Copy constructor.
    */
   public GrpcServerOptions(GrpcServerOptions other) {
-    grpcWebEnabled = other.grpcWebEnabled;
+    enabledProtocols = EnumSet.copyOf(other.enabledProtocols);
     scheduleDeadlineAutomatically = other.scheduleDeadlineAutomatically;
     deadlinePropagation = other.deadlinePropagation;
     maxMessageSize = other.maxMessageSize;
@@ -76,22 +80,22 @@ public class GrpcServerOptions {
     GrpcServerOptionsConverter.fromJson(json, this);
   }
 
-  /**
-   * @return {@code true} if the gRPC-Web protocol should be enabled, {@code false} otherwise
-   */
-  public boolean isGrpcWebEnabled() {
-    return grpcWebEnabled;
+  public boolean isProtocolEnabled(GrpcProtocol protocol) {
+    return enabledProtocols.contains(protocol);
   }
 
-  /**
-   * Whether the gRPC-Web protocol should be enabled. Defaults to {@code true}.
-   *
-   * @param grpcWebEnabled {@code true} if the gRPC-Web protocol should be enabled, {@code false} otherwise
-   * @return a reference to this, so the API can be used fluently
-   */
-  public GrpcServerOptions setGrpcWebEnabled(boolean grpcWebEnabled) {
-    this.grpcWebEnabled = grpcWebEnabled;
+  public GrpcServerOptions addEnabledProtocol(GrpcProtocol protocol) {
+    enabledProtocols.add(protocol);
     return this;
+  }
+
+  public GrpcServerOptions removeEnabledProtocol(GrpcProtocol protocol) {
+    enabledProtocols.remove(protocol);
+    return this;
+  }
+
+  public Set<GrpcProtocol> getEnabledProtocols() {
+    return enabledProtocols;
   }
 
   /**

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -153,14 +153,9 @@ public class GrpcServerImpl implements GrpcServer {
       return 415;
     }
     // Check config
-    switch (protocol) {
-      case WEB:
-      case WEB_TEXT:
-        if (!options.isGrpcWebEnabled()) {
-          log.trace("gRPC-Web is not supported on HTTP/1.1, sending error 415");
-          return 415;
-        }
-        break;
+    if (!options.isProtocolEnabled(protocol)) {
+      log.trace(protocol + " is not supported, sending error 415");
+      return 415;
     }
     return -1;
   }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ProtocolSupportTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ProtocolSupportTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.server;
+
+import io.vertx.core.http.*;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.common.GrpcHeaderNames;
+import io.vertx.grpc.server.GrpcProtocol;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.GrpcServerOptions;
+import org.junit.Test;
+
+public class ProtocolSupportTest extends ServerTestBase {
+
+  private HttpClient client;
+
+  @Test
+  public void testDisableHTTP2(TestContext should) {
+    testDisableProtocol(should, "application/grpc", GrpcProtocol.HTTP_2);
+  }
+
+  @Test
+  public void testDisableWeb(TestContext should) {
+    testDisableProtocol(should, "application/grpc-web", GrpcProtocol.WEB);
+  }
+
+  private void testDisableProtocol(TestContext should, String contentType, GrpcProtocol protocol) {
+
+    startServer(GrpcServer.server(vertx, new GrpcServerOptions().removeEnabledProtocol(protocol)));
+
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setProtocolVersion(HttpVersion.HTTP_2)
+      .setHttp2ClearTextUpgrade(true)
+    );
+
+    client
+      .request(HttpMethod.POST, 8080, "localhost", "/")
+      .compose(request -> {
+        request.putHeader(GrpcHeaderNames.GRPC_ENCODING, "identity");
+        request.putHeader(HttpHeaders.CONTENT_TYPE, contentType);
+        request.send();
+        return request.response()
+          .map(resp -> resp.statusCode());
+      }).onComplete(should.asyncAssertSuccess(status -> {
+        should.assertEquals(415, status);
+      }));
+  }
+}

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/ServerTestBase.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/ServerTestBase.java
@@ -94,7 +94,7 @@ public abstract class ServerTestBase extends GrpcTestBase {
   public void setUp(TestContext should) {
     super.setUp(should);
     httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(port));
-    GrpcServer grpcServer = GrpcServer.server(vertx, new GrpcServerOptions().setGrpcWebEnabled(true));
+    GrpcServer grpcServer = GrpcServer.server(vertx, new GrpcServerOptions());
     grpcServer.callHandler(EMPTY_CALL, request -> {
       copyHeaders(request.headers(), request.response().headers());
       copyTrailers(request.headers(), request.response().trailers());

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/interop/InteropServer.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/interop/InteropServer.java
@@ -55,7 +55,7 @@ public class InteropServer extends AbstractVerticle {
 
   @Override
   public void start(Promise<Void> startPromise) {
-    GrpcServer grpcServer = GrpcServer.server(vertx, new GrpcServerOptions().setGrpcWebEnabled(true));
+    GrpcServer grpcServer = GrpcServer.server(vertx, new GrpcServerOptions());
 
     grpcServer.callHandler(EMPTY_CALL, request -> {
       ServerTestBase.copyMetadata(request.headers(), request.response().headers(), "x-grpc-test-echo-initial");

--- a/vertx-grpc-transcoding/src/test/java/io/vertx/tests/transcoding/ServerTranscodingTest.java
+++ b/vertx-grpc-transcoding/src/test/java/io/vertx/tests/transcoding/ServerTranscodingTest.java
@@ -411,8 +411,12 @@ public class ServerTranscodingTest extends GrpcTestBase {
     ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", port)
       .usePlaintext()
       .build();
-    TestServiceGrpc.TestServiceBlockingStub client = TestServiceGrpc.newBlockingStub(channel);
-    EchoResponse response = client.unaryCall(EchoRequest.newBuilder().setPayload("hello").build());
-    assertEquals("hello", response.getPayload());
+    try {
+      TestServiceGrpc.TestServiceBlockingStub client = TestServiceGrpc.newBlockingStub(channel);
+      EchoResponse response = client.unaryCall(EchoRequest.newBuilder().setPayload("hello").build());
+      assertEquals("hello", response.getPayload());
+    } finally {
+      channel.shutdown();
+    }
   }
 }


### PR DESCRIPTION
Motivation:

The server has a flag configuring the support of gRPC-Web, it is also desirable to control other protocols as well.

Changes:

Replace the gRPC-Web boolean flag with a set of supported `GrpcProtocol`
