### PR TITLE
Proper implementation of service error mapping to status mapping.

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
@@ -179,26 +179,7 @@ public abstract class GrpcReadStreamBase<S extends GrpcReadStreamBase<S, T>, T> 
   }
 
   @Override
-  public S handler(@Nullable Handler<T> handler) {
-    if (handler != null) {
-      return messageHandler(msg -> {
-        T decoded;
-        try {
-          decoded = decodeMessage(msg);
-        } catch (CodecException e) {
-          Handler<InvalidMessageException> errorHandler = invalidMessageHandler;
-          if (errorHandler != null) {
-            InvalidMessagePayloadException impe = new InvalidMessagePayloadException(msg, e);
-            errorHandler.handle(impe);
-          }
-          return;
-        }
-        handler.handle(decoded);
-      });
-    } else {
-      return messageHandler(null);
-    }
-  }
+  public abstract S handler(@Nullable Handler<T> handler);
 
   @Override
   public final S endHandler(Handler<Void> endHandler) {

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcIo.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcIo.java
@@ -110,7 +110,7 @@ public final class GreeterGrpcIo {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_SAY_HELLO:
-          io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.HelloRequest, examples.grpc.HelloReply>oneToOne(
+          io.vertx.grpcio.server.impl.stub.ServerCalls.<examples.grpc.HelloRequest, examples.grpc.HelloReply>oneToOne(
             (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
             (examples.grpc.HelloRequest) request,
             (io.grpc.stub.StreamObserver<examples.grpc.HelloReply>) responseObserver,

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
@@ -15,6 +15,7 @@ import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.Service;
 import io.vertx.grpc.server.ServiceBuilder;
+import io.vertx.grpc.server.StatusException;
 
 import com.google.protobuf.Descriptors;
 
@@ -185,19 +186,13 @@ public class GreeterGrpcService extends GreeterService implements Service {
 
   private void handle_sayHello(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.HelloRequest, examples.grpc.HelloReply> request) {
     request.handler(msg -> {
-      try {
-        instance.sayHello(msg, (res, err) -> {
-          if (err == null) {
-            request.response().end(res);
-          } else {
-            request.response().status(GrpcStatus.UNKNOWN).end();
-          }
-        });
-      } catch (UnsupportedOperationException err) {
-        request.response().status(GrpcStatus.UNIMPLEMENTED).end();
-      } catch (RuntimeException err) {
-        request.response().status(GrpcStatus.UNKNOWN).end();
-      }
+      instance.sayHello(msg, (res, err) -> {
+        if (err == null) {
+          request.response().end(res);
+        } else {
+          request.response().status(StatusException.mapStatus(err)).end();
+        }
+      });
     });
   }
     }

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
@@ -190,7 +190,7 @@ public class GreeterGrpcService extends GreeterService implements Service {
         if (err == null) {
           request.response().end(res);
         } else {
-          request.response().status(StatusException.mapStatus(err)).end();
+          request.response().fail(err);
         }
       });
     });

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcStub.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcStub.java
@@ -2,16 +2,12 @@ package examples.grpc;
 
 import static examples.grpc.GreeterGrpc.getServiceDescriptor;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
-import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
-
-import io.grpc.ClientCall;
 
 import io.grpc.stub.StreamObserver;
 
 import io.vertx.grpcio.client.GrpcIoClientChannel;
 import io.vertx.grpcio.client.impl.GrpcIoClientImpl;
+import io.vertx.grpcio.server.impl.stub.ServerCalls;
 
 public final class GreeterGrpcStub {
   private GreeterGrpcStub() {}
@@ -24,7 +20,7 @@ public final class GreeterGrpcStub {
     return new GreeterVertxStub(channel);
   }
 
-  
+
   public static final class GreeterVertxStub extends io.grpc.stub.AbstractStub<GreeterVertxStub> implements GreeterClient {
     private final io.vertx.core.internal.ContextInternal context;
     private GreeterGrpc.GreeterStub delegateStub;
@@ -46,7 +42,7 @@ public final class GreeterGrpcStub {
       return new GreeterVertxStub(channel, callOptions);
     }
 
-    
+
     public io.vertx.core.Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request) {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.oneToOne(context, request, delegateStub::sayHello);
     }
@@ -89,7 +85,7 @@ public final class GreeterGrpcStub {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_SAY_HELLO:
-          io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.HelloRequest, examples.grpc.HelloReply>oneToOne(
+          ServerCalls.<examples.grpc.HelloRequest, examples.grpc.HelloReply>oneToOne(
             (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
             (examples.grpc.HelloRequest) request,
             (io.grpc.stub.StreamObserver<examples.grpc.HelloReply>) responseObserver,

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcIo.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcIo.java
@@ -135,7 +135,7 @@ public final class StreamingGrpcIo {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_SOURCE:
-          io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.Empty, examples.grpc.Item>oneToMany(
+          io.vertx.grpcio.server.impl.stub.ServerCalls.<examples.grpc.Empty, examples.grpc.Item>oneToMany(
             (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
             (examples.grpc.Empty) request,
             (io.grpc.stub.StreamObserver<examples.grpc.Item>) responseObserver,
@@ -153,14 +153,14 @@ public final class StreamingGrpcIo {
       StreamObserver<Req> reqStreamObserver;
       switch (methodId) {
         case METHODID_SINK:
-          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.Item, examples.grpc.Empty>manyToOne(
+          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.server.impl.stub.ServerCalls.<examples.grpc.Item, examples.grpc.Empty>manyToOne(
                   (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
                   (io.grpc.stub.StreamObserver<examples.grpc.Empty>) responseObserver,
                   compression,
                   serviceImpl::sink);
           return reqStreamObserver;
         case METHODID_PIPE:
-          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.Item, examples.grpc.Item>manyToMany(
+          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.server.impl.stub.ServerCalls.<examples.grpc.Item, examples.grpc.Item>manyToMany(
                   (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
                   (io.grpc.stub.StreamObserver<examples.grpc.Item>) responseObserver,
                   compression,

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
@@ -15,6 +15,7 @@ import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.Service;
 import io.vertx.grpc.server.ServiceBuilder;
+import io.vertx.grpc.server.StatusException;
 
 import com.google.protobuf.Descriptors;
 
@@ -207,40 +208,22 @@ public class StreamingGrpcService extends StreamingService implements Service {
 
   private void handle_source(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Empty, examples.grpc.Item> request) {
     request.handler(msg -> {
-      try {
-        instance.source(msg, request.response());
-      } catch (UnsupportedOperationException e) {
-        request.response().status(GrpcStatus.UNIMPLEMENTED).end();
-      } catch (RuntimeException err) {
-        request.response().status(GrpcStatus.UNKNOWN).end();
-      }
+      instance.source(msg, request.response());
     });
   }
 
   private void handle_sink(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Empty> request) {
-    try {
-      instance.sink(request, (res, err) -> {
-        if (err == null) {
-          request.response().end(res);
-        } else {
-          request.response().status(GrpcStatus.UNKNOWN).end();
-        }
-      });
-    } catch (UnsupportedOperationException err) {
-      request.response().status(GrpcStatus.UNIMPLEMENTED).end();
-    } catch (RuntimeException err) {
-      request.response().status(GrpcStatus.UNKNOWN).end();
-    }
+    instance.sink(request, (res, err) -> {
+      if (err == null) {
+        request.response().end(res);
+      } else {
+        request.response().status(StatusException.mapStatus(err)).end();
+      }
+    });
   }
 
   private void handle_pipe(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Item> request) {
-    try {
-      instance.pipe(request, request.response());
-     } catch (UnsupportedOperationException err) {
-      request.response().status(GrpcStatus.UNIMPLEMENTED).end();
-     } catch (RuntimeException err) {
-      request.response().status(GrpcStatus.UNKNOWN).end();
-    }
+    instance.pipe(request, request.response());
   }
     }
   }

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
@@ -217,7 +217,7 @@ public class StreamingGrpcService extends StreamingService implements Service {
       if (err == null) {
         request.response().end(res);
       } else {
-        request.response().status(StatusException.mapStatus(err)).end();
+        request.response().fail(err);
       }
     });
   }

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcStub.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcStub.java
@@ -1,17 +1,15 @@
 package examples.grpc;
 
 import static examples.grpc.StreamingGrpc.getServiceDescriptor;
-import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
-
-import io.grpc.ClientCall;
 
 import io.grpc.stub.StreamObserver;
 
 import io.vertx.grpcio.client.GrpcIoClientChannel;
 import io.vertx.grpcio.client.impl.GrpcIoClientImpl;
+import io.vertx.grpcio.server.impl.stub.ServerCalls;
 
 public final class StreamingGrpcStub {
   private StreamingGrpcStub() {}
@@ -24,7 +22,7 @@ public final class StreamingGrpcStub {
     return new StreamingVertxStub(channel);
   }
 
-  
+
   public static final class StreamingVertxStub extends io.grpc.stub.AbstractStub<StreamingVertxStub> implements StreamingClient {
     private final io.vertx.core.internal.ContextInternal context;
     private StreamingGrpc.StreamingStub delegateStub;
@@ -46,17 +44,17 @@ public final class StreamingGrpcStub {
       return new StreamingVertxStub(channel, callOptions);
     }
 
-    
+
     public io.vertx.core.Future<io.vertx.core.streams.ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request) {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.oneToMany(context, request, delegateStub::source);
     }
 
-    
+
     public io.vertx.core.Future<examples.grpc.Empty> sink(io.vertx.core.Completable<io.vertx.core.streams.WriteStream<examples.grpc.Item>> handler) {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.manyToOne(context, handler, delegateStub::sink);
     }
 
-    
+
     public io.vertx.core.Future<io.vertx.core.streams.ReadStream<examples.grpc.Item>> pipe(io.vertx.core.Completable<io.vertx.core.streams.WriteStream<examples.grpc.Item>> handler) {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.manyToMany(context, handler, delegateStub::pipe);
     }
@@ -114,7 +112,7 @@ public final class StreamingGrpcStub {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_SOURCE:
-          io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.Empty, examples.grpc.Item>oneToMany(
+          ServerCalls.<examples.grpc.Empty, examples.grpc.Item>oneToMany(
             (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
             (examples.grpc.Empty) request,
             (io.grpc.stub.StreamObserver<examples.grpc.Item>) responseObserver,
@@ -132,14 +130,14 @@ public final class StreamingGrpcStub {
       StreamObserver<Req> reqStreamObserver;
       switch (methodId) {
         case METHODID_SINK:
-          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.Item, examples.grpc.Empty>manyToOne(
+          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) ServerCalls.<examples.grpc.Item, examples.grpc.Empty>manyToOne(
                   (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
                   (io.grpc.stub.StreamObserver<examples.grpc.Empty>) responseObserver,
                   compression,
                   serviceImpl::sink);
           return reqStreamObserver;
         case METHODID_PIPE:
-          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.Item, examples.grpc.Item>manyToMany(
+          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) ServerCalls.<examples.grpc.Item, examples.grpc.Item>manyToMany(
                   (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
                   (io.grpc.stub.StreamObserver<examples.grpc.Item>) responseObserver,
                   compression,

--- a/vertx-grpc-docs/src/main/java/examples/grpc/VertxGreeterGrpc.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/VertxGreeterGrpc.java
@@ -2,16 +2,12 @@ package examples.grpc;
 
 import static examples.grpc.GreeterGrpc.getServiceDescriptor;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
-import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
-
-import io.grpc.ClientCall;
 
 import io.grpc.stub.StreamObserver;
 
 import io.vertx.grpcio.client.GrpcIoClientChannel;
 import io.vertx.grpcio.client.impl.GrpcIoClientImpl;
+import io.vertx.grpcio.server.impl.stub.ServerCalls;
 
 public final class VertxGreeterGrpc {
   private VertxGreeterGrpc() {}
@@ -24,7 +20,7 @@ public final class VertxGreeterGrpc {
     return new GreeterStub(channel);
   }
 
-  
+
   public static final class GreeterStub extends io.grpc.stub.AbstractStub<GreeterStub> implements GreeterClient {
     private final io.vertx.core.internal.ContextInternal context;
     private GreeterGrpc.GreeterStub delegateStub;
@@ -46,7 +42,7 @@ public final class VertxGreeterGrpc {
       return new GreeterStub(channel, callOptions);
     }
 
-    
+
     public io.vertx.core.Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request) {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.oneToOne(context, request, delegateStub::sayHello);
     }
@@ -89,7 +85,7 @@ public final class VertxGreeterGrpc {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_SAY_HELLO:
-          io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.HelloRequest, examples.grpc.HelloReply>oneToOne(
+          ServerCalls.<examples.grpc.HelloRequest, examples.grpc.HelloReply>oneToOne(
             (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
             (examples.grpc.HelloRequest) request,
             (io.grpc.stub.StreamObserver<examples.grpc.HelloReply>) responseObserver,

--- a/vertx-grpc-docs/src/main/java/examples/grpc/VertxStreamingGrpc.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/VertxStreamingGrpc.java
@@ -1,17 +1,15 @@
 package examples.grpc;
 
 import static examples.grpc.StreamingGrpc.getServiceDescriptor;
-import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
-
-import io.grpc.ClientCall;
 
 import io.grpc.stub.StreamObserver;
 
 import io.vertx.grpcio.client.GrpcIoClientChannel;
 import io.vertx.grpcio.client.impl.GrpcIoClientImpl;
+import io.vertx.grpcio.server.impl.stub.ServerCalls;
 
 public final class VertxStreamingGrpc {
   private VertxStreamingGrpc() {}
@@ -24,7 +22,7 @@ public final class VertxStreamingGrpc {
     return new StreamingStub(channel);
   }
 
-  
+
   public static final class StreamingStub extends io.grpc.stub.AbstractStub<StreamingStub> implements StreamingClient {
     private final io.vertx.core.internal.ContextInternal context;
     private StreamingGrpc.StreamingStub delegateStub;
@@ -46,17 +44,17 @@ public final class VertxStreamingGrpc {
       return new StreamingStub(channel, callOptions);
     }
 
-    
+
     public io.vertx.core.Future<io.vertx.core.streams.ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request) {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.oneToMany(context, request, delegateStub::source);
     }
 
-    
+
     public io.vertx.core.Future<examples.grpc.Empty> sink(io.vertx.core.Completable<io.vertx.core.streams.WriteStream<examples.grpc.Item>> handler) {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.manyToOne(context, handler, delegateStub::sink);
     }
 
-    
+
     public io.vertx.core.Future<io.vertx.core.streams.ReadStream<examples.grpc.Item>> pipe(io.vertx.core.Completable<io.vertx.core.streams.WriteStream<examples.grpc.Item>> handler) {
       return io.vertx.grpcio.common.impl.stub.ClientCalls.manyToMany(context, handler, delegateStub::pipe);
     }
@@ -114,7 +112,7 @@ public final class VertxStreamingGrpc {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_SOURCE:
-          io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.Empty, examples.grpc.Item>oneToMany(
+          ServerCalls.<examples.grpc.Empty, examples.grpc.Item>oneToMany(
             (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
             (examples.grpc.Empty) request,
             (io.grpc.stub.StreamObserver<examples.grpc.Item>) responseObserver,
@@ -132,14 +130,14 @@ public final class VertxStreamingGrpc {
       StreamObserver<Req> reqStreamObserver;
       switch (methodId) {
         case METHODID_SINK:
-          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.Item, examples.grpc.Empty>manyToOne(
+          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) ServerCalls.<examples.grpc.Item, examples.grpc.Empty>manyToOne(
                   (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
                   (io.grpc.stub.StreamObserver<examples.grpc.Empty>) responseObserver,
                   compression,
                   serviceImpl::sink);
           return reqStreamObserver;
         case METHODID_PIPE:
-          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.common.impl.stub.ServerCalls.<examples.grpc.Item, examples.grpc.Item>manyToMany(
+          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) ServerCalls.<examples.grpc.Item, examples.grpc.Item>manyToMany(
                   (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
                   (io.grpc.stub.StreamObserver<examples.grpc.Item>) responseObserver,
                   compression,

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-io.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-io.mustache
@@ -140,7 +140,7 @@ public final class {{grpcIoFqn}} {
         {{#methods}}
         {{^isManyInput}}
         case METHODID_{{methodNameUpperUnderscore}}:
-          io.vertx.grpcio.common.impl.stub.ServerCalls.<{{inputType}}, {{outputType}}>{{vertxCallsMethodName}}(
+          io.vertx.grpcio.server.impl.stub.ServerCalls.<{{inputType}}, {{outputType}}>{{vertxCallsMethodName}}(
             (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
             ({{inputType}}) request,
             (io.grpc.stub.StreamObserver<{{outputType}}>) responseObserver,
@@ -162,7 +162,7 @@ public final class {{grpcIoFqn}} {
         {{#methods}}
         {{#isManyInput}}
         case METHODID_{{methodNameUpperUnderscore}}:
-          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.common.impl.stub.ServerCalls.<{{inputType}}, {{outputType}}>{{vertxCallsMethodName}}(
+          reqStreamObserver = (io.grpc.stub.StreamObserver<Req>) io.vertx.grpcio.server.impl.stub.ServerCalls.<{{inputType}}, {{outputType}}>{{vertxCallsMethodName}}(
                   (io.vertx.core.internal.ContextInternal) io.vertx.core.Vertx.currentContext(),
                   (io.grpc.stub.StreamObserver<{{outputType}}>) responseObserver,
                   compression,

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
@@ -222,7 +222,7 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
         if (err == null) {
           request.response().end(res);
         } else {
-          request.response().status(StatusException.mapStatus(err)).end();
+          request.response().fail(err);
         }
       });
     });
@@ -243,7 +243,7 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
       if (err == null) {
         request.response().end(res);
       } else {
-        request.response().status(StatusException.mapStatus(err)).end();
+        request.response().fail(err);
       }
     });
   }

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
@@ -17,6 +17,7 @@ import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.Service;
 import io.vertx.grpc.server.ServiceBuilder;
+import io.vertx.grpc.server.StatusException;
 
 import com.google.protobuf.Descriptors;
 
@@ -217,19 +218,13 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
 
   private void handle_{{vertxMethodName}}(io.vertx.grpc.server.GrpcServerRequest<{{inputType}}, {{outputType}}> request) {
     request.handler(msg -> {
-      try {
-        instance.{{vertxMethodName}}(msg, (res, err) -> {
-          if (err == null) {
-            request.response().end(res);
-          } else {
-            request.response().status(GrpcStatus.UNKNOWN).end();
-          }
-        });
-      } catch (UnsupportedOperationException err) {
-        request.response().status(GrpcStatus.UNIMPLEMENTED).end();
-      } catch (RuntimeException err) {
-        request.response().status(GrpcStatus.UNKNOWN).end();
-      }
+      instance.{{vertxMethodName}}(msg, (res, err) -> {
+        if (err == null) {
+          request.response().end(res);
+        } else {
+          request.response().status(StatusException.mapStatus(err)).end();
+        }
+      });
     });
   }
 {{/unaryUnaryMethods}}
@@ -237,44 +232,26 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
 
   private void handle_{{vertxMethodName}}(io.vertx.grpc.server.GrpcServerRequest<{{inputType}}, {{outputType}}> request) {
     request.handler(msg -> {
-      try {
-        instance.{{vertxMethodName}}(msg, request.response());
-      } catch (UnsupportedOperationException e) {
-        request.response().status(GrpcStatus.UNIMPLEMENTED).end();
-      } catch (RuntimeException err) {
-        request.response().status(GrpcStatus.UNKNOWN).end();
-      }
+      instance.{{vertxMethodName}}(msg, request.response());
     });
   }
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
 
   private void handle_{{vertxMethodName}}(io.vertx.grpc.server.GrpcServerRequest<{{inputType}}, {{outputType}}> request) {
-    try {
-      instance.{{vertxMethodName}}(request, (res, err) -> {
-        if (err == null) {
-          request.response().end(res);
-        } else {
-          request.response().status(GrpcStatus.UNKNOWN).end();
-        }
-      });
-    } catch (UnsupportedOperationException err) {
-      request.response().status(GrpcStatus.UNIMPLEMENTED).end();
-    } catch (RuntimeException err) {
-      request.response().status(GrpcStatus.UNKNOWN).end();
-    }
+    instance.{{vertxMethodName}}(request, (res, err) -> {
+      if (err == null) {
+        request.response().end(res);
+      } else {
+        request.response().status(StatusException.mapStatus(err)).end();
+      }
+    });
   }
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
 
   private void handle_{{vertxMethodName}}(io.vertx.grpc.server.GrpcServerRequest<{{inputType}}, {{outputType}}> request) {
-    try {
-      instance.{{vertxMethodName}}(request, request.response());
-     } catch (UnsupportedOperationException err) {
-      request.response().status(GrpcStatus.UNIMPLEMENTED).end();
-     } catch (RuntimeException err) {
-      request.response().status(GrpcStatus.UNKNOWN).end();
-    }
+    instance.{{vertxMethodName}}(request, request.response());
   }
 {{/manyManyMethods}}
     }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
@@ -69,4 +69,18 @@ public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
   default Future<Void> send(ReadStream<Resp> body) {
     return body.pipeTo(this);
   }
+
+  /**
+   * End the stream with an appropriate status message, when {@code failure} is
+   *
+   * <ul>
+   *   <li>{@link StatusException}, set status to {@link StatusException#status()} and status message to {@link StatusException#message()}</li>
+   *   <li>{@link UnsupportedOperationException} returns {@link GrpcStatus#UNIMPLEMENTED}</li>
+   *   <li>otherwise returns {@link GrpcStatus#UNKNOWN}</li>
+   * </ul>
+   *
+   * @param failure the failure
+   */
+  void fail(Throwable failure);
+
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/StatusException.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/StatusException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.server;
+
+import io.vertx.core.VertxException;
+import io.vertx.grpc.common.GrpcStatus;
+
+/**
+ * A glorified GOTO forcing a response status.
+ */
+public final class StatusException extends VertxException {
+
+  /**
+   * Map an exception to a GrpcStatus:
+   *
+   * <ul>
+   *   <li>{@link StatusException} returns {@link #status()}</li>
+   *   <li>{@link UnsupportedOperationException} returns {@link GrpcStatus#UNIMPLEMENTED}</li>
+   *   <li>otherwise returns {@link GrpcStatus#UNKNOWN}</li>
+   * </ul>
+   *
+   * @param t the exception to map
+   * @return the mapped status
+   */
+  public static GrpcStatus mapStatus(Throwable t) {
+    if (t instanceof StatusException) {
+      return ((StatusException)t).status();
+    } else if (t instanceof UnsupportedOperationException) {
+      return GrpcStatus.UNIMPLEMENTED;
+    } else {
+      return GrpcStatus.UNKNOWN;
+    }
+  }
+
+  private final GrpcStatus status;
+
+  public StatusException(GrpcStatus status) {
+    super("Grpc status " + status.name());
+    this.status = status;
+  }
+
+  /**
+   * @return the status
+   */
+  public GrpcStatus status() {
+    return status;
+  }
+}

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/StatusException.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/StatusException.java
@@ -18,33 +18,19 @@ import io.vertx.grpc.common.GrpcStatus;
  */
 public final class StatusException extends VertxException {
 
-  /**
-   * Map an exception to a GrpcStatus:
-   *
-   * <ul>
-   *   <li>{@link StatusException} returns {@link #status()}</li>
-   *   <li>{@link UnsupportedOperationException} returns {@link GrpcStatus#UNIMPLEMENTED}</li>
-   *   <li>otherwise returns {@link GrpcStatus#UNKNOWN}</li>
-   * </ul>
-   *
-   * @param t the exception to map
-   * @return the mapped status
-   */
-  public static GrpcStatus mapStatus(Throwable t) {
-    if (t instanceof StatusException) {
-      return ((StatusException)t).status();
-    } else if (t instanceof UnsupportedOperationException) {
-      return GrpcStatus.UNIMPLEMENTED;
-    } else {
-      return GrpcStatus.UNKNOWN;
-    }
-  }
-
   private final GrpcStatus status;
+  private final String message;
 
   public StatusException(GrpcStatus status) {
     super("Grpc status " + status.name());
     this.status = status;
+    this.message = null;
+  }
+
+  public StatusException(GrpcStatus status, String message) {
+    super("Grpc status " + status.name());
+    this.status = status;
+    this.message = message;
   }
 
   /**
@@ -52,5 +38,12 @@ public final class StatusException extends VertxException {
    */
   public GrpcStatus status() {
     return status;
+  }
+
+  /**
+   * @return the status message
+   */
+  public String message() {
+    return message;
   }
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -332,7 +332,11 @@ public class GrpcServerImpl implements GrpcServer {
 
     @Override
     public void handle(GrpcServerRequest<Req, Resp> grpcRequest) {
-      handler.handle(grpcRequest);
+      try {
+        handler.handle(grpcRequest);
+      } catch (Exception e) {
+        ((GrpcServerResponseImpl)grpcRequest.response()).fail(e);
+      }
     }
   }
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -335,7 +335,7 @@ public class GrpcServerImpl implements GrpcServer {
       try {
         handler.handle(grpcRequest);
       } catch (Exception e) {
-        ((GrpcServerResponseImpl)grpcRequest.response()).fail(e);
+        grpcRequest.response().fail(e);
       }
     }
   }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
@@ -23,6 +23,7 @@ import io.vertx.grpc.common.impl.GrpcReadStreamBase;
 import io.vertx.grpc.common.impl.GrpcWriteStreamBase;
 import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.StatusException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -141,7 +142,11 @@ public abstract class GrpcServerRequestImpl<Req, Resp> extends GrpcReadStreamBas
           response.cancel();
           return;
         }
-        handler.handle(decoded);
+        try {
+          handler.handle(decoded);
+        } catch (Exception e) {
+          response.fail(e);
+        }
       });
     } else {
       return messageHandler(null);

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -24,6 +24,7 @@ import io.vertx.grpc.common.impl.GrpcWriteStreamBase;
 import io.vertx.grpc.common.impl.Utils;
 import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServerResponse;
+import io.vertx.grpc.server.StatusException;
 
 import java.util.Map;
 import java.util.Objects;
@@ -91,6 +92,11 @@ public abstract class GrpcServerResponseImpl<Req, Resp> extends GrpcWriteStreamB
     if (!requestEnded || !isTrailersSent()) {
       sendCancel();
     }
+  }
+
+  public void fail(Exception e) {
+    this.status = StatusException.mapStatus(e);
+    end();
   }
 
   public boolean isTrailersOnly() {

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -26,7 +26,6 @@ import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServerResponse;
 import io.vertx.grpc.server.StatusException;
 
-import javax.swing.undo.StateEdit;
 import java.util.Map;
 import java.util.Objects;
 

--- a/vertx-grpc-server/src/main/java/module-info.java
+++ b/vertx-grpc-server/src/main/java/module-info.java
@@ -10,9 +10,8 @@ module io.vertx.grpc.server {
   requires io.netty.codec;
   requires io.netty.buffer;
   requires com.google.protobuf;
-    requires java.desktop;
 
-    uses io.vertx.grpc.server.impl.GrpcHttpInvoker;
+  uses io.vertx.grpc.server.impl.GrpcHttpInvoker;
 
   exports io.vertx.grpc.server;
   exports io.vertx.grpc.server.impl to io.vertx.grpc.transcoding;

--- a/vertx-grpc-server/src/main/java/module-info.java
+++ b/vertx-grpc-server/src/main/java/module-info.java
@@ -10,8 +10,9 @@ module io.vertx.grpc.server {
   requires io.netty.codec;
   requires io.netty.buffer;
   requires com.google.protobuf;
+    requires java.desktop;
 
-  uses io.vertx.grpc.server.impl.GrpcHttpInvoker;
+    uses io.vertx.grpc.server.impl.GrpcHttpInvoker;
 
   exports io.vertx.grpc.server;
   exports io.vertx.grpc.server.impl to io.vertx.grpc.transcoding;

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
@@ -26,6 +26,7 @@ import io.vertx.grpc.common.*;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerOptions;
 import io.vertx.grpc.server.GrpcServerResponse;
+import io.vertx.grpc.server.StatusException;
 import io.vertx.tests.common.grpc.Empty;
 import io.vertx.tests.common.grpc.Reply;
 import io.vertx.tests.common.grpc.Request;
@@ -92,19 +93,38 @@ public class ServerRequestTest extends ServerTest {
     should.assertEquals("Hello Julien", res.getMessage());
   }
 
-  @Override
-  public void testStatus(TestContext should) {
-
+  @Test
+  public void testStatus1(TestContext should) {
     startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
       call.handler(helloRequest -> {
         GrpcServerResponse<Request, Reply> response = call.response();
         response
-          .status(GrpcStatus.UNAVAILABLE)
+          .status(GrpcStatus.ALREADY_EXISTS)
           .end();
       });
     }));
 
-    super.testStatus(should);
+    super.testStatus(should, Status.ALREADY_EXISTS);
+  }
+
+  @Test
+  public void testStatus2(TestContext should) {
+    startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
+      throw new StatusException(GrpcStatus.ALREADY_EXISTS);
+    }));
+
+    super.testStatus(should, Status.ALREADY_EXISTS);
+  }
+
+  @Test
+  public void testStatus3(TestContext should) {
+    startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
+      call.handler(helloRequest -> {
+        throw new StatusException(GrpcStatus.ALREADY_EXISTS);
+      });
+    }));
+
+    super.testStatus(should, Status.ALREADY_EXISTS);
   }
 
   @Override

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
@@ -101,8 +101,7 @@ public abstract class ServerTest extends ServerTestBase {
     }
   }
 
-  @Test
-  public void testStatus(TestContext should) {
+  public void testStatus(TestContext should, Status expectedStatus) {
     Request request = Request.newBuilder().setName("Julien").build();
     channel = ManagedChannelBuilder.forAddress( "localhost", port)
       .usePlaintext()
@@ -111,7 +110,7 @@ public abstract class ServerTest extends ServerTestBase {
     try {
       stub.unary(request);
     } catch (StatusRuntimeException e) {
-      should.assertEquals(Status.UNAVAILABLE, e.getStatus());
+      should.assertEquals(expectedStatus, e.getStatus());
     }
   }
 

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
@@ -37,10 +37,7 @@ import io.vertx.grpc.common.impl.GrpcMessageImpl;
 import io.vertx.tests.common.grpc.*;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -101,7 +98,7 @@ public abstract class ServerTest extends ServerTestBase {
     }
   }
 
-  public void testStatus(TestContext should, Status expectedStatus) {
+  public void testStatusUnary(TestContext should, Status expectedStatus, String expectedStatusMessage) {
     Request request = Request.newBuilder().setName("Julien").build();
     channel = ManagedChannelBuilder.forAddress( "localhost", port)
       .usePlaintext()
@@ -109,8 +106,29 @@ public abstract class ServerTest extends ServerTestBase {
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
     try {
       stub.unary(request);
+      should.fail();
+    } catch (StatusRuntimeException e) {
+      should.assertEquals(expectedStatus.getCode(), e.getStatus().getCode());
+      should.assertEquals(expectedStatusMessage, e.getStatus().getDescription());
+    }
+  }
+
+  public void testStatusStreaming(TestContext should, Status expectedStatus, String... expectedReplies) {
+    channel = ManagedChannelBuilder.forAddress( "localhost", port)
+      .usePlaintext()
+      .build();
+    TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
+    List<String> replies = new ArrayList<>();
+    try {
+      Iterator<Reply> iterator = stub.source(Empty.getDefaultInstance());
+      while (iterator.hasNext()) {
+        Reply next = iterator.next();
+        replies.add(next.getMessage());
+      }
+      should.fail();
     } catch (StatusRuntimeException e) {
       should.assertEquals(expectedStatus, e.getStatus());
+      should.assertEquals(Arrays.asList(expectedReplies), replies);
     }
   }
 

--- a/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/stub/StreamObserverReadStream.java
+++ b/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/stub/StreamObserverReadStream.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * @author Rogelio Orts
  */
-class StreamObserverReadStream<T> implements StreamObserver<T>, ReadStream<T> {
+public class StreamObserverReadStream<T> implements StreamObserver<T>, ReadStream<T> {
 
   private static final EndOfStream END_SENTINEL = new EndOfStream(null);
 

--- a/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
+++ b/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
@@ -122,7 +122,7 @@ public class ServerBridgeTest extends ServerTest {
     super.testUnary(should, "identity", "identity");
   }
 
-  @Override
+  @Test
   public void testStatus(TestContext should) {
 
     TestServiceGrpc.TestServiceImplBase impl = new TestServiceGrpc.TestServiceImplBase() {
@@ -137,7 +137,7 @@ public class ServerBridgeTest extends ServerTest {
     serverStub.bind(server);
     startServer(server);
 
-    super.testStatus(should);
+    super.testStatus(should, Status.UNAVAILABLE);
   }
 
   @Override

--- a/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
+++ b/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
@@ -123,12 +123,12 @@ public class ServerBridgeTest extends ServerTest {
   }
 
   @Test
-  public void testStatus(TestContext should) {
+  public void testStatusUnary1(TestContext should) {
 
     TestServiceGrpc.TestServiceImplBase impl = new TestServiceGrpc.TestServiceImplBase() {
       @Override
       public void unary(Request request, StreamObserver<Reply> responseObserver) {
-        responseObserver.onError(new StatusRuntimeException(Status.UNAVAILABLE));
+        responseObserver.onError(new StatusRuntimeException(Status.ALREADY_EXISTS.withDescription("status-msg")));
       }
     };
 
@@ -137,7 +137,45 @@ public class ServerBridgeTest extends ServerTest {
     serverStub.bind(server);
     startServer(server);
 
-    super.testStatus(should, Status.UNAVAILABLE);
+    super.testStatusUnary(should, Status.ALREADY_EXISTS, "status-msg");
+  }
+
+  @Test
+  public void testStatusUnary2(TestContext should) {
+
+    TestServiceGrpc.TestServiceImplBase impl = new TestServiceGrpc.TestServiceImplBase() {
+      @Override
+      public void unary(Request request, StreamObserver<Reply> responseObserver) {
+        responseObserver.onError(new RuntimeException("should-be-ignored"));
+      }
+    };
+
+    GrpcIoServer server = GrpcIoServer.server(vertx);
+    GrpcIoServiceBridge serverStub = GrpcIoServiceBridge.bridge(impl);
+    serverStub.bind(server);
+    startServer(server);
+
+    super.testStatusUnary(should, Status.UNKNOWN, null);
+  }
+
+  @Test
+  public void testStatusStreaming(TestContext should) {
+
+    TestServiceGrpc.TestServiceImplBase impl = new TestServiceGrpc.TestServiceImplBase() {
+      @Override
+      public void source(Empty request, StreamObserver<Reply> responseObserver) {
+        responseObserver.onNext(Reply.newBuilder().setMessage("msg1").build());
+        responseObserver.onNext(Reply.newBuilder().setMessage("msg2").build());
+        responseObserver.onError(new StatusRuntimeException(Status.ALREADY_EXISTS));
+      }
+    };
+
+    GrpcIoServer server = GrpcIoServer.server(vertx);
+    GrpcIoServiceBridge serverStub = GrpcIoServiceBridge.bridge(impl);
+    serverStub.bind(server);
+    startServer(server);
+
+    super.testStatusStreaming(should, Status.ALREADY_EXISTS, "msg1", "msg2");
   }
 
   @Override


### PR DESCRIPTION
Motivation:

The current mapping of errors to status is currently not homogeneous (between vertx/io service generation) and lacks of a status exception allowing to set force a status to be set by the wrapper.

Changes:

Introduce `io.vertx.grpc.server.StatusException` that conveys the grpc status to be returned by the service when this exception is encountered.
