### PR TITLE
Decode/encode JSON wire format messages for grpc-io.

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageDecoder.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageDecoder.java
@@ -53,7 +53,7 @@ public interface GrpcMessageDecoder<T> {
               throw new CodecException(e);
             }
           default:
-            throw new IllegalArgumentException("Invalid wire format: ");
+            throw new IllegalArgumentException("Invalid wire format: " + msg.format());
         }
       }
       @Override

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/WriteStreamAdapter.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/WriteStreamAdapter.java
@@ -19,6 +19,7 @@ import io.vertx.grpc.common.WireFormat;
  */
 public class WriteStreamAdapter<T> {
 
+  private WireFormat wireFormat;
   private GrpcWriteStream<T> stream;
   private boolean ready;
   private GrpcMessageEncoder<T> encoder;
@@ -29,9 +30,10 @@ public class WriteStreamAdapter<T> {
   protected void handleReady() {
   }
 
-  public final void init(GrpcWriteStream<T> stream, GrpcMessageEncoder<T> encoder) {
+  public final void init(GrpcWriteStream<T> stream, WireFormat wireFormat, GrpcMessageEncoder<T> encoder) {
     synchronized (this) {
       this.stream = stream;
+      this.wireFormat = wireFormat;
       this.encoder = encoder;
     }
     stream.drainHandler(v -> {
@@ -45,7 +47,7 @@ public class WriteStreamAdapter<T> {
   }
 
   public final void write(T msg) {
-    stream.writeMessage(encoder.encode(msg, WireFormat.PROTOBUF));
+    stream.writeMessage(encoder.encode(msg, wireFormat));
     synchronized (this) {
       ready = !stream.writeQueueFull();
     }

--- a/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingMessageDeframer.java
+++ b/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingMessageDeframer.java
@@ -10,11 +10,10 @@
  */
 package io.vertx.grpc.transcoding.impl;
 
-import io.netty.handler.codec.base64.Base64;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.grpc.common.GrpcMessage;
 import io.vertx.grpc.common.MessageSizeOverflowException;
+import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.common.impl.GrpcMessageDeframer;
 
 /**
@@ -64,7 +63,7 @@ public class TranscodingMessageDeframer implements GrpcMessageDeframer {
   @Override
   public void end() {
     if (!processed) {
-      result = GrpcMessage.message("identity", buffer == null ? Buffer.buffer() : buffer);
+      result = GrpcMessage.message("identity", WireFormat.JSON, buffer == null ? Buffer.buffer() : buffer);
       buffer = null;
     }
   }

--- a/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
+++ b/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
@@ -14,6 +14,7 @@ import io.vertx.grpc.client.GrpcClientRequest;
 import io.vertx.grpc.client.GrpcClientResponse;
 import io.vertx.grpc.common.GrpcErrorException;
 import io.vertx.grpc.client.impl.GrpcClientRequestImpl;
+import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.common.impl.*;
 import io.vertx.grpcio.common.impl.BridgeMessageDecoder;
 import io.vertx.grpcio.common.impl.BridgeMessageEncoder;
@@ -146,7 +147,7 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
             }
           }
         });
-        writeAdapter.init(request, new BridgeMessageEncoder<>(methodDescriptor.getRequestMarshaller(), compressor));
+        writeAdapter.init(request, WireFormat.PROTOBUF, new BridgeMessageEncoder<>(methodDescriptor.getRequestMarshaller(), compressor));
       } else {
         doClose(Status.UNAVAILABLE, new Metadata());
       }

--- a/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/impl/GrpcIoClientImpl.java
+++ b/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/impl/GrpcIoClientImpl.java
@@ -23,6 +23,8 @@ import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpcio.client.GrpcIoClient;
+import io.vertx.grpcio.common.impl.BridgeMessageDecoder;
+import io.vertx.grpcio.common.impl.BridgeMessageEncoder;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -39,15 +41,15 @@ public class GrpcIoClientImpl extends GrpcClientImpl implements GrpcIoClient {
 
   @Override
   public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(MethodDescriptor<Req, Resp> service) {
-    GrpcMessageDecoder<Resp> messageDecoder = io.vertx.grpcio.common.impl.Utils.unmarshaller(service.getResponseMarshaller());
-    GrpcMessageEncoder<Req> messageEncoder = io.vertx.grpcio.common.impl.Utils.marshaller(service.getRequestMarshaller());
+    GrpcMessageDecoder<Resp> messageDecoder = new BridgeMessageDecoder<>(service.getResponseMarshaller(), null);
+    GrpcMessageEncoder<Req> messageEncoder = new BridgeMessageEncoder<>(service.getRequestMarshaller(), null);
     ServiceMethod<Resp, Req> serviceMethod = ServiceMethod.client(ServiceName.create(service.getServiceName()), service.getBareMethodName(), messageEncoder, messageDecoder);
     return request(serviceMethod);
   }
 
   @Override public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(Address server, MethodDescriptor<Req, Resp> service) {
-    GrpcMessageDecoder<Resp> messageDecoder = io.vertx.grpcio.common.impl.Utils.unmarshaller(service.getResponseMarshaller());
-    GrpcMessageEncoder<Req> messageEncoder = io.vertx.grpcio.common.impl.Utils.marshaller(service.getRequestMarshaller());
+    GrpcMessageDecoder<Resp> messageDecoder = new BridgeMessageDecoder<>(service.getResponseMarshaller(), null);
+    GrpcMessageEncoder<Req> messageEncoder = new BridgeMessageEncoder<>(service.getRequestMarshaller(), null);
     ServiceMethod<Resp, Req> serviceMethod = ServiceMethod.client(ServiceName.create(service.getServiceName()), service.getBareMethodName(), messageEncoder, messageDecoder);
     return request(server, serviceMethod);
   }

--- a/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/BridgeMessageDecoder.java
+++ b/vertx-grpcio-common/src/main/java/io/vertx/grpcio/common/impl/BridgeMessageDecoder.java
@@ -10,9 +10,15 @@
  */
 package io.vertx.grpcio.common.impl;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.util.JsonFormat;
 import io.grpc.Decompressor;
 import io.grpc.KnownLength;
 import io.grpc.MethodDescriptor;
+import io.vertx.core.json.DecodeException;
+import io.vertx.grpc.common.CodecException;
 import io.vertx.grpc.common.WireFormat;
 import io.netty.buffer.ByteBufInputStream;
 import io.vertx.core.buffer.Buffer;
@@ -22,13 +28,16 @@ import io.vertx.grpc.common.GrpcMessageDecoder;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 public class BridgeMessageDecoder<T> implements GrpcMessageDecoder<T> {
 
   private MethodDescriptor.Marshaller<T> marshaller;
+  private final MessageLite messageLite;
   private Decompressor decompressor;
 
   public BridgeMessageDecoder(MethodDescriptor.Marshaller<T> marshaller, Decompressor decompressor) {
+    this.messageLite = (MessageLite) ((MethodDescriptor.PrototypeMarshaller<T>) marshaller).getMessagePrototype();
     this.marshaller = marshaller;
     this.decompressor = decompressor;
   }
@@ -49,17 +58,31 @@ public class BridgeMessageDecoder<T> implements GrpcMessageDecoder<T> {
 
   @Override
   public T decode(GrpcMessage msg) {
-    assert msg.format() == WireFormat.PROTOBUF;
-    try (KnownLengthStream kls = new KnownLengthStream(msg.payload())) {
-      if (msg.encoding().equals("identity")) {
-        return marshaller.parse(kls);
-      } else {
-        try (InputStream in = decompressor.decompress(kls)) {
-          return marshaller.parse(in);
-        } catch (IOException e) {
-          throw new RuntimeException(e);
+    switch (msg.format()) {
+      case PROTOBUF:
+        try (KnownLengthStream kls = new KnownLengthStream(msg.payload())) {
+          if (msg.encoding().equals("identity")) {
+            return marshaller.parse(kls);
+          } else if (decompressor != null) {
+            try (InputStream in = decompressor.decompress(kls)) {
+              return marshaller.parse(in);
+            } catch (IOException e) {
+              throw new CodecException(e);
+            }
+          } else {
+            throw new DecodeException();
+          }
         }
-      }
+      case JSON:
+        try {
+          Message.Builder builder = (Message.Builder) messageLite.toBuilder();
+          JsonFormat.parser().merge(msg.payload().toString(StandardCharsets.UTF_8), builder);
+          return (T) builder.build();
+        } catch (InvalidProtocolBufferException e) {
+          throw new CodecException(e);
+        }
+      default:
+        throw new CodecException("Invalid wire format: " + msg.format());
     }
   }
 

--- a/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServerImpl.java
+++ b/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServerImpl.java
@@ -17,6 +17,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.grpc.common.*;
 import io.vertx.grpc.server.*;
 import io.vertx.grpc.server.impl.GrpcServerImpl;
+import io.vertx.grpcio.common.impl.BridgeMessageDecoder;
+import io.vertx.grpcio.common.impl.BridgeMessageEncoder;
 import io.vertx.grpcio.common.impl.Utils;
 import io.vertx.grpcio.server.GrpcIoServer;
 
@@ -38,8 +40,8 @@ public class GrpcIoServerImpl extends GrpcServerImpl implements GrpcIoServer {
     ServiceMethod<Req, Resp> serviceMethod = ServiceMethod.server(ServiceName.create(
       methodDesc.getServiceName()),
       methodDesc.getBareMethodName(),
-      Utils.marshaller(methodDesc.getResponseMarshaller()),
-      Utils.unmarshaller(methodDesc.getRequestMarshaller())
+      new BridgeMessageEncoder<>(methodDesc.getResponseMarshaller(), null),
+      new BridgeMessageDecoder<>(methodDesc.getRequestMarshaller(), null)
     );
     return (GrpcIoServerImpl) callHandler(serviceMethod, handler);
   }

--- a/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServiceBridgeImpl.java
+++ b/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServiceBridgeImpl.java
@@ -184,7 +184,7 @@ public class GrpcIoServiceBridgeImpl implements GrpcIoServiceBridge {
         }
       });
       readAdapter.init(req, new BridgeMessageDecoder<>(methodDef.getMethodDescriptor().getRequestMarshaller(), decompressor));
-      writeAdapter.init(req.response(), new BridgeMessageEncoder<>(methodDef.getMethodDescriptor().getResponseMarshaller(), compressor));
+      writeAdapter.init(req.response(), req.format(), new BridgeMessageEncoder<>(methodDef.getMethodDescriptor().getResponseMarshaller(), compressor));
     }
 
     private Attributes createAttributes() {


### PR DESCRIPTION
Motivation:

The server grpc-io does not support properly transcoding requests due to lack of support for JSON in its decoders.

Changes:

Implement JSON support in grpc-io bridge message encoder/decoder. In addition reuse the bridge codec instead of using more or less the same code in the Utils class.
