### PR TITLE
In a grpc-io client stub pass the vertx context when building a derived client

### DIFF
--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcIo.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcIo.java
@@ -31,7 +31,7 @@ public final class GreeterGrpcIo {
    * Build a new stub.
    */
   public static GreeterStub newStub(io.vertx.core.Vertx vertx, io.grpc.Channel channel) {
-    return new GreeterStub(vertx, channel);
+    return new GreeterStub(vertx.getOrCreateContext(), channel);
   }
 
   
@@ -39,21 +39,21 @@ public final class GreeterGrpcIo {
     private final io.vertx.core.internal.ContextInternal context;
     private GreeterGrpc.GreeterStub delegateStub;
 
-    private GreeterStub(io.vertx.core.Vertx vertx, io.grpc.Channel channel) {
+    private GreeterStub(io.vertx.core.Context context, io.grpc.Channel channel) {
       super(channel);
       this.delegateStub = GreeterGrpc.newStub(channel);
-      this.context = (io.vertx.core.internal.ContextInternal)vertx.getOrCreateContext();
+      this.context = (io.vertx.core.internal.ContextInternal)context;
     }
 
-    private GreeterStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+    private GreeterStub(io.vertx.core.Context context, io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
       this.delegateStub = GreeterGrpc.newStub(channel).build(channel, callOptions);
-      this.context = (io.vertx.core.internal.ContextInternal) ((GrpcIoClientImpl)((GrpcIoClientChannel)getChannel()).client()).vertx().getOrCreateContext();
+      this.context = (io.vertx.core.internal.ContextInternal)context;
     }
 
     @Override
     protected GreeterStub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-      return new GreeterStub(channel, callOptions);
+      return new GreeterStub(context, channel, callOptions);
     }
 
     

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcIo.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcIo.java
@@ -31,7 +31,7 @@ public final class StreamingGrpcIo {
    * Build a new stub.
    */
   public static StreamingStub newStub(io.vertx.core.Vertx vertx, io.grpc.Channel channel) {
-    return new StreamingStub(vertx, channel);
+    return new StreamingStub(vertx.getOrCreateContext(), channel);
   }
 
   
@@ -39,21 +39,21 @@ public final class StreamingGrpcIo {
     private final io.vertx.core.internal.ContextInternal context;
     private StreamingGrpc.StreamingStub delegateStub;
 
-    private StreamingStub(io.vertx.core.Vertx vertx, io.grpc.Channel channel) {
+    private StreamingStub(io.vertx.core.Context context, io.grpc.Channel channel) {
       super(channel);
       this.delegateStub = StreamingGrpc.newStub(channel);
-      this.context = (io.vertx.core.internal.ContextInternal)vertx.getOrCreateContext();
+      this.context = (io.vertx.core.internal.ContextInternal)context;
     }
 
-    private StreamingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+    private StreamingStub(io.vertx.core.Context context, io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
       this.delegateStub = StreamingGrpc.newStub(channel).build(channel, callOptions);
-      this.context = (io.vertx.core.internal.ContextInternal) ((GrpcIoClientImpl)((GrpcIoClientChannel)getChannel()).client()).vertx().getOrCreateContext();
+      this.context = (io.vertx.core.internal.ContextInternal)context;
     }
 
     @Override
     protected StreamingStub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-      return new StreamingStub(channel, callOptions);
+      return new StreamingStub(context, channel, callOptions);
     }
 
     

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-io.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-io.mustache
@@ -33,7 +33,7 @@ public final class {{grpcIoFqn}} {
    * Build a new stub.
    */
   public static {{serviceName}}Stub newStub(io.vertx.core.Vertx vertx, io.grpc.Channel channel) {
-    return new {{serviceName}}Stub(vertx, channel);
+    return new {{serviceName}}Stub(vertx.getOrCreateContext(), channel);
   }
 
   {{#javaDoc}}{{{javaDoc}}}{{/javaDoc}}
@@ -41,21 +41,21 @@ public final class {{grpcIoFqn}} {
     private final io.vertx.core.internal.ContextInternal context;
     private {{serviceName}}Grpc.{{serviceName}}Stub delegateStub;
 
-    private {{serviceName}}Stub(io.vertx.core.Vertx vertx, io.grpc.Channel channel) {
+    private {{serviceName}}Stub(io.vertx.core.Context context, io.grpc.Channel channel) {
       super(channel);
       this.delegateStub = {{serviceName}}Grpc.newStub(channel);
-      this.context = (io.vertx.core.internal.ContextInternal)vertx.getOrCreateContext();
+      this.context = (io.vertx.core.internal.ContextInternal)context;
     }
 
-    private {{serviceName}}Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+    private {{serviceName}}Stub(io.vertx.core.Context context, io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
       this.delegateStub = {{serviceName}}Grpc.newStub(channel).build(channel, callOptions);
-      this.context = (io.vertx.core.internal.ContextInternal) ((GrpcIoClientImpl)((GrpcIoClientChannel)getChannel()).client()).vertx().getOrCreateContext();
+      this.context = (io.vertx.core.internal.ContextInternal)context;
     }
 
     @Override
     protected {{serviceName}}Stub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-      return new {{serviceName}}Stub(channel, callOptions);
+      return new {{serviceName}}Stub(context, channel, callOptions);
     }
 
     {{#unaryUnaryMethods}}


### PR DESCRIPTION
Motivation:

When a grpc-io client stub builds a new context, it attempts to get the vertx context from the channel with a cast. This cast fails when the channel has been rewrapped by the abstract stub. Instead the context should simply be propagated by the current stub instance.

Changes:

Pass the current stub context when deriving a stub.
