### PR TITLE
Add support for GrpcServerResponse headers writing.

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcMessageImpl.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcMessageImpl.java
@@ -37,9 +37,12 @@ public class GrpcMessageImpl implements GrpcMessage {
   }
 
   public static Buffer encode(GrpcMessage message) {
-    ByteBuf bbuf = message.payload().getByteBuf();
+    return encode(message.payload(), !message.encoding().equals("identity"));
+  }
+
+  public static Buffer encode(Buffer message, boolean compressed) {
+    ByteBuf bbuf = message.getByteBuf();
     int len = bbuf.readableBytes();
-    boolean compressed = !message.encoding().equals("identity");
     ByteBuf prefix = Unpooled.buffer(5, 5);
     prefix.writeByte(compressed ? 1 : 0);      // Compression flag
     prefix.writeInt(len);                      // Length

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
@@ -58,6 +58,13 @@ public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
   @Override
   GrpcServerResponse<Req, Resp> drainHandler(@Nullable Handler<Void> handler);
 
+  /**
+   * Send the response headers.
+   *
+   * @return a future notified by the success or failure of the write
+   */
+  Future<Void> writeHead();
+
   default Future<Void> send(Resp item) {
     return end(item);
   }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServiceBridgeImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServiceBridgeImpl.java
@@ -172,7 +172,9 @@ public class GrpcServiceBridgeImpl implements GrpcServiceBridge, GrpcIoServiceBr
 
     @Override
     public void sendHeaders(Metadata headers) {
-      Utils.writeMetadata(headers, req.response().headers());
+      GrpcServerResponse<Req, Resp> response = req.response();
+      Utils.writeMetadata(headers, response.headers());
+      response.writeHead();
     }
 
     @Override

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerBridgeTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerBridgeTest.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.grpc.server;
 
-import com.google.rpc.Code;
 import io.grpc.Attributes;
 import io.grpc.ForwardingServerCall;
 import io.grpc.ForwardingServerCallListener;
@@ -361,44 +360,11 @@ public class ServerBridgeTest extends ServerTest {
     super.testMetadata(should);
   }
 
-/*
-  @Override
-  public void testTrailersOnly(TestContext should) {
-
-    GreeterGrpc.GreeterImplBase impl = new GreeterGrpc.GreeterImplBase() {
-      @Override
-      public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
-        Metadata md = new Metadata();
-        md.put(Metadata.Key.of("custom_response_trailer", io.grpc.Metadata.ASCII_STRING_MARSHALLER), "custom_response_trailer_value");
-        md.put(Metadata.Key.of("custom_response_trailer-bin", Metadata.BINARY_BYTE_MARSHALLER), new byte[]{0,1,2});
-        md.put(Metadata.Key.of("grpc-custom_response_trailer", io.grpc.Metadata.ASCII_STRING_MARSHALLER), "grpc-custom_response_trailer_value");
-        md.put(Metadata.Key.of("grpc-custom_response_trailer-bin", io.grpc.Metadata.BINARY_BYTE_MARSHALLER), new byte[]{2,1,0});
-        final StatusRuntimeException t =
-          StatusProto.toStatusRuntimeException(
-            com.google.rpc.Status.newBuilder()
-              .setCode(Code.INVALID_ARGUMENT_VALUE)
-              .setMessage("grpc-status-message-value +*~")
-              .build(), md);
-        responseObserver.onError(t);
-      }
-    };
-
-    GrpcServer server = GrpcServer.server(vertx);
-    GrpcServiceBridge serverStub = GrpcServiceBridge.bridge(impl);
-    serverStub.bind(server);
-    startServer(server);
-
-    super.testTrailersOnly(should);
-  }
-*/
-
-  @Ignore
   @Test
   public void testEarlyHeadersOk(TestContext should) {
     testEarlyHeaders(GrpcStatus.OK, should);
   }
 
-  @Ignore
   @Test
   public void testEarlyHeadersInvalidArgument(TestContext should) {
     testEarlyHeaders(GrpcStatus.INVALID_ARGUMENT, should);

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
@@ -29,6 +29,7 @@ import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.InvalidMessagePayloadException;
 import io.vertx.grpc.common.MessageSizeOverflowException;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -38,6 +39,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -274,17 +276,46 @@ public class ServerRequestTest extends ServerTest {
     super.testHandleCancel(should);
   }
 
+  @Ignore
+  @Test
+  public void testEarlyHeadersOk(TestContext should) {
+    testEarlyHeaders(GrpcStatus.OK, should);
+  }
+
+  @Ignore
+  @Test
+  public void testEarlyHeadersInvalidArgument(TestContext should) {
+    testEarlyHeaders(GrpcStatus.INVALID_ARGUMENT, should);
+  }
+
+  private void testEarlyHeaders(GrpcStatus status, TestContext should) {
+
+    AtomicReference<Runnable> continuation = new AtomicReference<>();
+
+    startServer(GrpcServer.server(vertx).callHandler(GreeterGrpc.getSayHelloMethod(), call -> {
+      GrpcServerResponse<HelloRequest, HelloReply> response = call.response();
+
+      MultiMap headers = response.headers();
+
+      headers.set("xx-acme-header", "whatever");
+
+      continuation.set(() -> {
+        response.status(status);
+        response.end(HelloReply.newBuilder().setMessage("the message").build());
+      });
+
+//      response.writeHead();
+    }));
+
+    super.testEarlyHeaders(should, status, () -> continuation.get().run());
+  }
+
   @Override
   public void testTrailersOnly(TestContext should) {
 
     startServer(GrpcServer.server(vertx).callHandler(GreeterGrpc.getSayHelloMethod(), call -> {
       call.handler(helloRequest -> {
         GrpcServerResponse<HelloRequest, HelloReply> response = call.response();
-        response.statusMessage("grpc-status-message-value +*~");
-        response.trailers().set("custom_response_trailer", "custom_response_trailer_value");
-        response.trailers().set("custom_response_trailer-bin", Base64.getEncoder().encodeToString(new byte[] { 0,1,2 }));
-        response.trailers().set("grpc-custom_response_trailer", "grpc-custom_response_trailer_value");
-        response.trailers().set("grpc-custom_response_trailer-bin", Base64.getEncoder().encodeToString(new byte[] { 2,1,0 }));
         response
           .status(GrpcStatus.INVALID_ARGUMENT)
           .end();
@@ -292,6 +323,19 @@ public class ServerRequestTest extends ServerTest {
     }));
 
     super.testTrailersOnly(should);
+  }
+
+  @Override
+  public void testDistinctHeadersAndTrailers(TestContext should) {
+
+    startServer(GrpcServer.server(vertx).callHandler(StreamingGrpc.getSourceMethod(), call -> {
+      call.handler(helloRequest -> {
+        GrpcServerResponse<Empty, Item> response = call.response();
+        response.end();
+      });
+    }));
+
+    super.testDistinctHeadersAndTrailers(should);
   }
 
   @Test

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
@@ -276,13 +276,11 @@ public class ServerRequestTest extends ServerTest {
     super.testHandleCancel(should);
   }
 
-  @Ignore
   @Test
   public void testEarlyHeadersOk(TestContext should) {
     testEarlyHeaders(GrpcStatus.OK, should);
   }
 
-  @Ignore
   @Test
   public void testEarlyHeadersInvalidArgument(TestContext should) {
     testEarlyHeaders(GrpcStatus.INVALID_ARGUMENT, should);
@@ -304,7 +302,7 @@ public class ServerRequestTest extends ServerTest {
         response.end(HelloReply.newBuilder().setMessage("the message").build());
       });
 
-//      response.writeHead();
+      response.writeHead();
     }));
 
     super.testEarlyHeaders(should, status, () -> continuation.get().run());


### PR DESCRIPTION
Motivation:
    
Grpc allows to send separate HTTP headers, we should implement it.
    
Changes:
    
Add and implement `GrpcServerResponse#writeHead`