### PR TITLE
Handle the gRPC-Web case of a response with no trailers set.

### DIFF
--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -147,7 +147,7 @@ public abstract class GrpcServerResponseImpl<Req, Resp> extends GrpcWriteStreamB
     encodeGrpcStatus(httpTrailers);
   }
 
-  protected void encodeGrpcTrailers(MultiMap grpcTrailers, MultiMap httpTrailers) {
+  protected final void encodeGrpcTrailers(MultiMap grpcTrailers, MultiMap httpTrailers) {
     if (grpcTrailers != null && !grpcTrailers.isEmpty()) {
       for (Map.Entry<String, String> header : grpcTrailers) {
         httpTrailers.add(header.getKey(), header.getValue());

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcServerResponse.java
@@ -68,12 +68,16 @@ public class WebGrpcServerResponse<Req, Resp> extends GrpcServerResponseImpl<Req
   @Override
   protected void setTrailers(MultiMap grpcTrailers) {
     if (isTrailersOnly()) {
-      encodeGrpcTrailers(grpcTrailers, httpResponse.headers());
+      if (grpcTrailers != null) {
+        encodeGrpcTrailers(grpcTrailers, httpResponse.headers());
+      }
     } else {
       MultiMap buffer = HttpHeaders.headers();
       super.encodeGrpcStatus(buffer);
       appendToTrailers(buffer);
-      appendToTrailers(grpcTrailers);
+      if (grpcTrailers != null) {
+        appendToTrailers(grpcTrailers);
+      }
     }
   }
 


### PR DESCRIPTION
Motivation:

When a gRPC-Web response has no trailers set, the response fails with a `NullPointerException` since it assumes the `trailers` is not null.
