### PR TITLE
Server cancellation in the usual case should happen using the grpc status and not a reset.

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
@@ -74,6 +74,7 @@ public class GrpcClientResponseImpl<Req, Resp> extends GrpcReadStreamBase<GrpcCl
       }
     }
     super.handleEnd();
+    request.handleStatus(status);
     if (!request.isTrailersSent()) {
       request.cancel();
     }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
@@ -68,4 +68,9 @@ public interface GrpcWriteStream<T> extends WriteStream<T> {
    */
   void cancel();
 
+  /**
+   * @return whether the stream is cancelled
+   */
+  boolean isCancelled();
+
 }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerMessageEncodingTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerMessageEncodingTest.java
@@ -29,6 +29,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcHeaderNames;
 import io.vertx.grpc.common.GrpcMessage;
+import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.GrpcServerResponse;
@@ -182,10 +183,9 @@ public class ServerMessageEncodingTest extends ServerTestBase {
       req.handler(msg -> {
         should.fail();
       });
-    }, req -> req.response().onComplete(should.asyncAssertFailure(err -> {
-      should.assertEquals(StreamResetException.class, err.getClass());
-      StreamResetException reset = (StreamResetException) err;
-      should.assertEquals(GrpcError.CANCELLED.http2ResetCode, reset.getCode());
+    }, req -> req.response().onComplete(should.asyncAssertSuccess(resp -> {
+      should.assertEquals(200, resp.statusCode());
+      should.assertEquals("" + GrpcStatus.CANCELLED.code, resp.getHeader("grpc-status"));
     })));
   }
 

--- a/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingGrpcServerResponse.java
+++ b/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingGrpcServerResponse.java
@@ -78,8 +78,9 @@ public class TranscodingGrpcServerResponse<Req, Resp> extends GrpcServerResponse
   }
 
   @Override
-  protected void sendCancel() {
+  protected boolean sendCancel() {
     httpResponse.setStatusCode(400);
     httpResponse.end();
+    return true;
   }
 }


### PR DESCRIPTION
Motivation:

Server cancellation is using reset frames to signal stream cancellation, instead it should send a grpc status response whenever possible.

Changes:

Change server cancellation to send a grpc status response instead of sending a reset frame.
