### PR TITLE
Add support for gRPC error metadata propagation

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/InvalidStatusException.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/InvalidStatusException.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.grpc.client;
 
+import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
 import io.vertx.grpc.common.GrpcStatus;
 
@@ -20,11 +21,13 @@ public final class InvalidStatusException extends VertxException {
 
   private final GrpcStatus expected;
   private final GrpcStatus actual;
+  private final MultiMap metadata;
 
-  public InvalidStatusException(GrpcStatus expected, GrpcStatus actual) {
+  public InvalidStatusException(GrpcStatus expected, GrpcStatus actual, MultiMap metadata) {
     super("Invalid status: actual:" + actual.name() + ", expected:" + expected.name());
     this.expected = expected;
     this.actual = actual;
+    this.metadata = metadata;
   }
 
   /**
@@ -40,4 +43,12 @@ public final class InvalidStatusException extends VertxException {
   public GrpcStatus actualStatus() {
     return actual;
   }
+
+  /**
+   * @return the server trailers
+   */
+  public MultiMap metadata() {
+    return metadata;
+  }
+
 }

--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientResponseImpl.java
@@ -112,7 +112,13 @@ public class GrpcClientResponseImpl<Req, Resp> extends GrpcReadStreamBase<GrpcCl
         }
         @Override
         public Throwable describe(Void value) {
-          return new InvalidStatusException(GrpcStatus.OK, status());
+          MultiMap metadata;
+          if (httpResponse.trailers().isEmpty()) { // TODO: Check if any payload has been parsed (needs GrpcReadStream modification)
+            metadata = httpResponse.headers(); // trailersOnly response
+          } else {
+            metadata = httpResponse.trailers();
+          }
+          return new InvalidStatusException(GrpcStatus.OK, status(), metadata);
         }
       });
   }

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
@@ -142,6 +142,7 @@ public class ClientRequestTest extends ClientTest {
             should.assertTrue(err instanceof InvalidStatusException);
             should.assertEquals(GrpcStatus.OK, ((InvalidStatusException)err).expectedStatus());
             should.assertEquals(GrpcStatus.UNAVAILABLE, ((InvalidStatusException)err).actualStatus());
+            should.assertEquals("error-value", ((InvalidStatusException)err).metadata().get("error-data"));
             latch2.complete();
           }));
         }));

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientTest.java
@@ -291,8 +291,10 @@ public abstract class ClientTest extends ClientTestBase {
     TestServiceGrpc.TestServiceImplBase called = new TestServiceGrpc.TestServiceImplBase() {
       @Override
       public void unary(Request request, StreamObserver<Reply> responseObserver) {
-        responseObserver.onError(Status.UNAVAILABLE
-          .withDescription("~Greeter temporarily unavailable...~").asRuntimeException());
+        Metadata metadata = new Metadata();
+        metadata.put(Metadata.Key.of("error-data", Metadata.ASCII_STRING_MARSHALLER), "error-value");
+        var re = Status.UNAVAILABLE.withDescription("~Greeter temporarily unavailable...~").asRuntimeException(metadata);
+        responseObserver.onError(re);
       }
     };
     startServer(called);

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
@@ -3,6 +3,7 @@ package examples.grpc;
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
 import io.vertx.core.streams.ReadStream;

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
@@ -5,6 +5,7 @@ package {{javaPackageFqn}};
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
 import io.vertx.core.streams.ReadStream;
@@ -95,7 +96,13 @@ class {{grpcClientFqn}}Impl implements {{grpcClientFqn}} {
       req.format(wireFormat);
       return req.end(request).compose(v -> req.response().flatMap(resp -> {
         if (resp.status() != null && resp.status() != GrpcStatus.OK) {
-          return Future.failedFuture(new io.vertx.grpc.client.InvalidStatusException(GrpcStatus.OK, resp.status()));
+            MultiMap metadata;
+            if (resp.trailers().isEmpty()) { // TODO: Check if any payload has been parsed (needs GrpcReadStream modification)
+              metadata = resp.headers(); // trailersOnly response
+            } else {
+              metadata = resp.trailers();
+            }
+          return Future.failedFuture(new io.vertx.grpc.client.InvalidStatusException(GrpcStatus.OK, resp.status(), metadata));
         } else {
           return Future.succeededFuture(resp);
         }
@@ -131,7 +138,13 @@ class {{grpcClientFqn}}Impl implements {{grpcClientFqn}} {
      .compose(req -> {
         return req.response().flatMap(resp -> {
           if (resp.status() != null && resp.status() != GrpcStatus.OK) {
-            return Future.failedFuture(new io.vertx.grpc.client.InvalidStatusException(GrpcStatus.OK, resp.status()));
+            MultiMap metadata;
+            if (resp.trailers().isEmpty()) {
+              metadata = resp.headers(); // trailersOnly response
+            } else {
+              metadata = resp.trailers();
+            }
+            return Future.failedFuture(new io.vertx.grpc.client.InvalidStatusException(GrpcStatus.OK, resp.status(), metadata));
           } else {
             return Future.succeededFuture(resp);
           }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcErrorInfoProvider.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcErrorInfoProvider.java
@@ -1,0 +1,41 @@
+package io.vertx.grpc.server;
+
+import io.vertx.core.MultiMap;
+import io.vertx.grpc.common.GrpcStatus;
+
+/**
+ * Interface for providing detailed error information in gRPC server responses.
+ * <p>
+ * Implementing this interface allows exceptions to expose structured gRPC error details,
+ * including a status a descriptive error message, and optional trailers.
+ * </p>
+ * <p>
+ * This design enables custom exceptions to propagate meaningful and rich error context to gRPC clients
+ * without coupling to a specific exception class.
+ * </p>
+ */
+
+public interface GrpcErrorInfoProvider {
+
+  /**
+   * Returns the GrpcStatus associated with this error.
+   *
+   * @return the gRPC status
+   */
+  GrpcStatus status();
+
+  /**
+   * Returns the gRPC error message to send to the client.
+   *
+   * @return the error message as a string
+   */
+  String message();
+
+  /**
+   * Returns optional key-value trailers to include in the response.
+   * Can be {@code null} or empty.
+   *
+   * @return containing error trailers
+   */
+  MultiMap trailers();
+}

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
@@ -81,7 +81,8 @@ public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
    * End the stream with an appropriate status message, when {@code failure} is
    *
    * <ul>
-   *   <li>{@link StatusException}, set status to {@link StatusException#status()} and status message to {@link StatusException#message()}</li>
+   *   <li>{@link StatusException}, set status to {@link StatusException#status()}, status message to {@link StatusException#message()} and associated metadata to {@link StatusException#trailers()}</li>
+   *   <li>Use any exception implementing {@link GrpcErrorInfoProvider} to propagate meaningful and rich error context to gRPC clients without coupling to a specific exception class.</li>
    *   <li>{@link UnsupportedOperationException} returns {@link GrpcStatus#UNIMPLEMENTED}</li>
    *   <li>otherwise returns {@link GrpcStatus#UNKNOWN}</li>
    * </ul>

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/StatusException.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/StatusException.java
@@ -10,40 +10,46 @@
  */
 package io.vertx.grpc.server;
 
+import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
 import io.vertx.grpc.common.GrpcStatus;
 
 /**
  * A glorified GOTO forcing a response status.
  */
-public final class StatusException extends VertxException {
+public final class StatusException extends VertxException implements GrpcErrorInfoProvider {
 
   private final GrpcStatus status;
   private final String message;
+  private final MultiMap trailers;
 
   public StatusException(GrpcStatus status) {
-    super("Grpc status " + status.name());
-    this.status = status;
-    this.message = null;
+    this(status, null, null);
   }
 
   public StatusException(GrpcStatus status, String message) {
+    this(status, message, null);
+  }
+
+  public StatusException(GrpcStatus status, String message, MultiMap trailers) {
     super("Grpc status " + status.name());
     this.status = status;
     this.message = message;
+    this.trailers = trailers;
   }
 
-  /**
-   * @return the status
-   */
+  @Override
   public GrpcStatus status() {
     return status;
   }
 
-  /**
-   * @return the status message
-   */
+  @Override
   public String message() {
     return message;
+  }
+
+  @Override
+  public MultiMap trailers() {
+    return trailers;
   }
 }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
@@ -144,6 +144,21 @@ public class ServerRequestTest extends ServerTest {
   }
 
   @Test
+  public void testStatusUnary5(TestContext should) {
+
+    MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
+    trailers.add("error-data", "error-value");
+
+    startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
+      call.handler(helloRequest -> {
+        throw new StatusException(GrpcStatus.ALREADY_EXISTS, "status-msg", trailers);
+      });
+    }));
+
+    super.testStatusUnary(should, Status.ALREADY_EXISTS, "status-msg", trailers);
+  }
+
+  @Test
   public void testStatusStreaming(TestContext should) {
     startServer(GrpcServer.server(vertx).callHandler(SOURCE, call -> {
       call.response().write(Reply.newBuilder().setMessage("msg1").build());

--- a/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
+++ b/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
@@ -9,6 +9,7 @@ import io.grpc.Deadline;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClientRequest;
 import io.vertx.grpc.client.GrpcClientResponse;
@@ -130,7 +131,14 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
                 if (grpcResponse.statusMessage() != null) {
                   status = status.withDescription(grpcResponse.statusMessage());
                 }
-                trailers = io.vertx.grpcio.common.impl.Utils.readMetadata(grpcResponse.trailers());
+                MultiMap responseTrailers;
+                boolean trailersOnly = grpcResponse.trailers().isEmpty();
+                if (trailersOnly) {
+                  responseTrailers = grpcResponse.headers();
+                } else {
+                  responseTrailers = grpcResponse.trailers();
+                }
+                trailers = io.vertx.grpcio.common.impl.Utils.readMetadata(responseTrailers);
               } else {
                 status = Status.fromThrowable(ar.cause());
                 trailers = new Metadata();


### PR DESCRIPTION
This PR introduces support for propagating structured gRPC error metadata from the server to the client across the Vert.x gRPC stack. It allows both client and server components to handle and transmit metadata in error responses consistently.

Motivation:
Handling rich error information in gRPC is critical for debugging, client behavior, and user feedback. Until now, only status codes and messages were propagated, with no support for custom trailers or metadata.

This change allows:
- Server-side exceptions to carry metadata.
- Middleware and clients to access that metadata.
- End-to-end visibility of error context for both internal and external clients.

This feature is required for internal use at our company, where we rely on Vert.x-based gRPC services and need to provide detailed error context (status, message, and metadata) from server to client. Without this functionality, we are unable to fully adopt vertx-grpc in our projects.

**Changes**
 
Server
Created GrpcErrorInfoProvider interface to allow exceptions to expose:

- A GrpcStatus
- A message
- Metadata (io.vertx.core.MultiMap)

Made existing StatusException implement GrpcErrorInfoProvider and adapt GrpcServerResponseImpl to return the metadata from GrpcErrorInfoProvider

Client
Updated InvalidStatusException to include a metadata field.
Modified GrpcClientResponseImpl and the gRPC proto plugin to populate the metadata field when the returned status is not GrpcStatus.OK.

Vert.x gRPC-IO Layer
Server: Inject metadata into StatusRuntimeException for correct transmission to clients.
Client: Parse metadata from headers if the response is trailersOnly, not just from trailers.

Improved (but still not ideal) detection of trailersOnly responses by checking if a payload has been read.