### PR TITLE
Use the correct method in context storage context duplication.

### DIFF
--- a/vertx-grpcio-context-storage/src/main/java/io/grpc/override/ContextStorageOverride.java
+++ b/vertx-grpcio-context-storage/src/main/java/io/grpc/override/ContextStorageOverride.java
@@ -21,20 +21,12 @@ public class ContextStorageOverride extends Context.Storage {
     // Do not remove, empty constructor required by gRPC
   }
 
-  private static ContextInternal duplicate(ContextInternal context) {
-    ContextInternal dup = context.duplicate();
-    if (context.isDuplicate()) {
-      dup.localContextData().putAll(context.localContextData()); // For now hand rolled  but should be handled by context duplication
-    }
-    return dup;
-  }
-
   @Override
   public Context doAttach(Context toAttach) {
     ContextInternal vertxContext = vertxContext();
     Context toRestoreLater;
     if (vertxContext != null) {
-      ContextInternal next = duplicate(vertxContext);
+      ContextInternal next = vertxContext.duplicate(true);
       ContextInternal prev = next.beginDispatch();
       next.putLocal(ContextStorageService.CONTEXT_LOCAL, SAME_THREAD, new GrpcStorage(toAttach, prev));
       GrpcStorage local = next.getLocal(ContextStorageService.CONTEXT_LOCAL, SAME_THREAD);

--- a/vertx-grpcio-context-storage/src/test/java/io/vertx/grpc/context/storage/CopiableObject.java
+++ b/vertx-grpcio-context-storage/src/test/java/io/vertx/grpc/context/storage/CopiableObject.java
@@ -1,0 +1,14 @@
+package io.vertx.grpc.context.storage;
+
+public class CopiableObject {
+
+  public final CopiableObject ref;
+
+  public CopiableObject(CopiableObject ref) {
+    this.ref = ref;
+  }
+
+  public CopiableObject() {
+    this.ref = null;
+  }
+}

--- a/vertx-grpcio-context-storage/src/test/java/io/vertx/grpc/context/storage/MockContextStorage.java
+++ b/vertx-grpcio-context-storage/src/test/java/io/vertx/grpc/context/storage/MockContextStorage.java
@@ -1,0 +1,22 @@
+package io.vertx.grpc.context.storage;
+
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+import io.vertx.grpc.contextstorage.GrpcStorage;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Register the local storage.
+ */
+public class MockContextStorage implements VertxServiceProvider {
+
+  public static final ContextLocal<CopiableObject> CONTEXT_LOCAL = ContextLocal.registerLocal(CopiableObject.class,
+    CopiableObject::new);
+
+  @Override
+  public void init(VertxBootstrap builder) {
+  }
+}

--- a/vertx-grpcio-context-storage/src/test/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/vertx-grpcio-context-storage/src/test/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.vertx.grpc.context.storage.MockContextStorage


### PR DESCRIPTION
Motivation:

gRPC IO context storage requires to copy the vertx context, at the moment the copy is hand rolled and only affects the context local map.

Instead it should use the copying variant of duplicate.

Changes:

Replace the hand rolled duplication by the copying variant of `ContexInternal#duplicate`
