### PR TITLE
GrpcIo server bridge should resume reading message when sending an error

### DIFF
--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServiceBridgeImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServiceBridgeImpl.java
@@ -113,7 +113,9 @@ public class GrpcServiceBridgeImpl implements GrpcServiceBridge, GrpcIoServiceBr
         }
         @Override
         protected void handleMessage(Req msg) {
-          listener.onMessage(msg);
+          if (!closed) {
+            listener.onMessage(msg);
+          }
         }
       };
       this.writeAdapter = new WriteStreamAdapter<Resp>() {
@@ -189,6 +191,7 @@ public class GrpcServiceBridgeImpl implements GrpcServiceBridge, GrpcIoServiceBr
         throw new IllegalStateException("Already closed");
       }
       closed = true;
+      readAdapter.request(Integer.MAX_VALUE);
       GrpcServerResponse<Req, Resp> response = req.response();
       if (status == Status.OK && methodDef.getMethodDescriptor().getType().serverSendsOneMessage() && messagesSent == 0) {
         response.status(GrpcStatus.UNAVAILABLE).end();


### PR DESCRIPTION
Motivation:

The GrpcIo server bridge does not resume reading message when sending an error.

When an error happens in `StreamObserver.onNext`, the caller does not request a new message leading to stopping the consumption of messages.

Although the grpc response is properly sent to the client, this can lead to a dead-lock when the client sends many messages.

Changes:

When the GrpcIo server bridge sends a response, resume the stream adapter to release messages.

Avoid dispatching to `StreamObserver.onNext` when the stream is closed.
