### PR TITLE
Switch docs to use asciidoc tabs for dependency references

### DIFF
--- a/vertx-grpc-docs/src/main/asciidoc/client.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/client.adoc
@@ -6,8 +6,10 @@ The Vert.x gRPC Client provides a gRPC request/response oriented API as well as 
 
 To use Vert.x gRPC Client, add the following dependency to the _dependencies_ section of your build descriptor:
 
-* Maven (in your `pom.xml`):
-
+[tabs]
+====
+pom.xml::
++
 [source,xml,subs="+attributes"]
 ----
 <dependency>
@@ -17,14 +19,15 @@ To use Vert.x gRPC Client, add the following dependency to the _dependencies_ se
 </dependency>
 ----
 
-* Gradle (in your `build.gradle` file):
-
+build.gradle::
++
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
   compile 'io.vertx:vertx-grpc-client:${maven.version}'
 }
 ----
+====
 
 === Creating a gRPC client
 

--- a/vertx-grpc-docs/src/main/asciidoc/ioclient.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/ioclient.adoc
@@ -8,8 +8,10 @@ This client provides a generated stub approach with a gRPC Channel
 
 To use Vert.x gRPC/IO Client, add the following dependency to the _dependencies_ section of your build descriptor:
 
-* Maven (in your `pom.xml`):
-
+[tabs]
+====
+pom.xml::
++
 [source,xml,subs="+attributes"]
 ----
 <dependency>
@@ -19,14 +21,15 @@ To use Vert.x gRPC/IO Client, add the following dependency to the _dependencies_
 </dependency>
 ----
 
-* Gradle (in your `build.gradle` file):
-
+build.gradle::
++
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
   compile 'io.vertx:vertx-grpcio-client:${maven.version}'
 }
 ----
+====
 
 === gRPC channel
 

--- a/vertx-grpc-docs/src/main/asciidoc/ioserver.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/ioserver.adoc
@@ -8,8 +8,10 @@ This server provides compatibility with the _grpc-java_ generated stub approach 
 
 To use Vert.x gRPC/IO Server, add the following dependency to the _dependencies_ section of your build descriptor:
 
-* Maven (in your `pom.xml`):
-
+[tabs]
+====
+pom.xml::
++
 [source,xml,subs="+attributes"]
 ----
 <dependency>
@@ -19,14 +21,15 @@ To use Vert.x gRPC/IO Server, add the following dependency to the _dependencies_
 </dependency>
 ----
 
-* Gradle (in your `build.gradle` file):
-
+build.gradle::
++
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
   compile 'io.vertx:vertx-grpcio-server:${maven.version}'
 }
 ----
+====
 
 === Service bridge
 

--- a/vertx-grpc-docs/src/main/asciidoc/iostorage.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/iostorage.adoc
@@ -23,8 +23,10 @@ It is not propagated if, for example, you invoke a stub on a non-Vert.x thread o
 
 To use Vert.x gRPC Context Storage, add the following dependency to the _dependencies_ section of your build descriptor:
 
-* Maven (in your `pom.xml`):
-
+[tabs]
+====
+pom.xml::
++
 [source,xml,subs="+attributes"]
 ----
 <dependency>
@@ -34,11 +36,12 @@ To use Vert.x gRPC Context Storage, add the following dependency to the _depende
 </dependency>
 ----
 
-* Gradle (in your `build.gradle` file):
-
+build.gradle::
++
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
   compile 'io.vertx:vertx-grpc-context-storage:${maven.version}'
 }
 ----
+====

--- a/vertx-grpc-docs/src/main/asciidoc/server.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/server.adoc
@@ -8,8 +8,10 @@ This server provides a gRPC request/response oriented API as well as a generated
 
 To use Vert.x gRPC Server, add the following dependency to the _dependencies_ section of your build descriptor:
 
-* Maven (in your `pom.xml`):
-
+[tabs]
+====
+pom.xml::
++
 [source,xml,subs="+attributes"]
 ----
 <dependency>
@@ -19,14 +21,16 @@ To use Vert.x gRPC Server, add the following dependency to the _dependencies_ se
 </dependency>
 ----
 
-* Gradle (in your `build.gradle` file):
-
+build.gradle::
++
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
   compile 'io.vertx:vertx-grpc-server:${maven.version}'
 }
 ----
+====
+
 
 === Creating a gRPC server
 
@@ -362,8 +366,10 @@ Support for the https://grpc.io/docs/guides/reflection/[gRPC reflection service]
 
 To use the Reflection service, add the following dependency:
 
-* Maven (in your `pom.xml`):
-
+[tabs]
+====
+pom.xml::
++
 [source,xml,subs="+attributes"]
 ----
 <dependency>
@@ -373,14 +379,15 @@ To use the Reflection service, add the following dependency:
 </dependency>
 ----
 
-* Gradle (in your `build.gradle` file):
-
+build.gradle::
++
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
   compile 'io.vertx:vertx-grpc-reflection:${maven.version}'
 }
 ----
+====
 
 You can then deploy the reflection service in your server:
 
@@ -404,8 +411,10 @@ It implements two RPCs:
 
 To use the Health Service, add the following dependency:
 
-* Maven (in your `pom.xml`):
-
+[tabs]
+====
+pom.xml::
++
 [source,xml,subs="+attributes"]
 ----
 <dependency>
@@ -415,14 +424,15 @@ To use the Health Service, add the following dependency:
 </dependency>
 ----
 
-* Gradle (in your `build.gradle` file):
-
+build.gradle::
++
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
   compile 'io.vertx:vertx-grpc-health:${maven.version}'
 }
 ----
+====
 
 Here's how to create and bind a Health service to your gRPC server:
 

--- a/vertx-grpc-docs/src/main/asciidoc/transcoding.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/transcoding.adoc
@@ -15,10 +15,12 @@ NOTE: transcoding is in tech preview in Vert.x 5.0 until the API becomes stable.
 
 === Using transcoding
 
-To use Vert.x gRPC transcoding, add the following dependency to the _dependencies_ section of your build descriptor:
+To use the Transcoding, add the following dependency:
 
-* Maven (in your `pom.xml`):
-
+[tabs]
+====
+pom.xml::
++
 [source,xml,subs="+attributes"]
 ----
 <dependency>
@@ -28,14 +30,15 @@ To use Vert.x gRPC transcoding, add the following dependency to the _dependencie
 </dependency>
 ----
 
-* Gradle (in your `build.gradle` file):
-
+build.gradle::
++
 [source,groovy,subs="+attributes"]
 ----
 dependencies {
   compile 'io.vertx:vertx-grpc-transcoding:${maven.version}'
 }
 ----
+====
 
 === Idiomatic transcoding generation
 


### PR DESCRIPTION
Switch docs to use asciidoc tabs for dependency references
