### PR TITLE
Refactor gRPC test to use Jash for process execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>dev.jbang</groupId>
+        <artifactId>jash</artifactId>
+        <version>0.0.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty-shaded</artifactId>
         <version>${grpc.version}</version>

--- a/vertx-grpc-it/pom.xml
+++ b/vertx-grpc-it/pom.xml
@@ -79,6 +79,11 @@
       <artifactId>bcpkix-jdk15on</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>dev.jbang</groupId>
+      <artifactId>jash</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This pull request introduces a new test dependency and refactors the `ReflectionTest` to use Jash to simplify working with cli tools.