### PR TITLE
Add more logging for when 415 error is returned

### DIFF
--- a/vertx-grpc-server/pom.xml
+++ b/vertx-grpc-server/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -16,6 +16,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.core.internal.logging.Logger;
@@ -82,6 +83,7 @@ public class GrpcServerImpl implements GrpcServer, Closeable {
         return;
       }
     } else {
+      log.trace("invalid content-type header " + httpRequest.getHeader(HttpHeaders.CONTENT_TYPE) + ", sending error 415");
       httpRequest.response().setStatusCode(415).end();
       return;
     }
@@ -116,7 +118,7 @@ public class GrpcServerImpl implements GrpcServer, Closeable {
   private int validate(GrpcServerRequestInspector.RequestInspectionDetails details) {
     // Check HTTP version compatibility
     if (!details.protocol.accepts(details.version)) {
-      log.trace(details.protocol.name() + " not supported on " + details.version + ", sending error 415");
+      log.trace(details.protocol.mediaType() + " not supported on " + details.version + ", sending error 415");
       return 415;
     }
 

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/InvalidContentTypeHeaderTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/InvalidContentTypeHeaderTest.java
@@ -13,52 +13,35 @@ package io.vertx.tests.server;
 import io.vertx.core.http.*;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.GrpcHeaderNames;
-import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerOptions;
 import org.junit.Test;
 
-public class ProtocolSupportTest extends ServerTestBase {
+public class InvalidContentTypeHeaderTest extends ServerTestBase {
 
   private HttpClient client;
 
   @Test
-  public void testDisableHTTP2(TestContext should) {
-    testDisableProtocol(should, "application/grpc", GrpcProtocol.HTTP_2, HttpVersion.HTTP_2);
+  public void testInvalidContentTypeHttp2(TestContext should) {
+    testInvalidContentType(should, "application/invalid-grpc");
   }
 
   @Test
-  public void testInvalidHTTP2(TestContext should) {
-    testDisableProtocol(should, "application/grpc", null, HttpVersion.HTTP_1_1);
+  public void testInvalidContentTypeWeb(TestContext should) {
+    testInvalidContentType(should, "application/invalid-grpc-web");
   }
 
   @Test
-  public void testDisableWeb(TestContext should) {
-    testDisableProtocol(should, "application/grpc-web", GrpcProtocol.WEB, HttpVersion.HTTP_2);
+  public void testInvalidContentTypeNull(TestContext should) {
+    testInvalidContentType(should, null);
   }
 
-  @Test
-  public void testDisableWebHttp11(TestContext should) {
-    testDisableProtocol(should, "application/grpc-web", GrpcProtocol.WEB, HttpVersion.HTTP_1_1);
-  }
+  private void testInvalidContentType(TestContext should, String contentType) {
 
-  @Test
-  public void testDisableWebText(TestContext should) {
-    testDisableProtocol(should, "application/grpc-web-text", GrpcProtocol.WEB_TEXT, HttpVersion.HTTP_1_1);
-  }
-
-  private void testDisableProtocol(TestContext should, String contentType, GrpcProtocol protocol, HttpVersion version) {
-
-    GrpcServerOptions options;
-    if (protocol != null) {
-      options = new GrpcServerOptions().removeEnabledProtocol(protocol);
-    } else {
-      options = new GrpcServerOptions();
-    }
-    startServer(GrpcServer.server(vertx, options));
+    startServer(GrpcServer.server(vertx, new GrpcServerOptions()));
 
     client = vertx.createHttpClient(new HttpClientOptions()
-      .setProtocolVersion(version)
+      .setProtocolVersion(HttpVersion.HTTP_2)
       .setHttp2ClearTextUpgrade(true)
     );
 

--- a/vertx-grpc-server/src/test/resources/simplelogger.properties
+++ b/vertx-grpc-server/src/test/resources/simplelogger.properties
@@ -1,0 +1,11 @@
+# Default level for everything else
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+# Enable TRACE for Vert.x
+org.slf4j.simpleLogger.log.io.vertx=trace
+org.slf4j.simpleLogger.log.io.vertx.core.net.impl.NetServerImpl=info
+
+# Optional but handy output tweaks
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS
+org.slf4j.simpleLogger.showThreadName=true


### PR DESCRIPTION
Motivation:

When trying to resolve bug #207 I found that the server was not logging the reason for the 415 error which meant I had to add my own logging for before calling the `grpcServer.handle` method. This change extends the log output to cover all cases when 415 error is returned.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

Changes:
Add more logging for when 415 error is returned
- add trace when invalid content-type
- refine trace when content-type doesn't match HTTP version
- also: configure SLF4J simple logging when running tests to see trace output
