### PR TITLE
Replace `protobuf-maven-plugin` with `ascopes-protobuf-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
     <jprotoc.version>1.2.2</jprotoc.version>
     <protoc.version>4.29.3</protoc.version>
     <protobuf.version>4.29.3</protobuf.version>
+    <!-- NOTE: We need to stay on version 3.x of ascopes protobuf maven plugin until we bump minimum version of java from
+     java 11 to java 17 as starting from 4.x minimum required version is java 17.
+     See: https://ascopes.github.io/protobuf-maven-plugin/plugin-info.html#system-requirements-history
+     -->
+    <protobuf.maven.plugin.version>3.10.2</protobuf.maven.plugin.version>
     <jmh.version>1.37</jmh.version>
   </properties>
 
@@ -220,13 +225,6 @@
   </modules>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.1</version>
-      </extension>
-    </extensions>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -248,29 +246,28 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.xolstice.maven.plugins</groupId>
-          <artifactId>protobuf-maven-plugin</artifactId>
-          <version>0.6.1</version>
-          <configuration>
-            <!--
-              The version of protoc must match protobuf-java. If you don't depend on
-              protobuf-java directly, you will be transitively depending on the
-              protobuf-java version that grpc depends on.
-            -->
-            <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
-            <pluginId>grpc-java</pluginId>
-            <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-            <!-- Skip generating @javax.annotation.Generated which creates split packages  -->
-            <pluginParameter>@generated=omit</pluginParameter>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>io.github.ascopes</groupId>
           <artifactId>protobuf-maven-plugin</artifactId>
-          <version>3.8.2</version>
+          <version>${protobuf.maven.plugin.version}</version>
           <configuration>
             <protocVersion>${protobuf.version}</protocVersion>
           </configuration>
+          <executions>
+            <execution>
+              <id>test-compile</id>
+              <configuration>
+                <binaryMavenPlugins>
+                  <binaryMavenPlugin>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>protoc-gen-grpc-java</artifactId>
+                    <version>${grpc.version}</version>
+                    <!-- Skip generating @javax.annotation.Generated which creates split packages  -->
+                    <options>@generated=omit</options>
+                  </binaryMavenPlugin>
+                </binaryMavenPlugins>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/vertx-grpc-common/pom.xml
+++ b/vertx-grpc-common/pom.xml
@@ -59,14 +59,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
+        <groupId>io.github.ascopes</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>test-compile</id>
             <goals>
-              <goal>test-compile</goal>
-              <goal>test-compile-custom</goal>
+              <goal>generate-test</goal>
             </goals>
           </execution>
         </executions>

--- a/vertx-grpc-docs/pom.xml
+++ b/vertx-grpc-docs/pom.xml
@@ -116,6 +116,16 @@
               <goal>generate</goal>
             </goals>
           </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>generate-test</goal>
+            </goals>
+            <configuration>
+              <sourceDirectories>${project.basedir}/src/main/proto</sourceDirectories>
+              <javaEnabled>false</javaEnabled>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/vertx-grpc-health/pom.xml
+++ b/vertx-grpc-health/pom.xml
@@ -85,20 +85,19 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
+        <groupId>io.github.ascopes</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>test-compile</id>
             <goals>
-              <goal>test-compile</goal>
-              <goal>test-compile-custom</goal>
+              <goal>generate-test</goal>
             </goals>
           </execution>
           <execution>
             <id>compile</id>
             <goals>
-              <goal>compile</goal>
+              <goal>generate</goal>
             </goals>
           </execution>
         </executions>

--- a/vertx-grpc-reflection/pom.xml
+++ b/vertx-grpc-reflection/pom.xml
@@ -85,20 +85,19 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
+        <groupId>io.github.ascopes</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>test-compile</id>
             <goals>
-              <goal>test-compile</goal>
-              <goal>test-compile-custom</goal>
+              <goal>generate-test</goal>
             </goals>
           </execution>
           <execution>
             <id>compile</id>
             <goals>
-              <goal>compile</goal>
+              <goal>generate</goal>
             </goals>
           </execution>
         </executions>

--- a/vertx-grpc-server/pom.xml
+++ b/vertx-grpc-server/pom.xml
@@ -83,14 +83,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
+        <groupId>io.github.ascopes</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>test-compile</id>
             <goals>
-              <goal>test-compile</goal>
-              <goal>test-compile-custom</goal>
+              <goal>generate-test</goal>
             </goals>
           </execution>
         </executions>

--- a/vertx-grpcio-context-storage/pom.xml
+++ b/vertx-grpcio-context-storage/pom.xml
@@ -56,14 +56,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
+        <groupId>io.github.ascopes</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>test-compile</id>
             <goals>
-              <goal>test-compile</goal>
-              <goal>test-compile-custom</goal>
+              <goal>generate-test</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Motivation:

Replace `protobuf-maven-plugin` with `ascopes-protobuf-maven-plugin` across modules and update configurations.

Supersedes: #143 