### PR TITLE
VertxClientCall should use the correct trailers.

### DIFF
--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
@@ -385,8 +385,19 @@ public class ClientRequestTest extends ClientTest {
 
   @Test
   public void testMetadata(TestContext should) throws Exception {
+    List<String> steps = testMetadata(should, Status.OK);
+    should.assertEquals(Arrays.asList("intercept_call", "unary", "send_headers", "close", "response_handler", "end_handler"), steps);
+  }
 
-    super.testMetadata(should);
+  @Test
+  public void testMetadataTrailersOnly(TestContext should) throws Exception {
+    List<String> steps = testMetadata(should, Status.CANCELLED);
+    should.assertEquals(Arrays.asList("intercept_call", "unary", "close", "response_handler", "end_handler"), steps);
+  }
+
+  public List<String> testMetadata(TestContext should, Status status) throws Exception {
+
+    List<String> seq = super.testMetadata(should, status);
 
     Async test = should.async();
     client = GrpcClient.client(vertx);
@@ -397,24 +408,31 @@ public class ClientRequestTest extends ClientTest {
         callRequest.headers().set("grpc-custom_request_header", "grpc-custom_request_header_value");
         callRequest.headers().set("grpc-custom_request_header-bin", Base64.getEncoder().encodeToString(new byte[] { 2,1,0 }));
         callRequest.response().onComplete(should.asyncAssertSuccess(callResponse -> {
-          should.assertEquals("custom_response_header_value", callResponse.headers().get("custom_response_header"));
-          int step = testMetadataStep.getAndIncrement();
-          should.assertTrue(2 <= step && step <= 3);
+          if (status == Status.OK) {
+            should.assertEquals("custom_response_header_value", callResponse.headers().get("custom_response_header"));
+          } else {
+            should.assertEquals("custom_response_trailer_value", callResponse.headers().get("custom_response_trailer"));
+          }
+          seq.add("response_handler");
           AtomicInteger count = new AtomicInteger();
           callResponse.handler(reply -> {
             should.assertEquals(1, count.incrementAndGet());
             should.assertEquals("Hello Julien", reply.getMessage());
           });
           callResponse.endHandler(v2 -> {
-            should.assertEquals(GrpcStatus.OK, callResponse.status());
-            should.assertEquals("custom_response_trailer_value", callResponse.trailers().get("custom_response_trailer"));
-            should.assertEquals(1, count.get());
-            should.assertEquals(4, testMetadataStep.getAndIncrement());
+            should.assertEquals(GrpcStatus.valueOf(status.getCode().value()), callResponse.status());
+            String expected = status == Status.OK ? "custom_response_trailer_value" : null;
+            should.assertEquals(expected, callResponse.trailers().get("custom_response_trailer"));
+            seq.add("end_handler");
             test.complete();
           });
         }));
         callRequest.end(Request.newBuilder().setName("Julien").build());
       }));
+
+    test.awaitSuccess(20_000);
+
+    return seq;
   }
 
   @Test

--- a/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
+++ b/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
@@ -102,6 +102,8 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
 
             grpcResponse = ar2.result();
 
+            boolean trailersOnly = grpcResponse.status() != null;
+
             if (sf != null) {
               grpcResponse.end().onComplete(ar -> {
                 sf.cancel(false);
@@ -130,7 +132,7 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
                 if (grpcResponse.statusMessage() != null) {
                   status = status.withDescription(grpcResponse.statusMessage());
                 }
-                trailers = io.vertx.grpcio.common.impl.Utils.readMetadata(grpcResponse.trailers());
+                trailers = io.vertx.grpcio.common.impl.Utils.readMetadata(trailersOnly ? grpcResponse.headers() : grpcResponse.trailers());
               } else {
                 status = Status.fromThrowable(ar.cause());
                 trailers = new Metadata();

--- a/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
+++ b/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -361,10 +362,21 @@ public class ClientBridgeTest extends ClientTest {
     ((ClientCallStreamObserver<?>) sink).cancel("cancelled", new Exception());
   }
 
-  @Override
+  @Test
   public void testMetadata(TestContext should) throws Exception {
+    List<String> steps = testMetadata(should, Status.OK);
+    should.assertEquals(Arrays.asList("intercept_call", "unary", "send_headers", "close", "on_headers", "on_close"), steps);
+  }
 
-    super.testMetadata(should);
+  @Test
+  public void testMetadataTrailersOnly(TestContext should) throws Exception {
+    List<String> steps = testMetadata(should, Status.CANCELLED);
+    should.assertEquals(Arrays.asList("intercept_call", "unary", "close", "on_headers", "on_close"), steps);
+  }
+
+  public List<String> testMetadata(TestContext should, Status status) throws Exception {
+
+    List<String> steps = super.testMetadata(should, status);
 
     client = GrpcIoClient.client(vertx);
     GrpcIoClientChannel channel = new GrpcIoClientChannel(client, SocketAddress.inetSocketAddress(port, "localhost"));
@@ -382,16 +394,18 @@ public class ClientBridgeTest extends ClientTest {
             super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
               @Override
               public void onHeaders(Metadata headers) {
-                should.assertEquals(3, testMetadataStep.getAndIncrement());
-                should.assertEquals("custom_response_header_value", headers.get(Metadata.Key.of("custom_response_header", Metadata.ASCII_STRING_MARSHALLER)));
-                assertEquals(should, new byte[] { 0,1,2 }, headers.get(Metadata.Key.of("custom_response_header-bin", Metadata.BINARY_BYTE_MARSHALLER)));
-                should.assertEquals("grpc-custom_response_header_value", headers.get(Metadata.Key.of("grpc-custom_response_header", Metadata.ASCII_STRING_MARSHALLER)));
-                assertEquals(should, new byte[] { 2,1,0 }, headers.get(Metadata.Key.of("grpc-custom_response_header-bin", Metadata.BINARY_BYTE_MARSHALLER)));
+                steps.add("on_headers");
+                if (status == Status.OK) {
+                  should.assertEquals("custom_response_header_value", headers.get(Metadata.Key.of("custom_response_header", Metadata.ASCII_STRING_MARSHALLER)));
+                  assertEquals(should, new byte[] { 0,1,2 }, headers.get(Metadata.Key.of("custom_response_header-bin", Metadata.BINARY_BYTE_MARSHALLER)));
+                  should.assertEquals("grpc-custom_response_header_value", headers.get(Metadata.Key.of("grpc-custom_response_header", Metadata.ASCII_STRING_MARSHALLER)));
+                  assertEquals(should, new byte[] { 2,1,0 }, headers.get(Metadata.Key.of("grpc-custom_response_header-bin", Metadata.BINARY_BYTE_MARSHALLER)));
+                }
                 super.onHeaders(headers);
               }
               @Override
               public void onClose(Status status, Metadata trailers) {
-                should.assertEquals(4, testMetadataStep.getAndIncrement());
+                steps.add("on_close");
                 should.assertEquals("custom_response_trailer_value", trailers.get(Metadata.Key.of("custom_response_trailer", Metadata.ASCII_STRING_MARSHALLER)));
                 assertEquals(should, new byte[] { 0,1,2 }, trailers.get(Metadata.Key.of("custom_response_trailer-bin", Metadata.BINARY_BYTE_MARSHALLER)));
                 should.assertEquals("grpc-custom_response_trailer_value", trailers.get(Metadata.Key.of("grpc-custom_response_trailer", Metadata.ASCII_STRING_MARSHALLER)));
@@ -406,10 +420,15 @@ public class ClientBridgeTest extends ClientTest {
 
     TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(ClientInterceptors.intercept(channel, interceptor));
     Request request = Request.newBuilder().setName("Julien").build();
-    Reply res = stub.unary(request);
-    should.assertEquals("Hello Julien", res.getMessage());
+    try {
+      Reply res = stub.unary(request);
+      should.assertEquals("Hello Julien", res.getMessage());
+      should.assertEquals(Status.OK, status);
+    } catch (StatusRuntimeException e) {
+      should.assertEquals(status, e.getStatus());
+    }
 
-    should.assertEquals(5, testMetadataStep.get());
+    return steps;
   }
 
   @Test


### PR DESCRIPTION
Motivation:

VertxClientCall incorrectly assumes that gRPC metadata trailers correspond to the response trailers and gets wrong for trailers-only responses.

Changes:

VertxClientCall uses the response metadata headers for trailers-only responses, otherwise it should use headers.
