### PR TITLE
VertxClientCall should use the correct trailers.

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/VertxClientCall.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/VertxClientCall.java
@@ -82,6 +82,7 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
 
             grpcResponse = ar2.result();
 
+            boolean trailersOnly = grpcResponse.status() != null;
             String respEncoding = grpcResponse.encoding();
             Decompressor decompressor = DecompressorRegistry.getDefaultInstance().lookupDecompressor(respEncoding);
 
@@ -104,7 +105,7 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
                 if (grpcResponse.statusMessage() != null) {
                   status = status.withDescription(grpcResponse.statusMessage());
                 }
-                trailers = Utils.readMetadata(grpcResponse.trailers());
+                trailers = Utils.readMetadata(trailersOnly ? grpcResponse.headers() : grpcResponse.trailers());
               } else {
                 status = Status.fromThrowable(ar.cause());
                 trailers = new Metadata();


### PR DESCRIPTION
Motivation:

VertxClientCall incorrectly assumes that gRPC metadata trailers correspond to the response trailers and gets wrong for trailers-only responses.

Changes:

VertxClientCall uses the response metadata headers for trailers-only responses, otherwise it should use headers.
