### PR TITLE
GrpcServiceBridge should only use client accepted encodings.

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
@@ -17,9 +17,12 @@ public interface GrpcWriteStream<T> extends WriteStream<T> {
   MultiMap headers();
 
   /**
-   * Set the stream encoding, e.g {@code identity} or {@code gzip}.
+   * <p>Set the stream encoding, e.g. {@code identity} or {@code gzip},</p>
    *
-   * It must be called before sending any message, otherwise {@code identity will be used.
+   * <ul>
+   *   <li>The encoding must be set before sending any message, otherwise {@code identity} will be used.</li>
+   *   <li>The encoding should also match the opposite endpoint expectations.</li>
+   * </ul>
    *
    * @param encoding the target message encoding
    * @return a reference to this, so the API can be used fluently

--- a/vertx-grpc-server/src/main/asciidoc/server.adoc
+++ b/vertx-grpc-server/src/main/asciidoc/server.adoc
@@ -113,7 +113,10 @@ You can check the writability of a response and set a drain handler
 
 === Compression
 
-You can compress response messages by setting the response encoding *prior* before sending any message
+You can compress response messages by setting the response encoding *prior* before sending any message.
+
+Before setting the encoding, you should use {@link io.vertx.grpc.server.GrpcServerResponse#acceptedEncodings()} to ensure
+the client RPC supports the encoding algorithm.
 
 [source,java]
 ----

--- a/vertx-grpc-server/src/main/java/examples/GrpcServerExamples.java
+++ b/vertx-grpc-server/src/main/java/examples/GrpcServerExamples.java
@@ -118,7 +118,9 @@ public class GrpcServerExamples {
   }
 
   public void responseCompression(GrpcServerResponse<Empty, Item> response) {
-    response.encoding("gzip");
+    if (response.acceptedEncodings().contains("gzip")) {
+      response.encoding("gzip");
+    }
 
     // Write items after encoding has been defined
     response.write(Item.newBuilder().setValue("item-1").build());

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
@@ -20,6 +20,8 @@ import io.vertx.core.streams.ReadStream;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.GrpcWriteStream;
 
+import java.util.Set;
+
 @VertxGen
 public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
 
@@ -43,6 +45,13 @@ public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
 
   @Fluent
   GrpcServerResponse<Req, Resp> encoding(String encoding);
+
+  /**
+   * @return the set of accepted encodings sent by the client, note that {@code identity} should not be part of this set.
+   *         This can be used to set the response {@link #encoding(String) encoding} to ensure the client will accept
+   *         the encoding. This is a glorified wrapper for the {@code grpc-accept-encoding} header.
+   */
+  Set<String> acceptedEncodings();
 
   /**
    * @return the {@link MultiMap} to write metadata trailers

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServiceBridgeImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServiceBridgeImpl.java
@@ -217,7 +217,10 @@ public class GrpcServiceBridgeImpl implements GrpcServiceBridge, GrpcIoServiceBr
     @Override
     public void setCompression(String encoding) {
       compressor = CompressorRegistry.getDefaultInstance().lookupCompressor(encoding);
-      req.response().encoding(encoding);
+      GrpcServerResponse<Req, Resp> response = req.response();
+      if (response.acceptedEncodings().contains(encoding)) {
+        response.encoding(encoding);
+      }
     }
 
     @Override

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerBridgeTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerBridgeTest.java
@@ -10,26 +10,13 @@
  */
 package io.vertx.grpc.server;
 
-import io.grpc.Attributes;
-import io.grpc.ForwardingServerCall;
-import io.grpc.ForwardingServerCallListener;
-import io.grpc.Grpc;
-import io.grpc.ManagedChannelBuilder;
-import io.grpc.Metadata;
-import io.grpc.ServerCall;
-import io.grpc.ServerCallHandler;
-import io.grpc.ServerInterceptor;
-import io.grpc.ServerInterceptors;
-import io.grpc.ServerServiceDefinition;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
+import io.grpc.*;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.streaming.Empty;
 import io.grpc.examples.streaming.Item;
 import io.grpc.examples.streaming.StreamingGrpc;
-import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.vertx.core.Vertx;
@@ -38,7 +25,6 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpcio.server.GrpcIoServer;
 import io.vertx.grpcio.server.GrpcIoServiceBridge;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -52,12 +38,12 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ServerBridgeTest extends ServerTest {
 
   @Override
-  protected void testUnary(TestContext should, String requestEncoding, String responseEncoding) {
+  protected void testUnary(TestContext should, String requestEncoding, String responseEncoding, DecompressorRegistry decompressors) {
     GreeterGrpc.GreeterImplBase impl = new GreeterGrpc.GreeterImplBase() {
       @Override
       public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
         if (!responseEncoding.equals("identity")) {
-          ((ServerCallStreamObserver<?>)responseObserver).setCompression("gzip");
+          ((ServerCallStreamObserver<?>)responseObserver).setCompression(responseEncoding);
         }
         if (!requestEncoding.equals("identity")) {
           // No way to check the request encoding with the API
@@ -72,7 +58,7 @@ public class ServerBridgeTest extends ServerTest {
     serverStub.bind(server);
     startServer(server);
 
-    super.testUnary(should, requestEncoding, responseEncoding);
+    super.testUnary(should, requestEncoding, responseEncoding, decompressors);
   }
 
   @Test
@@ -140,7 +126,7 @@ public class ServerBridgeTest extends ServerTest {
     serverStub.bind(server);
     startServer(server);
 
-    super.testUnary(should, "identity", "identity");
+    super.testUnary(should, "identity", "identity", DecompressorRegistry.getDefaultInstance());
   }
 
   @Override

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
@@ -29,7 +29,6 @@ import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.InvalidMessagePayloadException;
 import io.vertx.grpc.common.MessageSizeOverflowException;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -47,7 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ServerRequestTest extends ServerTest {
 
   @Override
-  protected void testUnary(TestContext should, String requestEncoding, String responseEncoding) {
+  protected void testUnary(TestContext should, String requestEncoding, String responseEncoding, DecompressorRegistry decompressors) {
     startServer(GrpcServer.server(vertx).callHandler(GreeterGrpc.getSayHelloMethod(), call -> {
       call.handler(helloRequest -> {
         HelloReply helloReply = HelloReply.newBuilder().setMessage("Hello " + helloRequest.getName()).build();
@@ -55,13 +54,16 @@ public class ServerRequestTest extends ServerTest {
           should.assertEquals(requestEncoding, call.encoding());
         }
         GrpcServerResponse<HelloRequest, HelloReply> response = call.response();
+        if (response.acceptedEncodings().contains(responseEncoding)) {
+          response
+            .encoding(responseEncoding);
+        }
         response
-          .encoding(responseEncoding)
           .end(helloReply);
       });
     }));
 
-    super.testUnary(should, requestEncoding, responseEncoding);
+    super.testUnary(should, requestEncoding, responseEncoding, decompressors);
   }
 
   @Test


### PR DESCRIPTION
Motivation:

The GrpcServiceBridge implementation does not check the encodings accepted by the client and can use an encoding that the client would not support.

Changes:

- Add API to properly check client accepted encodings.
- Modify GrpcServiceBridge implementation to check the client accepted encodings.
