### PR TITLE
GrpcServiceBridge should only use client accepted encodings.

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
@@ -17,9 +17,12 @@ public interface GrpcWriteStream<T> extends WriteStream<T> {
   MultiMap headers();
 
   /**
-   * Set the stream encoding, e.g. {@code identity} or {@code gzip}.
+   * <p>Set the stream encoding, e.g. {@code identity} or {@code gzip},</p>
    *
-   * It must be called before sending any message, otherwise {@code identity} will be used.
+   * <ul>
+   *   <li>The encoding must be set before sending any message, otherwise {@code identity} will be used.</li>
+   *   <li>The encoding should also match the opposite endpoint expectations.</li>
+   * </ul>
    *
    * @param encoding the target message encoding
    * @return a reference to this, so the API can be used fluently

--- a/vertx-grpc-docs/src/main/asciidoc/server.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/server.adoc
@@ -312,7 +312,10 @@ Anemic JSON is also supported with Vert.x `JsonObject`
 
 === Compression
 
-You can compress response messages by setting the response encoding *prior* before sending any message
+You can compress response messages by setting the response encoding *prior* before sending any message.
+
+Before setting the encoding, you should use {@link io.vertx.grpc.server.GrpcServerResponse#acceptedEncodings()} to ensure
+the client RPC supports the encoding algorithm.
 
 [source,java]
 ----

--- a/vertx-grpc-docs/src/main/java/examples/GrpcServerExamples.java
+++ b/vertx-grpc-docs/src/main/java/examples/GrpcServerExamples.java
@@ -170,7 +170,9 @@ public class GrpcServerExamples {
   }
 
   public void responseCompression(GrpcServerResponse<Empty, Item> response) {
-    response.encoding("gzip");
+    if (response.acceptedEncodings().contains("gzip")) {
+      response.encoding("gzip");
+    }
 
     // Write items after encoding has been defined
     response.write(Item.newBuilder().setValue("item-1").build());

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
@@ -21,6 +21,8 @@ import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.GrpcWriteStream;
 import io.vertx.grpc.common.WireFormat;
 
+import java.util.Set;
+
 @VertxGen
 public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
 
@@ -47,6 +49,13 @@ public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
 
   @Fluent
   GrpcServerResponse<Req, Resp> format(WireFormat format);
+
+  /**
+   * @return the set of accepted encodings sent by the client, note that {@code identity} should not be part of this set.
+   *         This can be used to set the response {@link #encoding(String) encoding} to ensure the client will accept
+   *         the encoding. This is a glorified wrapper for the {@code grpc-accept-encoding} header.
+   */
+  Set<String> acceptedEncodings();
 
   /**
    * @return the {@link MultiMap} to write metadata trailers

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -27,13 +27,16 @@ import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServerResponse;
 import io.vertx.grpc.server.StatusException;
 
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public abstract class GrpcServerResponseImpl<Req, Resp> extends GrpcWriteStreamBase<GrpcServerResponseImpl<Req, Resp>, Resp> implements GrpcServerResponse<Req, Resp> {
+
+  private static final Pattern COMMA_SEPARATOR = Pattern.compile(" *, *");
+  private static final Set<String> GZIP_ACCEPT_ENCODING = Collections.singleton("gzip");
 
   private final GrpcServerRequestImpl<Req, Resp> request;
   private final HttpServerResponse httpResponse;
@@ -41,6 +44,7 @@ public abstract class GrpcServerResponseImpl<Req, Resp> extends GrpcWriteStreamB
   private String statusMessage;
   private boolean trailersOnly;
   private boolean cancelled;
+  private Set<String> acceptedEncodings;
 
   public GrpcServerResponseImpl(ContextInternal context,
                                 GrpcServerRequestImpl<Req, Resp> request,
@@ -172,6 +176,27 @@ public abstract class GrpcServerResponseImpl<Req, Resp> extends GrpcWriteStreamB
     } else {
       entries.remove(GrpcHeaderNames.GRPC_MESSAGE);
     }
+  }
+
+  @Override
+  public Set<String> acceptedEncodings() {
+    if (acceptedEncodings == null) {
+      String acceptEncodingHeader = request.headers().get("grpc-accept-encoding");
+      if (acceptEncodingHeader != null) {
+        if (acceptEncodingHeader.equals("gzip")) {
+          acceptedEncodings = GZIP_ACCEPT_ENCODING;
+        } else {
+          acceptedEncodings = new HashSet<>(2);
+          String[] encodings = COMMA_SEPARATOR.split(acceptEncodingHeader);
+          for (String encoding : encodings) {
+            acceptedEncodings.add(encoding.trim());
+          }
+        }
+      } else {
+        acceptedEncodings = Collections.emptySet();
+      }
+    }
+    return acceptedEncodings;
   }
 
   @Override

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ServerRequestTest extends ServerTest {
 
   @Override
-  protected void testUnary(TestContext should, String requestEncoding, String responseEncoding) {
+  protected void testUnary(TestContext should, String requestEncoding, String responseEncoding, DecompressorRegistry decompressors) {
     startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
       call.handler(helloRequest -> {
         Reply helloReply = Reply.newBuilder().setMessage("Hello " + helloRequest.getName()).build();
@@ -57,13 +57,15 @@ public class ServerRequestTest extends ServerTest {
           should.assertEquals(requestEncoding, call.encoding());
         }
         GrpcServerResponse<Request, Reply> response = call.response();
+        if (response.acceptedEncodings().contains(responseEncoding)) {
+          response.encoding(responseEncoding);
+        }
         response
-          .encoding(responseEncoding)
           .end(helloReply);
       });
     }));
 
-    super.testUnary(should, requestEncoding, responseEncoding);
+    super.testUnary(should, requestEncoding, responseEncoding, decompressors);
   }
 
   @Test

--- a/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServiceBridgeImpl.java
+++ b/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServiceBridgeImpl.java
@@ -268,7 +268,10 @@ public class GrpcIoServiceBridgeImpl implements GrpcIoServiceBridge {
     @Override
     public void setCompression(String encoding) {
       compressor = CompressorRegistry.getDefaultInstance().lookupCompressor(encoding);
-      req.response().encoding(encoding);
+      GrpcServerResponse<Req, Resp> response = req.response();
+      if (response.acceptedEncodings().contains(encoding)) {
+        response.encoding(encoding);
+      }
     }
 
     @Override

--- a/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
+++ b/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
@@ -35,12 +35,12 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ServerBridgeTest extends ServerTest {
 
   @Override
-  protected void testUnary(TestContext should, String requestEncoding, String responseEncoding) {
+  protected void testUnary(TestContext should, String requestEncoding, String responseEncoding, DecompressorRegistry decompressors) {
     TestServiceGrpc.TestServiceImplBase impl = new TestServiceGrpc.TestServiceImplBase() {
       @Override
       public void unary(Request request, StreamObserver<Reply> responseObserver) {
         if (!responseEncoding.equals("identity")) {
-          ((ServerCallStreamObserver<?>)responseObserver).setCompression("gzip");
+          ((ServerCallStreamObserver<?>)responseObserver).setCompression(responseEncoding);
         }
         if (!requestEncoding.equals("identity")) {
           // No way to check the request encoding with the API
@@ -55,7 +55,7 @@ public class ServerBridgeTest extends ServerTest {
     serverStub.bind(server);
     startServer(server);
 
-    super.testUnary(should, requestEncoding, responseEncoding);
+    super.testUnary(should, requestEncoding, responseEncoding, decompressors);
   }
 
   @Test
@@ -123,7 +123,7 @@ public class ServerBridgeTest extends ServerTest {
     serverStub.bind(server);
     startServer(server);
 
-    super.testUnary(should, "identity", "identity");
+    super.testUnary(should, "identity", "identity", DecompressorRegistry.getDefaultInstance());
   }
 
   @Test


### PR DESCRIPTION
Motivation:

The GrpcServiceBridge implementation does not check the encodings accepted by the client and can use an encoding that the client would not support.

Changes:

- Add API to properly check client accepted encodings.
- Modify GrpcServiceBridge implementation to check the client accepted encodings.
