### PR TITLE
Add Testcontainers support for grpcurl and grpc_health_probe integraion tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,20 +25,5 @@ jobs:
         with:
           java-version: ${{ inputs.jdk }}
           distribution: temurin
-      - name: Install grpcurl (Linux only)
-        if: runner.os == 'Linux'
-        run: |
-          curl -L https://github.com/fullstorydev/grpcurl/releases/download/v1.9.3/grpcurl_1.9.3_linux_x86_64.tar.gz | tar -xz
-          sudo mv grpcurl /usr/local/bin/
-      - name: Install grpc_health_probe (Linux only)
-        if: runner.os == 'Linux'
-        run: |
-          curl -L https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.41/grpc_health_probe-linux-amd64 -o grpc_health_probe
-          chmod +x grpc_health_probe
-          sudo mv grpc_health_probe /usr/local/bin/
       - name: Run tests
-        if: runner.os != 'Linux'
-        run: mvn -s .github/maven-ci-settings.xml -q clean verify -B
-      - name: Run tests with grpcurl and health-probe profiles (Linux only)
-        if: runner.os == 'Linux'
         run: mvn -s .github/maven-ci-settings.xml -q clean verify -B -P grpcurl,health-probe

--- a/vertx-grpc-it/pom.xml
+++ b/vertx-grpc-it/pom.xml
@@ -85,8 +85,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>dev.jbang</groupId>
-      <artifactId>jash</artifactId>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/TestContainerTestBase.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/TestContainerTestBase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.grpc.it;
+
+import io.vertx.core.Future;
+import io.vertx.tests.common.GrpcTestBase;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.ToStringConsumer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Base class for tests that use Testcontainers to run external tools. Provides shared logic for container setup and execution.
+ */
+public abstract class TestContainerTestBase extends GrpcTestBase {
+
+  /**
+   * The hostname to use for connecting from containers to the host.
+   */
+  protected static final String HOST_INTERNAL = "host.testcontainers.internal";
+
+  /**
+   * Exposes the test server port to containers. Must be called after the server is started and listening.
+   */
+  protected void exposeHostPort() {
+    Testcontainers.exposeHostPorts(port);
+  }
+
+  /**
+   * Executes a command in a container and returns the output.
+   *
+   * @param image the Docker image to use
+   * @param command the command arguments
+   * @return a Future containing the container output
+   */
+  protected Future<String> executeInContainer(ImageFromDockerfile image, List<String> command) {
+    return vertx.executeBlocking(() -> {
+      System.out.println("[container] Executing with args: " + command);
+
+      ToStringConsumer logConsumer = new ToStringConsumer();
+      try (GenericContainer<?> container = new GenericContainer<>(image)) {
+        container
+          .withLogConsumer(logConsumer)
+          .withCommand(command.toArray(new String[0]))
+          .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(30)));
+
+        try {
+          container.start();
+        } catch (Exception e) {
+          // Container may exit with non-zero for expected failures
+        }
+
+        String output = logConsumer.toUtf8String();
+        System.out.println("[container] Output: " + output);
+        return output;
+      }
+    });
+  }
+}

--- a/vertx-grpc-it/src/test/resources/grpc-health-probe.Dockerfile
+++ b/vertx-grpc-it/src/test/resources/grpc-health-probe.Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.19
+
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.42
+
+RUN apk add --no-cache curl && \
+    curl -fsSL https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 \
+    -o /usr/local/bin/grpc_health_probe && \
+    chmod +x /usr/local/bin/grpc_health_probe && \
+    apk del curl
+
+ENTRYPOINT ["/usr/local/bin/grpc_health_probe"]

--- a/vertx-grpc-it/src/test/resources/grpcurl.Dockerfile
+++ b/vertx-grpc-it/src/test/resources/grpcurl.Dockerfile
@@ -1,0 +1,3 @@
+FROM fullstorydev/grpcurl:latest
+
+ENTRYPOINT ["/bin/grpcurl"]


### PR DESCRIPTION
Motivation:

- Simplify integration test setup by replacing local installations of grpcurl and grpc_health_probe with containerized alternatives.
- Improve test portability and ensure consistent behavior across environments.

Changes:

- Added grpcurl and grpc_health_probe containers.
- Updated integration tests to use Testcontainers for running grpcurl and grpc_health_probe.
- Removed direct system dependencies for grpcurl and grpc_health_probe in the CI workflow.