### PR TITLE
GrpcServer should response with the UNIMPLEMENTED grpc status when the service is not deployed.

### DIFF
--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/TranscodingTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/TranscodingTest.java
@@ -491,6 +491,27 @@ public class TranscodingTest extends ProxyTestBase {
     grpcTest.awaitSuccess();
   }
 
+  @Test
+  public void testUnknownService(TestContext should) {
+    HttpClient client = vertx.createHttpClient();
+
+    Future<HttpServer> server = vertx.createHttpServer()
+      .requestHandler(GrpcServer.server(vertx)).listen(8080, "localhost");
+
+    RequestOptions options = new RequestOptions().setHost("localhost").setPort(8080).setURI("/v1/hello").setMethod(HttpMethod.POST);
+    Async test = should.async();
+
+    server.onComplete(should.asyncAssertSuccess(v -> client.request(options).compose(req -> {
+      req.putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+      req.putHeader(HttpHeaders.ACCEPT, "application/json");
+      return req.send(Buffer.buffer(new JsonObject().put("name", "Julien").encode()));
+    }).compose(resp -> {
+      should.assertEquals(500, resp.statusCode());
+      return resp.body();
+    }).onComplete(should.asyncAssertSuccess(body -> test.complete()))));
+
+    test.awaitSuccess();
+  }
   private String createRequest(String name) {
     return Json.encode(new JsonObject().put("name", name));
   }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -13,7 +13,9 @@ package io.vertx.grpc.server.impl;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.core.internal.logging.Logger;
@@ -142,7 +144,25 @@ public class GrpcServerImpl implements GrpcServer {
     if (handler != null) {
       handle(new MethodCallHandler<>(null, GrpcMessageDecoder.IDENTITY, GrpcMessageEncoder.IDENTITY, handler), httpRequest, methodCall, details.protocol, details.format);
     } else {
-      httpRequest.response().setStatusCode(500).end();
+      String msg = "Method not found: " + httpRequest.path().substring(1);
+      HttpServerResponse response = httpRequest.response();
+      boolean webText = true;
+      switch (details.protocol) {
+        case HTTP_2:
+        case WEB:
+        case WEB_TEXT:
+          response.setStatusCode(200);
+          response.putHeader(HttpHeaders.CONTENT_TYPE, details.protocol.mediaType());
+          response.putHeader(GrpcHeaderNames.GRPC_STATUS, GrpcStatus.UNIMPLEMENTED.toString());
+          response.putHeader(GrpcHeaderNames.GRPC_MESSAGE, msg);
+          response.end();
+          break;
+        default:
+          response
+            .setStatusCode(500)
+            .end();
+          break;
+      }
     }
   }
 

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcServerResponse.java
@@ -27,6 +27,10 @@ import static io.vertx.grpc.server.GrpcProtocol.WEB_TEXT;
 
 public class WebGrpcServerResponse<Req, Resp> extends GrpcServerResponseImpl<Req,Resp> {
 
+  public static Buffer grpcWebEncode(Buffer message) {
+    return BufferInternal.buffer(Base64.encode(((BufferInternal)message).getByteBuf(), false));
+  }
+
   private final GrpcProtocol protocol;
   private final HttpServerResponse httpResponse;
   private Buffer trailers;
@@ -54,7 +58,7 @@ public class WebGrpcServerResponse<Req, Resp> extends GrpcServerResponseImpl<Req
   protected Buffer encodeMessage(Buffer message, boolean compressed, boolean trailer) {
     message = super.encodeMessage(message, compressed, trailer);
     if (protocol == WEB_TEXT) {
-      message = BufferInternal.buffer(Base64.encode(((BufferInternal)message).getByteBuf(), false));
+      message = grpcWebEncode(message);
     }
     return message;
   }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
@@ -231,6 +231,14 @@ public class ServerRequestTest extends ServerTest {
     super.testBidiStreamingCompletedBeforeHalfClose(should);
   }
 
+  @Override
+  public void testUnknownService(TestContext should) {
+
+    startServer(GrpcServer.server(vertx));
+
+    super.testUnknownService(should);
+  }
+
   @Test
   public void testMetadata(TestContext should) {
 

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
@@ -274,6 +274,26 @@ public abstract class ServerTest extends ServerTestBase {
   protected AtomicInteger testMetadataStep;
 
   @Test
+  public void testUnknownService(TestContext should) {
+    channel = ManagedChannelBuilder.forAddress("localhost", port)
+      .usePlaintext()
+      .build();
+    TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
+
+    try {
+      Iterator<Reply> iterator = stub.source(Empty.newBuilder().build());
+      // This is lazy
+      while (iterator.hasNext()) {
+        iterator.next();
+      }
+      should.fail();
+    } catch (StatusRuntimeException e) {
+      should.assertEquals(12, e.getStatus().getCode().value());
+      should.assertEquals("Method not found: io.vertx.tests.common.grpc.tests.TestService/Source", e.getStatus().getDescription());
+    }
+  }
+
+  @Test
   public void testMetadata(TestContext should) {
 
     testMetadataStep = new AtomicInteger();

--- a/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
+++ b/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
@@ -18,6 +18,7 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpcio.common.impl.Utils;
 import io.vertx.grpcio.server.GrpcIoServer;
 import io.vertx.grpcio.server.GrpcIoServiceBridge;
@@ -330,6 +331,15 @@ public class ServerBridgeTest extends ServerTest {
     startServer(server);
 
     super.testBidiStreamingCompletedBeforeHalfClose(should);
+  }
+
+  @Override
+  public void testUnknownService(TestContext should) {
+
+    GrpcIoServer server = GrpcIoServer.server(vertx);
+    startServer(server);
+
+    super.testUnknownService(should);
   }
 
   @Override


### PR DESCRIPTION
Motivation:

`GrpcServer` behavior for unknown services is to send an HTTP 500 response, which is not the appropriate way to respond to a client for the `application/grpc` based protocols.

Changes:

Update `GrpcServer` to response with the `UNIMPLEMENTED` `grpc-status` and appropriate `grpc-message` trailers when a service is unknown.