### PR TITLE
Add grpcurl and grpc_health_probe installation steps to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,20 @@ jobs:
         with:
           java-version: ${{ inputs.jdk }}
           distribution: temurin
+      - name: Install grpcurl (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          curl -L https://github.com/fullstorydev/grpcurl/releases/download/v1.9.3/grpcurl_1.9.3_linux_x86_64.tar.gz | tar -xz
+          sudo mv grpcurl /usr/local/bin/
+      - name: Install grpc_health_probe (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          curl -L https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.41/grpc_health_probe-linux-amd64 -o grpc_health_probe
+          chmod +x grpc_health_probe
+          sudo mv grpc_health_probe /usr/local/bin/
       - name: Run tests
+        if: runner.os != 'Linux'
+        run: mvn -s .github/maven-ci-settings.xml -q clean verify -B
+      - name: Run tests with grpcurl and health-probe profiles (Linux only)
+        if: runner.os == 'Linux'
         run: mvn -s .github/maven-ci-settings.xml -q clean verify -B -P grpcurl,health-probe


### PR DESCRIPTION
Motivation:

- Enable back Linux-specific integration tests using grpcurl and grpc_health_probe tools in GitHub Actions workflow to fix https://github.com/eclipse-vertx/vertx-grpc/issues/227

Changes:

- Added installation steps for grpcurl and grpc_health_probe for Linux runners.
- Configured separate test execution profiles for Linux and non-Linux environments.
