### PR TITLE
Clean up unused imports in contract.mustache

### DIFF
--- a/vertx-grpc-protoc-plugin2/src/main/resources/contract.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/contract.mustache
@@ -13,10 +13,6 @@ import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
-import io.vertx.grpc.server.GrpcServerRequest;
-import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.ServiceBuilder;
 
 import com.google.protobuf.Descriptors;
 


### PR DESCRIPTION
Motivation:

Removed unused imports related to GrpcServer and Service.