### PR TITLE
Expose callHandler registered services in service() method

### DIFF
--- a/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServerImpl.java
+++ b/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServerImpl.java
@@ -10,22 +10,33 @@
  */
 package io.vertx.grpcio.server.impl;
 
+import com.google.protobuf.Descriptors;
 import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoServiceDescriptorSupplier;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.grpc.common.*;
-import io.vertx.grpc.server.*;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.GrpcServerOptions;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.Service;
 import io.vertx.grpc.server.impl.GrpcServerImpl;
 import io.vertx.grpcio.common.impl.BridgeMessageDecoder;
 import io.vertx.grpcio.common.impl.BridgeMessageEncoder;
-import io.vertx.grpcio.common.impl.Utils;
 import io.vertx.grpcio.server.GrpcIoServer;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class GrpcIoServerImpl extends GrpcServerImpl implements GrpcIoServer {
+
+  private final List<MethodDescriptor<?, ?>> callHandlerMethods = new CopyOnWriteArrayList<>();
 
   public GrpcIoServerImpl(Vertx vertx, GrpcServerOptions options) {
     super(vertx, options);
@@ -37,12 +48,110 @@ public class GrpcIoServerImpl extends GrpcServerImpl implements GrpcIoServer {
   }
 
   public <Req, Resp> GrpcIoServerImpl callHandler(MethodDescriptor<Req, Resp> methodDesc, Handler<GrpcServerRequest<Req, Resp>> handler) {
-    ServiceMethod<Req, Resp> serviceMethod = ServiceMethod.server(ServiceName.create(
-      methodDesc.getServiceName()),
+    ServiceMethod<Req, Resp> serviceMethod = ServiceMethod.server(
+      ServiceName.create(methodDesc.getServiceName()),
       methodDesc.getBareMethodName(),
       new BridgeMessageEncoder<>(methodDesc.getResponseMarshaller(), null),
       new BridgeMessageDecoder<>(methodDesc.getRequestMarshaller(), null)
     );
-    return (GrpcIoServerImpl) callHandler(serviceMethod, handler);
+
+    String serviceName = methodDesc.getServiceName();
+    String bareMethodName = methodDesc.getBareMethodName();
+    callHandler(serviceMethod, handler);
+    callHandlerMethods.removeIf(m -> Objects.equals(serviceName, m.getServiceName()) && Objects.equals(bareMethodName, m.getBareMethodName()));
+    if (handler != null) {
+      callHandlerMethods.add(methodDesc);
+    }
+
+    return this;
+  }
+
+  @Override
+  public List<Service> services() {
+    // Merges services from addService() with those discovered via callHandler(),
+    // skipping callHandler entries that duplicate an addService entry.
+    // Fix for https://github.com/eclipse-vertx/vertx-grpc/issues/208
+    List<Service> services = super.services();
+
+    if (callHandlerMethods.isEmpty()) {
+      return services;
+    }
+
+    // Group registered method descriptors by their service name, preserving registration order.
+    Map<String, List<MethodDescriptor<?, ?>>> methodsByService = new LinkedHashMap<>();
+    for (MethodDescriptor<?, ?> methodDesc : callHandlerMethods) {
+      methodsByService.computeIfAbsent(methodDesc.getServiceName(), k -> new ArrayList<>()).add(methodDesc);
+    }
+
+    Set<String> names = services.stream()
+      .map(s -> s.name().fullyQualifiedName())
+      .collect(Collectors.toSet());
+
+    List<Service> virtual = new ArrayList<>(services);
+
+    for (Map.Entry<String, List<MethodDescriptor<?, ?>>> entry : methodsByService.entrySet()) {
+      String serviceName = entry.getKey();
+      if (names.contains(serviceName)) {
+        continue;
+      }
+
+      Service service = buildCallHandlerService(serviceName, entry.getValue());
+      if (service != null) {
+        virtual.add(service);
+      }
+    }
+
+    return virtual;
+  }
+
+  private static Service buildCallHandlerService(String serviceName, List<MethodDescriptor<?, ?>> methods) {
+    Descriptors.ServiceDescriptor protoService = null;
+    for (MethodDescriptor<?, ?> methodDesc : methods) {
+      Object schemaDescriptor = methodDesc.getSchemaDescriptor();
+      if (schemaDescriptor instanceof ProtoServiceDescriptorSupplier) {
+        Descriptors.ServiceDescriptor candidate = ((ProtoServiceDescriptorSupplier) schemaDescriptor).getServiceDescriptor();
+        if (candidate != null) {
+          protoService = candidate;
+          break;
+        }
+      }
+    }
+    if (protoService == null) {
+      return null;
+    }
+
+    List<Descriptors.MethodDescriptor> registered = new ArrayList<>(methods.size());
+    for (MethodDescriptor<?, ?> methodDesc : methods) {
+      Descriptors.MethodDescriptor m = protoService.findMethodByName(methodDesc.getBareMethodName());
+      if (m != null) {
+        registered.add(m);
+      }
+    }
+
+    ServiceName name = ServiceName.create(serviceName);
+    Descriptors.ServiceDescriptor descriptor = protoService;
+    List<Descriptors.MethodDescriptor> methodDescriptors = Collections.unmodifiableList(registered);
+
+    return new Service() {
+      @Override
+      public ServiceName name() {
+        return name;
+      }
+
+      @Override
+      public Descriptors.ServiceDescriptor descriptor() {
+        return descriptor;
+      }
+
+      @Override
+      public List<Descriptors.MethodDescriptor> methodDescriptors() {
+        return methodDescriptors;
+      }
+
+      @Override
+      public void bind(GrpcServer server) {
+        // Handlers are already registered via callHandler(MethodDescriptor, Handler).
+      }
+    };
   }
 }

--- a/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ReflectionCallHandlerTest.java
+++ b/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ReflectionCallHandlerTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.server;
+
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import io.vertx.grpc.reflection.ReflectionService;
+import io.vertx.grpc.server.GrpcServerResponse;
+import io.vertx.grpc.server.Service;
+import io.vertx.grpcio.server.GrpcIoServer;
+import io.vertx.tests.common.grpc.Reply;
+import io.vertx.tests.common.grpc.Request;
+import io.vertx.tests.common.grpc.TestConstants;
+import io.vertx.tests.common.grpc.TestServiceGrpc;
+import io.vertx.tests.reflection.grpc.ListServiceResponse;
+import io.vertx.tests.reflection.grpc.ServerReflectionGrpc;
+import io.vertx.tests.reflection.grpc.ServerReflectionRequest;
+import io.vertx.tests.reflection.grpc.ServerReflectionResponse;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+public class ReflectionCallHandlerTest extends ServerTestBase {
+
+  @Test
+  public void testCallHandlerVisibleInReflection() throws Exception {
+    GrpcIoServer grpcServer = GrpcIoServer.server(vertx);
+    grpcServer.addService(ReflectionService.v1());
+
+    grpcServer.callHandler(TestServiceGrpc.getUnaryMethod(), call -> {
+      call.handler(request -> {
+        Reply reply = Reply.newBuilder().setMessage("Hello " + request.getName()).build();
+        GrpcServerResponse<Request, Reply> response = call.response();
+        response.encoding("identity").end(reply);
+      });
+    });
+
+    startServer(grpcServer);
+    channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();
+
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    StreamObserver<ServerReflectionRequest> streamObserver = ServerReflectionGrpc.newStub(channel).serverReflectionInfo(new StreamObserver<>() {
+      @Override
+      public void onNext(ServerReflectionResponse response) {
+        try {
+          ListServiceResponse listResponse = response.getListServicesResponse();
+          assertEquals(2, listResponse.getServiceCount());
+          listResponse.getServiceList().stream()
+            .filter(service -> service.getName().equals(TestConstants.TEST_SERVICE.fullyQualifiedName()))
+            .findFirst().orElseThrow();
+          listResponse.getServiceList().stream()
+            .filter(service -> service.getName().equals("grpc.reflection.v1.ServerReflection"))
+            .findFirst().orElseThrow();
+        } catch (Throwable t) {
+          failure.set(t);
+          latch.countDown();
+        }
+      }
+      @Override
+      public void onError(Throwable throwable) {
+        failure.set(throwable);
+        latch.countDown();
+      }
+      @Override
+      public void onCompleted() {
+        latch.countDown();
+      }
+    });
+    streamObserver.onNext(ServerReflectionRequest.newBuilder().setListServices("").build());
+    streamObserver.onCompleted();
+
+    assertTrue("Timed out waiting for reflection response", latch.await(10, TimeUnit.SECONDS));
+    if (failure.get() != null) {
+      throw new AssertionError(failure.get());
+    }
+  }
+
+  @Test
+  public void testCallHandlerNotDuplicatedWithAddService() throws Exception {
+    GrpcIoServer grpcServer = GrpcIoServer.server(vertx);
+    grpcServer.addService(ReflectionService.v1());
+    grpcServer.addService(
+      io.vertx.grpc.server.Service.service(
+        TestConstants.TEST_SERVICE,
+        io.vertx.tests.common.grpc.Tests.getDescriptor().findServiceByName("TestService")
+      ).build()
+    );
+    grpcServer.callHandler(TestServiceGrpc.getUnaryMethod(), call -> {
+      call.handler(request -> {
+        Reply reply = Reply.newBuilder().setMessage("Hello " + request.getName()).build();
+        GrpcServerResponse<Request, Reply> response = call.response();
+        response.encoding("identity").end(reply);
+      });
+    });
+
+    startServer(grpcServer);
+    channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();
+
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    StreamObserver<ServerReflectionRequest> streamObserver = ServerReflectionGrpc.newStub(channel).serverReflectionInfo(new StreamObserver<>() {
+      @Override
+      public void onNext(ServerReflectionResponse response) {
+        try {
+          // Should be 2, not 3 - callHandler service should not duplicate the addService entry
+          assertEquals(2, response.getListServicesResponse().getServiceCount());
+        } catch (Throwable t) {
+          failure.set(t);
+          latch.countDown();
+        }
+      }
+      @Override
+      public void onError(Throwable throwable) {
+        failure.set(throwable);
+        latch.countDown();
+      }
+      @Override
+      public void onCompleted() {
+        latch.countDown();
+      }
+    });
+    streamObserver.onNext(ServerReflectionRequest.newBuilder().setListServices("").build());
+    streamObserver.onCompleted();
+
+    assertTrue("Timed out waiting for reflection response", latch.await(10, TimeUnit.SECONDS));
+    if (failure.get() != null) {
+      throw new AssertionError(failure.get());
+    }
+  }
+
+  @Test
+  public void testCallHandlerOnlyExposesRegisteredMethods() {
+    GrpcIoServer grpcServer = GrpcIoServer.server(vertx);
+
+    // TestService defines Unary, Source, Sink and Pipe — register only Unary
+    grpcServer.callHandler(TestServiceGrpc.getUnaryMethod(), call -> {});
+
+    Service testService = grpcServer.services().stream()
+      .filter(s -> s.name().fullyQualifiedName().equals(TestConstants.TEST_SERVICE.fullyQualifiedName()))
+      .findFirst()
+      .orElseThrow();
+
+    assertEquals(1, testService.methodDescriptors().size());
+    assertEquals("Unary", testService.methodDescriptors().get(0).getName());
+    assertTrue(testService.hasMethod("Unary"));
+    assertFalse(testService.hasMethod("Source"));
+    assertFalse(testService.hasMethod("Sink"));
+    assertFalse(testService.hasMethod("Pipe"));
+  }
+
+  @Test
+  public void testCallHandlerUnregistrationRemovesService() {
+    GrpcIoServer grpcServer = GrpcIoServer.server(vertx);
+    grpcServer.callHandler(TestServiceGrpc.getUnaryMethod(), call -> {});
+
+    assertTrue(grpcServer.services().stream()
+      .anyMatch(s -> s.name().fullyQualifiedName().equals(TestConstants.TEST_SERVICE.fullyQualifiedName())));
+
+    // Passing a null handler is the unregistration path.
+    grpcServer.callHandler(TestServiceGrpc.getUnaryMethod(), null);
+
+    assertFalse(grpcServer.services().stream().anyMatch(s -> s.name().fullyQualifiedName().equals(TestConstants.TEST_SERVICE.fullyQualifiedName())));
+  }
+
+  @Test
+  public void testCallHandlerReRegistrationDoesNotDuplicate() {
+    GrpcIoServer grpcServer = GrpcIoServer.server(vertx);
+    grpcServer.callHandler(TestServiceGrpc.getUnaryMethod(), call -> {});
+    grpcServer.callHandler(TestServiceGrpc.getUnaryMethod(), call -> {});
+
+    Service testService = grpcServer.services().stream()
+      .filter(s -> s.name().fullyQualifiedName().equals(TestConstants.TEST_SERVICE.fullyQualifiedName()))
+      .findFirst()
+      .orElseThrow();
+
+    assertEquals(1, testService.methodDescriptors().size());
+    assertEquals("Unary", testService.methodDescriptors().get(0).getName());
+  }
+
+  @Test
+  public void testCallHandlerFileContainingSymbol() throws Exception {
+    GrpcIoServer grpcServer = GrpcIoServer.server(vertx);
+    grpcServer.addService(ReflectionService.v1());
+
+    grpcServer.callHandler(TestServiceGrpc.getUnaryMethod(), call -> {
+      call.handler(request -> {
+        Reply reply = Reply.newBuilder().setMessage("Hello " + request.getName()).build();
+        call.response().encoding("identity").end(reply);
+      });
+    });
+
+    startServer(grpcServer);
+    channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();
+
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    StreamObserver<ServerReflectionRequest> streamObserver = ServerReflectionGrpc.newStub(channel).serverReflectionInfo(new StreamObserver<>() {
+      @Override
+      public void onNext(ServerReflectionResponse response) {
+        try {
+          assertTrue(response.hasFileDescriptorResponse());
+          assertTrue(response.getFileDescriptorResponse().getFileDescriptorProtoCount() > 0);
+        } catch (Throwable t) {
+          failure.set(t);
+          latch.countDown();
+        }
+      }
+      @Override
+      public void onError(Throwable throwable) {
+        failure.set(throwable);
+        latch.countDown();
+      }
+      @Override
+      public void onCompleted() {
+        latch.countDown();
+      }
+    });
+    streamObserver.onNext(ServerReflectionRequest.newBuilder()
+      .setFileContainingSymbol(TestConstants.TEST_SERVICE.fullyQualifiedName())
+      .build());
+    streamObserver.onCompleted();
+
+    assertTrue("Timed out waiting for reflection response", latch.await(10, TimeUnit.SECONDS));
+    if (failure.get() != null) {
+      throw new AssertionError(failure.get());
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

Services registered via GrpcIoServer.callHandler(MethodDescriptor, Handler) were not included in the reflection service's ListServices response. Only services registered via addService() appeared, because callHandler only populates the method routing map without adding a Service entry. This meant users who register all their service methods with custom handlers had no services visible through reflection.

Changes:

GrpcIoServerImpl now extracts the ProtoServiceDescriptorSupplier from the MethodDescriptor's schema descriptor when callHandler is called, and creates a Service entry for reflection. The services() method is overridden to merge these with addService registered services, deduplicating by name so the same service registered through both paths only appears once.

Fixes: #208 
