### PR TITLE
Add option including JSON default value for transcoding

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageEncoder.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcMessageEncoder.java
@@ -17,6 +17,17 @@ public interface GrpcMessageEncoder<T> {
    */
   @GenIgnore
   static <T extends MessageLite> GrpcMessageEncoder<T> encoder() {
+    return encoder(JsonFormat.printer());
+  }
+
+  /**
+   * Create an encoder for arbitrary message extending {@link MessageLite} with a custom JSON format printer.
+   *
+   * @param jsonPrinter the JSON format printer to use for JSON encoding
+   * @return the message encoder
+   */
+  @GenIgnore
+  static <T extends MessageLite> GrpcMessageEncoder<T> encoder(JsonFormat.Printer jsonPrinter) {
     return new GrpcMessageEncoder<T>() {
       @Override
       public GrpcMessage encode(T msg, WireFormat format) throws CodecException {
@@ -28,7 +39,7 @@ public interface GrpcMessageEncoder<T> {
             if (msg instanceof MessageOrBuilder) {
               MessageOrBuilder mob = (MessageOrBuilder) msg;
               try {
-                String res = JsonFormat.printer().print(mob);
+                String res = jsonPrinter.print(mob);
                 return GrpcMessage.message("identity", WireFormat.JSON, Buffer.buffer(res));
               } catch (InvalidProtocolBufferException e) {
                 throw new CodecException(e);
@@ -61,19 +72,29 @@ public interface GrpcMessageEncoder<T> {
   };
 
   /**
-   * Create and reutrn an encoder in JSON format encoding instances of {@link MessageOrBuilder} using the protobuf-java-util library
+   * Create and return an encoder in JSON format encoding instances of {@link MessageOrBuilder} using the protobuf-java-util library
    * otherwise using {@link Json#encodeToBuffer(Object)} (Jackson Databind is required).
    *
    * @return an encoder in JSON format encoding instances of {@code <T>}.
    */
   static <T> GrpcMessageEncoder<T> json() {
+    return json(JsonFormat.printer());
+  }
+
+  /**
+   * Create and return an encoder in JSON format with a custom JSON format printer.
+   *
+   * @param jsonPrinter the JSON format printer to use for encoding MessageOrBuilder instances
+   * @return an encoder in JSON format encoding instances of {@code <T>}.
+   */
+  static <T> GrpcMessageEncoder<T> json(JsonFormat.Printer jsonPrinter) {
     return new GrpcMessageEncoder<>() {
       @Override
       public GrpcMessage encode(T msg, WireFormat format) throws CodecException {
         if (msg instanceof MessageOrBuilder) {
           MessageOrBuilder mob = (MessageOrBuilder) msg;
           try {
-            String res = JsonFormat.printer().print(mob);
+            String res = jsonPrinter.print(mob);
             return GrpcMessage.message("identity", WireFormat.JSON, Buffer.buffer(res));
           } catch (InvalidProtocolBufferException e) {
             throw new CodecException(e);

--- a/vertx-grpc-it/pom.xml
+++ b/vertx-grpc-it/pom.xml
@@ -126,6 +126,7 @@
                 <arg>--grpc-client</arg>
                 <arg>--grpc-service</arg>
                 <arg>--grpc-io</arg>
+                <arg>--json-include-default-values</arg>
               </args>
             </protocPlugin>
           </protocPlugins>

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/TranscodingTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/TranscodingTest.java
@@ -128,6 +128,32 @@ public class TranscodingTest extends ProxyTestBase {
   }
 
   @Test
+  public void testUnaryJsonDefaultValue() throws TimeoutException {
+      HttpClient client = vertx.createHttpClient();
+
+      vertx.createHttpServer()
+        .requestHandler(GrpcServer.server(vertx).callHandler(GreeterGrpcService.SayHello, call -> call.handler(helloRequest -> {
+          HelloReply helloReply = HelloReply.newBuilder().setMessage("").build();
+          call.response().end(helloReply);
+        }))).listen(58080, "localhost").await(10, TimeUnit.SECONDS);
+
+      RequestOptions options = new RequestOptions().setHost("localhost").setPort(58080).setURI("/v1/hello").setMethod(HttpMethod.POST);
+
+      Buffer body = client.request(options).compose(req -> {
+        req.putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        req.putHeader(HttpHeaders.ACCEPT, "application/json");
+        return req.send(createRequest("Julien"));
+      }).expecting(HttpResponseExpectation.SC_OK)
+        .expecting(HttpResponseExpectation.JSON)
+        .compose(HttpClientResponse::body)
+        .await(10, TimeUnit.SECONDS);
+
+      // Verify the "message" key is present in JSON (default values are included)
+      JsonObject jsonResponse = new JsonObject(body.toString());
+      assertEquals(true, jsonResponse.containsKey("message"));
+  }
+
+  @Test
   public void testUnaryAdditionalBindingsUnknownPath() throws TimeoutException {
     HttpClient client = vertx.createHttpClient();
 

--- a/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGenerator.java
+++ b/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGenerator.java
@@ -32,6 +32,9 @@ public class VertxGrpcGenerator implements Callable<Integer> {
   @Option(names = { "--vertx-codegen" }, description = "Whether to generate vertx generator annotations")
   boolean generateVertxGeneratorAnnotations = false;
 
+  @Option(names = { "--json-include-default-values" }, description = "Whether to include default values in JSON output.")
+  public boolean jsonIncludeDefaultValues = false;
+
   @Option(
     names = { "--service-prefix" },
     description = "Generate service classes with a prefix. For example, if you set it to `MyService`, the generated service class will be `MyServiceGreeterService` instead of `GreeterService`."

--- a/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGeneratorImpl.java
+++ b/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/VertxGrpcGeneratorImpl.java
@@ -111,6 +111,13 @@ public class VertxGrpcGeneratorImpl extends Generator {
     //serviceContext.fileName = CLASS_PREFIX + serviceProto.getName() + "Grpc.java";
     //serviceContext.className = CLASS_PREFIX + serviceProto.getName() + "Grpc";
 
+    // Configure JSON encoder based on options
+    if (options.jsonIncludeDefaultValues) {
+      serviceContext.encoderExpression = "GrpcMessageEncoder.encoder(com.google.protobuf.util.JsonFormat.printer().includingDefaultValueFields())";
+    } else {
+      serviceContext.encoderExpression = "GrpcMessageEncoder.encoder()";
+    }
+
     List<DescriptorProtos.SourceCodeInfo.Location> allLocationsForService = locations.stream()
       .filter(location ->
         location.getPathCount() >= 2 &&
@@ -434,6 +441,7 @@ public class VertxGrpcGeneratorImpl extends Generator {
     public boolean codegenEnabled;
     public boolean deprecated;
     public String javaDoc;
+    public String encoderExpression;
     public final List<MethodContext> methods = new ArrayList<>();
 
     public ServiceContext(DescriptorProtos.ServiceDescriptorProto proto, String classPrefix) {

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
@@ -117,7 +117,7 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
   public static final io.vertx.grpc.transcoding.TranscodingServiceMethod<{{inputType}}, {{outputType}}> {{methodName}} = io.vertx.grpc.transcoding.TranscodingServiceMethod.server(
     SERVICE_NAME,
     "{{methodName}}",
-    GrpcMessageEncoder.encoder(),
+    {{{encoderExpression}}},
     GrpcMessageDecoder.decoder({{inputType}}.newBuilder()),
     {{methodName}}_OPTIONS
   );


### PR DESCRIPTION
Motivation:

I'm using grpc-transcoding so that I can have one grpc-service implementation which can serve both Grpc/REST entry point. However, the JsonPrinter's default behavior excludes default values such as int32:0, string:"". Therefore, a GrpcResponse with 
`{ "message": "Hello", "status": 0 }`
will become like this for REST response.
 `{ "message": "Hello" }`
Even though it's valid in terms of ProtoJSON, it would be nice to have default values because JSON in REST conventionally includes default value like this.

Draft for #261 (need discussion)
Adds a flag for `vertx-grpc-protoc-plugin2` and directly embeds `printer.includingDefaultValueFields()` into transcoding's `encoder` method. Changing the `ServiceMethod` signature should be avoided and therefore I approach the issue from `vertx-grpc-protoc-plugin2`.
