### PR TITLE
gRPC client should better handle HTTP response codes.

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/Http2GrpcInboundStream.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/Http2GrpcInboundStream.java
@@ -88,24 +88,26 @@ public class Http2GrpcInboundStream extends Http2GrpcOutboundStream {
 
   private void init(HttpClientResponse httpResponse) {
 
+    int httpStatus = httpResponse.statusCode();
     String contentType = httpResponse.getHeader(HttpHeaders.CONTENT_TYPE);
-
-    String msg = null;
-    String statusHeader = httpResponse.getHeader(GrpcHeaderNames.GRPC_STATUS);
-    GrpcStatus status = statusHeader != null ? GrpcStatus.valueOf(Integer.parseInt(statusHeader)) : null;
-    WireFormat format = null;
-    if (status == null) {
+    GrpcStatus status;
+    WireFormat format;
+    if (httpStatus == 200) {
+      String statusHeader = httpResponse.getHeader(GrpcHeaderNames.GRPC_STATUS);
+      status = statusHeader != null ? GrpcStatus.valueOf(Integer.parseInt(statusHeader)) : null;
       if (contentType != null) {
-        format = GrpcMediaType.parseContentType(contentType, "application/grpc");
-      }
-      if (contentType == null) {
-        msg = "HTTP response missing content-type header";
+        format = GrpcMediaType.parseContentType(contentType, GrpcMediaType.GRPC.toString());
       } else {
-        msg = "Invalid HTTP response content-type header";
+        format = null;
       }
+    } else {
+      status = GrpcStatus.fromHttpStatusCode(httpStatus);
+      format = WireFormat.PROTOBUF;
     }
 
-    if (format != null || status != null) {
+
+
+    if (format != null) {
 
       if (status != null) {
         // Trailers only
@@ -170,6 +172,12 @@ public class Http2GrpcInboundStream extends Http2GrpcOutboundStream {
       }
 
     } else {
+      String msg;
+      if (contentType == null) {
+        msg = "HTTP response missing content-type header";
+      } else {
+        msg = "Invalid HTTP response content-type header";
+      }
       httpResponse.request().reset(GrpcError.CANCELLED.http2ResetCode);
 //      return context().failedFuture(msg);
       throw new UnsupportedOperationException("Handle me: " + msg);

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientMessageEncodingTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientMessageEncodingTest.java
@@ -21,10 +21,7 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.client.GrpcClient;
 import io.vertx.grpc.client.GrpcClientResponse;
-import io.vertx.grpc.common.GrpcError;
-import io.vertx.grpc.common.GrpcHeaderNames;
-import io.vertx.grpc.common.GrpcMessage;
-import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.*;
 import io.vertx.tests.common.grpc.TestServiceGrpc;
 import org.junit.Test;
 
@@ -73,6 +70,7 @@ public class ClientMessageEncodingTest extends ClientTestBase {
         }
         should.assertEquals(expected, payload);
         req.response()
+          .putHeader(HttpHeaders.CONTENT_TYPE, GrpcMediaType.GRPC)
           .putHeader(GrpcHeaderNames.GRPC_STATUS, "" + GrpcStatus.CANCELLED.code)
           .end();
       });

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
@@ -13,6 +13,7 @@ package io.vertx.tests.client;
 import io.grpc.*;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
@@ -22,16 +23,13 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.context.storage.AccessMode;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.grpc.client.GrpcClient;
-import io.vertx.grpc.client.GrpcClientOptions;
-import io.vertx.grpc.client.GrpcClientResponse;
-import io.vertx.grpc.client.InvalidStatusException;
+import io.vertx.grpc.client.*;
 import io.vertx.grpc.common.*;
 import io.vertx.tests.common.grpc.Empty;
 import io.vertx.tests.common.grpc.Reply;
 import io.vertx.tests.common.grpc.Request;
 import io.vertx.tests.common.grpc.TestServiceGrpc;
-import org.junit.Ignore;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
@@ -881,5 +879,16 @@ public class ClientRequestTest extends ClientTest {
         callRequest.response().onComplete(should.asyncAssertSuccess(responseHandler));
         callRequest.end(Empty.getDefaultInstance());
       }));
+  }
+
+  @Test
+  public void testHttpInvalidStatusCode() throws Exception {
+    super.testHttpInvalidStatusCode(401);
+    GrpcClient client = GrpcClient.client(vertx, new GrpcClientOptions());
+    Future<GrpcStatus> status = client.request(SocketAddress.inetSocketAddress(port, "localhost"), SOURCE)
+      .compose(request -> request
+        .send(Empty.getDefaultInstance())
+        .map(GrpcClientResponse::status));
+    Assert.assertEquals(GrpcStatus.UNAUTHENTICATED, status.await());
   }
 }

--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientTest.java
@@ -451,4 +451,15 @@ public abstract class ClientTest extends ClientTestBase {
       .toCompletableFuture()
       .get(20, TimeUnit.SECONDS);
   }
+
+
+  public void testHttpInvalidStatusCode(int statusCode) throws Exception {
+    HttpServer server = vertx.createHttpServer();
+    server
+      .requestHandler(request -> {
+        request.response().setStatusCode(statusCode).end();
+      })
+      .listen(port, "localhost")
+      .await();
+  }
 }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcStatus.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcStatus.java
@@ -62,6 +62,34 @@ public enum GrpcStatus {
     return codeMap.get(code);
   }
 
+  /**
+   * Map an HTTP status code to a gRPC status, see <a href="https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md">spec</a>.
+   * @param sc the HTTP status code
+   * @return the mapped status code
+   */
+  public static GrpcStatus fromHttpStatusCode(int sc) {
+    if (sc < 0) {
+      throw new IllegalArgumentException("Invalid status code: " + sc);
+    }
+    switch (sc) {
+      case 400:
+        return INTERNAL;
+      case 401:
+        return UNAUTHENTICATED;
+      case 403:
+        return PERMISSION_DENIED;
+      case 404:
+        return NOT_FOUND;
+      case 429:
+      case 502:
+      case 503:
+      case 504:
+        return UNAVAILABLE;
+      default:
+        return UNKNOWN;
+    }
+  }
+
   static {
     for (GrpcStatus status : values()) {
       codeMap.put(status.code, status);

--- a/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
+++ b/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
@@ -15,6 +15,7 @@ import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientCalls;
 import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerRequest;
@@ -24,11 +25,16 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.client.GrpcClient;
+import io.vertx.grpc.client.GrpcClientOptions;
+import io.vertx.grpc.client.GrpcClientResponse;
 import io.vertx.grpc.common.GrpcHeaderNames;
+import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpcio.client.GrpcIoClient;
 import io.vertx.grpcio.client.GrpcIoClientChannel;
 import io.vertx.grpcio.common.impl.Utils;
 import io.vertx.tests.common.grpc.*;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -525,7 +531,7 @@ public class ClientBridgeTest extends ClientTest {
       req.endHandler(v -> {
         req.response().putHeader(GrpcHeaderNames.GRPC_STATUS, "0").setStatusCode(500).end();
       });
-    }, Status.Code.INTERNAL);
+    }, Status.Code.UNKNOWN);
   }
 
   @Test
@@ -534,7 +540,7 @@ public class ClientBridgeTest extends ClientTest {
       req.endHandler(v -> {
         req.response().putHeader(GrpcHeaderNames.GRPC_STATUS, "0").setStatusCode(500).end();
       });
-    }, Status.Code.INTERNAL);
+    }, Status.Code.UNKNOWN);
   }
 
   private void testGrpcResponseHttpError(TestContext should, Handler<HttpServerRequest> handler, Status.Code expectedStatus) {
@@ -643,5 +649,22 @@ public class ClientBridgeTest extends ClientTest {
     ClientCall<Request, Reply> call = channel.newCall(unary, CallOptions.DEFAULT);
     Reply response = ClientCalls.blockingUnaryCall(call, Request.newBuilder().setName("Julien").build());
     should.assertEquals("Hello Julien", response.getMessage());
+  }
+
+  @Test
+  public void testHttpInvalidStatusCode() throws Exception {
+    super.testHttpInvalidStatusCode(401);
+
+    client = GrpcIoClient.client(vertx);
+    GrpcIoClientChannel channel = new GrpcIoClientChannel(client, SocketAddress.inetSocketAddress(port, "localhost"));
+
+    TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
+    Iterator<Reply> reply = stub.source(Empty.getDefaultInstance());
+    try {
+      reply.hasNext();
+      fail();
+    } catch (StatusRuntimeException expected) {
+      Assert.assertEquals(Status.UNAUTHENTICATED, expected.getStatus());
+    }
   }
 }


### PR DESCRIPTION
Motivation:

gRPC client does not properly handle HTTP response code, in particular non 200 codes do not need a content-type header.

In addition HTTP response code should be mapped to a gRPC status.

Changes:

Require content-type header only for 200 codes.

Map non 200 codes to a gRPC status.
