### PR TITLE
Correctly handle HttpServerResponse reset signals.

### DIFF
--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
@@ -10,13 +10,10 @@
  */
 package io.vertx.grpc.server.impl;
 
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
-import io.vertx.grpc.common.CodecException;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.common.ServiceName;
@@ -39,6 +36,17 @@ public class GrpcServerRequestImpl<Req, Resp> extends GrpcReadStreamBase<GrpcSer
     this.httpRequest = httpRequest;
     this.response = new GrpcServerResponseImpl<>(this, httpRequest.response(), messageEncoder);
     this.methodCall = methodCall;
+  }
+
+  @Override
+  protected void handleEnd() {
+    super.handleEnd();
+    ((GrpcServerResponseImpl)response).requestEnded();
+  }
+
+  @Override
+  protected void handleReset(long code) {
+    super.handleReset(code);
   }
 
   public String fullMethodName() {

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -16,6 +16,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.StreamResetException;
 import io.vertx.grpc.common.CodecException;
 import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcMessage;
@@ -44,7 +45,7 @@ public class GrpcServerResponseImpl<Req, Resp> implements GrpcServerResponse<Req
   private GrpcStatus status = GrpcStatus.OK;
   private String statusMessage;
   private boolean headersSent;
-  private boolean trailersSent;
+  boolean trailersSent;
   private boolean cancelled;
   private MultiMap headers, trailers;
   private Set<String> acceptedEncodings;
@@ -53,6 +54,18 @@ public class GrpcServerResponseImpl<Req, Resp> implements GrpcServerResponse<Req
     this.request = request;
     this.httpResponse = httpResponse;
     this.encoder = encoder;
+  }
+
+  void requestEnded() {
+    // When request ends set a signal handler for reset.
+    if (!trailersSent && !cancelled) {
+      httpResponse.exceptionHandler(err -> {
+        if (err instanceof StreamResetException) {
+          StreamResetException sre = (StreamResetException) err;
+          request.handleReset(sre.getCode());
+        }
+      });
+    }
   }
 
   public GrpcServerResponse<Req, Resp> status(GrpcStatus status) {

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/ServerRequestTest.java
@@ -18,8 +18,10 @@ import io.grpc.examples.streaming.Empty;
 import io.grpc.examples.streaming.Item;
 import io.grpc.examples.streaming.StreamingGrpc;
 import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.net.SelfSignedCertificate;
@@ -29,6 +31,9 @@ import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.InvalidMessagePayloadException;
 import io.vertx.grpc.common.MessageSizeOverflowException;
+import io.vertx.grpc.common.impl.GrpcMessageImpl;
+import io.vertx.grpcio.server.GrpcIoServer;
+import io.vertx.grpcio.server.GrpcIoServiceBridge;
 import org.junit.Test;
 
 import java.io.File;
@@ -37,6 +42,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -487,5 +496,66 @@ public class ServerRequestTest extends ServerTest {
     }));
 
     test.awaitSuccess(20_000);
+  }
+
+  @Test
+  public void testCancelResponseSignalPropagation(TestContext should) {
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    HttpClient client = vertx.createHttpClient(new HttpClientOptions()
+      .setHttp2ClearTextUpgrade(false)
+      .setProtocolVersion(HttpVersion.HTTP_2));
+
+    try {
+      Async async = should.async();
+
+      StreamingGrpc.StreamingImplBase impl = new StreamingGrpc.StreamingImplBase() {
+        @Override
+        public StreamObserver<Item> sink(StreamObserver<Empty> responseObserver) {
+          return new StreamObserver<Item>() {
+            @Override
+            public void onNext(Item value) {
+            }
+            @Override
+            public void onError(Throwable t) {
+            }
+            @Override
+            public void onCompleted() {
+              ServerCallStreamObserver<?> superObserver = (ServerCallStreamObserver<?>)responseObserver;
+              executor.execute(() -> {
+                while (true) {
+                  try {
+                    Thread.sleep(10);
+                  } catch (InterruptedException ignore) {
+                    break;
+                  }
+                  if (superObserver.isCancelled()) {
+                    async.complete();
+                    break;
+                  }
+                }
+              });
+            }
+          };
+        }
+      };
+
+      GrpcIoServer server = GrpcIoServer.server(vertx);
+      GrpcIoServiceBridge serverStub = GrpcIoServiceBridge.bridge(impl);
+      serverStub.bind(server);
+      startServer(server);
+
+      client.request(HttpMethod.POST, port, "localhost", "/" + StreamingGrpc.SERVICE_NAME + "/Sink")
+        .onComplete(should.asyncAssertSuccess(req -> {
+          req.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
+          req.end(GrpcMessageImpl.encode(Buffer.buffer(Item.getDefaultInstance().toByteArray()), false));
+          req.reset(GrpcError.CANCELLED.http2ResetCode);
+        }));
+
+      async.awaitSuccess();
+    } finally {
+      client.close();
+      executor.shutdownNow();
+    }
   }
 }


### PR DESCRIPTION
Motivation:

Vert.x gRPC server does not handle HttpServerResponse reset signals, leading to missing signal from the gRPC interaction perspective.

Changes:

Also handle gRPC server response.
