### PR TITLE
Correctly handle HttpServerResponse reset signals.

### DIFF
--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
@@ -23,6 +23,7 @@ import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.*;
+import io.vertx.grpc.common.impl.GrpcMessageImpl;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerOptions;
 import io.vertx.grpc.server.GrpcServerResponse;
@@ -39,6 +40,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -642,5 +645,23 @@ public class ServerRequestTest extends ServerTest {
       }));
 
     test.awaitSuccess(20_000);
+  }
+
+  @Test
+  public void testCancelResponseSignalPropagation(TestContext should) {
+
+    Async async = should.async();
+
+    startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
+      call.endHandler(v -> {
+        call.errorHandler(err -> {
+          async.complete();
+        });
+      });
+    }));
+
+    super.testCancelResponseSignalPropagation(should);
+
+    async.awaitSuccess();
   }
 }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
@@ -19,11 +19,9 @@ import io.vertx.core.http.*;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.grpc.common.GrpcHeaderNames;
-import io.vertx.grpc.common.GrpcMessage;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.common.*;
 import io.vertx.grpc.common.impl.GrpcMessageImpl;
+import io.vertx.grpc.server.GrpcServer;
 import io.vertx.tests.common.grpc.*;
 import org.junit.Test;
 
@@ -42,6 +40,16 @@ import java.util.stream.IntStream;
 public abstract class ServerTest extends ServerTestBase {
 
   static final int NUM_ITEMS = 128;
+  private HttpClient client;
+
+  @Override
+  public void tearDown(TestContext should) {
+    super.tearDown(should);
+    if (client != null) {
+      client.close().await();
+      client = null;
+    }
+  }
 
   @Test
   public void testUnary(TestContext should) {
@@ -512,5 +520,18 @@ public abstract class ServerTest extends ServerTestBase {
       }));
 
     async.awaitSuccess();
+  }
+
+  @Test
+  public void testCancelResponseSignalPropagation(TestContext should) {
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setHttp2ClearTextUpgrade(false)
+      .setProtocolVersion(HttpVersion.HTTP_2));
+    client.request(HttpMethod.POST, port, "localhost", "/" + UNARY.fullMethodName())
+      .onComplete(should.asyncAssertSuccess(req -> {
+        req.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
+        req.end(GrpcMessageImpl.encode(Buffer.buffer(Request.getDefaultInstance().toByteArray()), false, false));
+        req.reset(GrpcError.CANCELLED.http2ResetCode);
+      }));
   }
 }

--- a/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
+++ b/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
@@ -26,6 +26,8 @@ import io.vertx.tests.common.grpc.*;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -683,6 +685,47 @@ public class ServerBridgeTest extends ServerTest {
       if (!finishLatch.await(10, TimeUnit.SECONDS)) {
         should.fail();
       }
+    }
+  }
+
+  @Test
+  public void testCancelResponseSignalPropagation(TestContext should) {
+
+    Async async = should.async();
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    try {
+      TestServiceGrpc.TestServiceImplBase impl = new TestServiceGrpc.TestServiceImplBase() {
+        @Override
+        public void unary(Request request, StreamObserver<Reply> responseObserver) {
+          ServerCallStreamObserver<?> superObserver = (ServerCallStreamObserver<?>)responseObserver;
+          executor.execute(() -> {
+            while (true) {
+              try {
+                Thread.sleep(10);
+              } catch (InterruptedException ignore) {
+                break;
+              }
+              if (superObserver.isCancelled()) {
+                async.complete();
+                break;
+              }
+            }
+          });
+        }
+      };
+
+      GrpcIoServer server = GrpcIoServer.server(vertx);
+      GrpcIoServiceBridge serverStub = GrpcIoServiceBridge.bridge(impl);
+      serverStub.bind(server);
+      startServer(server);
+
+      super.testCancelResponseSignalPropagation(should);
+
+      async.awaitSuccess();
+    } finally {
+      executor.shutdownNow();
     }
   }
 }


### PR DESCRIPTION
Motivation:

Vert.x gRPC server does not handle HttpServerResponse reset signals, leading to missing signal from the gRPC interaction perspective.

Changes:

Also handle gRPC server response.
