### PR TITLE
Correctly handle HttpServerResponse reset signals.

### DIFF
--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
@@ -659,4 +659,22 @@ public class ServerRequestTest extends ServerTest {
 
     test.awaitSuccess(20_000);
   }
+
+  @Test
+  public void testCancelResponseSignalPropagation(TestContext should) {
+
+    Async async = should.async();
+
+    startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
+      call.endHandler(v -> {
+        call.errorHandler(err -> {
+          async.complete();
+        });
+      });
+    }));
+
+    super.testCancelResponseSignalPropagation(should);
+
+    async.awaitSuccess();
+  }
 }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerTest.java
@@ -19,10 +19,7 @@ import io.vertx.core.http.*;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.grpc.common.GrpcHeaderNames;
-import io.vertx.grpc.common.GrpcMessage;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.common.*;
 import io.vertx.grpc.common.impl.DefaultGrpcMessage;
 import io.vertx.tests.common.grpc.*;
 import org.junit.Test;
@@ -42,6 +39,16 @@ import java.util.stream.IntStream;
 public abstract class ServerTest extends ServerTestBase {
 
   static final int NUM_ITEMS = 128;
+  private HttpClient client;
+
+  @Override
+  public void tearDown(TestContext should) {
+    super.tearDown(should);
+    if (client != null) {
+      client.close().await();
+      client = null;
+    }
+  }
 
   @Test
   public void testUnary(TestContext should) {
@@ -379,7 +386,7 @@ public abstract class ServerTest extends ServerTestBase {
       .usePlaintext()
       .build();
 
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions()
+    client = vertx.createHttpClient(new HttpClientOptions()
       .setHttp2ClearTextUpgrade(false)
       .setProtocolVersion(HttpVersion.HTTP_2));
     Async async = should.async();
@@ -410,7 +417,7 @@ public abstract class ServerTest extends ServerTestBase {
 
   @Test
   public void testTrailersOnly(TestContext should) {
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions()
+    client = vertx.createHttpClient(new HttpClientOptions()
       .setHttp2ClearTextUpgrade(false)
       .setProtocolVersion(HttpVersion.HTTP_2));
     Async async = should.async();
@@ -433,7 +440,7 @@ public abstract class ServerTest extends ServerTestBase {
 
   @Test
   public void testDistinctHeadersAndTrailers(TestContext should) {
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions()
+    client = vertx.createHttpClient(new HttpClientOptions()
       .setHttp2ClearTextUpgrade(false)
       .setProtocolVersion(HttpVersion.HTTP_2));
     Async async = should.async();
@@ -456,7 +463,7 @@ public abstract class ServerTest extends ServerTestBase {
 
   @Test
   public void testTimeoutOnServerBeforeSendingResponse(TestContext should) throws Exception {
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions()
+    client = vertx.createHttpClient(new HttpClientOptions()
       .setHttp2ClearTextUpgrade(false)
       .setProtocolVersion(HttpVersion.HTTP_2));
     Async async = should.async();
@@ -491,7 +498,7 @@ public abstract class ServerTest extends ServerTestBase {
     JsonObject helloReply = new JsonObject().put("message", "Hello Julien");
     JsonObject helloRequest = new JsonObject().put("name", "Julien");
 
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions()
+    client = vertx.createHttpClient(new HttpClientOptions()
       .setHttp2ClearTextUpgrade(false)
       .setProtocolVersion(HttpVersion.HTTP_2));
     Async async = should.async();
@@ -512,5 +519,18 @@ public abstract class ServerTest extends ServerTestBase {
       }));
 
     async.awaitSuccess();
+  }
+
+  @Test
+  public void testCancelResponseSignalPropagation(TestContext should) {
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setHttp2ClearTextUpgrade(false)
+      .setProtocolVersion(HttpVersion.HTTP_2));
+    client.request(HttpMethod.POST, port, "localhost", "/" + UNARY.fullMethodName())
+      .onComplete(should.asyncAssertSuccess(req -> {
+        req.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
+        req.end(DefaultGrpcMessage.encode(Buffer.buffer(Request.getDefaultInstance().toByteArray()), false, false));
+        req.reset(GrpcError.CANCELLED.http2ResetCode);
+      }));
   }
 }

--- a/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
+++ b/vertx-grpcio-server/src/test/java/io/vertx/tests/server/ServerBridgeTest.java
@@ -18,7 +18,6 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpcio.common.impl.Utils;
 import io.vertx.grpcio.server.GrpcIoServer;
 import io.vertx.grpcio.server.GrpcIoServiceBridge;
@@ -26,6 +25,8 @@ import io.vertx.tests.common.grpc.*;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -683,6 +684,47 @@ public class ServerBridgeTest extends ServerTest {
       if (!finishLatch.await(10, TimeUnit.SECONDS)) {
         should.fail();
       }
+    }
+  }
+
+  @Test
+  public void testCancelResponseSignalPropagation(TestContext should) {
+
+    Async async = should.async();
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    try {
+      TestServiceGrpc.TestServiceImplBase impl = new TestServiceGrpc.TestServiceImplBase() {
+        @Override
+        public void unary(Request request, StreamObserver<Reply> responseObserver) {
+          ServerCallStreamObserver<?> superObserver = (ServerCallStreamObserver<?>)responseObserver;
+          executor.execute(() -> {
+            while (true) {
+              try {
+                Thread.sleep(10);
+              } catch (InterruptedException ignore) {
+                break;
+              }
+              if (superObserver.isCancelled()) {
+                async.complete();
+                break;
+              }
+            }
+          });
+        }
+      };
+
+      GrpcIoServer server = GrpcIoServer.server(vertx);
+      GrpcIoServiceBridge serverStub = GrpcIoServiceBridge.bridge(impl);
+      serverStub.bind(server);
+      startServer(server);
+
+      super.testCancelResponseSignalPropagation(should);
+
+      async.awaitSuccess();
+    } finally {
+      executor.shutdownNow();
     }
   }
 }


### PR DESCRIPTION
Motivation:

Vert.x gRPC server does not handle HttpServerResponse reset signals, leading to missing signal from the gRPC interaction perspective.

Changes:

Also handle gRPC server response.
