### PR TITLE
Support code generation for lower camel case proto method names.

### DIFF
--- a/vertx-grpc-it/src/test/proto/helloworld.proto
+++ b/vertx-grpc-it/src/test/proto/helloworld.proto
@@ -95,6 +95,10 @@ service Greeter {
 
   // Sends a greeting without the options
   rpc SayHelloWithoutOptions (HelloRequest) returns (HelloReply) {}
+
+  // Bogus method with a lowerCamelCase name to exercise code generation for
+  // non-conventional proto method names. Not invoked by tests.
+  rpc sayHelloLowerCamel (HelloRequest) returns (HelloReply) {}
 }
 
 // The request message containing the user's name.

--- a/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/generation/context/MethodTemplateContext.java
+++ b/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/generation/context/MethodTemplateContext.java
@@ -1,5 +1,7 @@
 package io.vertx.grpc.plugin.generation.context;
 
+import io.vertx.codegen.format.CamelCase;
+import io.vertx.codegen.format.LowerCamelCase;
 import io.vertx.grpc.plugin.descriptors.MethodDescriptor;
 
 public class MethodTemplateContext {
@@ -49,7 +51,7 @@ public class MethodTemplateContext {
   }
 
   public String methodNameGetter() {
-    return NameUtils.formatMethodName("Get" + methodName + "Method");
+    return NameUtils.formatMethodName("Get" + CamelCase.INSTANCE.format(LowerCamelCase.INSTANCE.parse(methodName)) + "Method");
   }
 
   private static String buildMethodHeader(MethodDescriptor method) {


### PR DESCRIPTION
Motivation:

- Ensure compatibility with proto definitions using unconventional lower camel case method names.

Changes:

- Updated `methodNameGetter` logic to handle method names by converting them to proper camel case format.
- Added a test case with a non-conventional `sayHelloLowerCamel` proto method to validate the fix.

Fixes: #262 
