### PR TITLE
add support for DEADLINE_EXCEEDED

### DIFF
--- a/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
+++ b/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
@@ -125,6 +125,10 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
             }
             readAdapter.init(grpcResponse, decoder);
             grpcResponse.end().onComplete(ar -> {
+              if (deadline != null && deadline.isExpired()) {
+                doClose(Status.DEADLINE_EXCEEDED.withDescription("Deadline exceeded"), new Metadata());
+                return;
+              }
               Status status;
               Metadata trailers;
               if (grpcResponse.status() != null) {
@@ -140,12 +144,16 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
               doClose(status, trailers);
             });
           } else {
-            Throwable err = ar2.cause();
-            if (err instanceof GrpcErrorException) {
-              GrpcErrorException reset = (GrpcErrorException) err;
-              doClose(Status.fromCodeValue(reset.status().code), new Metadata());
+            if (deadline != null && deadline.isExpired()) {
+              doClose(Status.DEADLINE_EXCEEDED.withDescription("Deadline exceeded"), new Metadata());
             } else {
-              doClose(Status.fromThrowable(err), new Metadata());
+              Throwable err = ar2.cause();
+              if (err instanceof GrpcErrorException) {
+                GrpcErrorException reset = (GrpcErrorException) err;
+                doClose(Status.fromCodeValue(reset.status().code), new Metadata());
+              } else {
+                doClose(Status.fromThrowable(err), new Metadata());
+              }
             }
           }
         });

--- a/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
+++ b/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
@@ -607,7 +607,7 @@ public class ClientBridgeTest extends ClientTest {
     try {
       c.accept(stub);
     } catch (StatusRuntimeException e) {
-      should.assertEquals(Status.Code.CANCELLED, e.getStatus().getCode());
+      should.assertEquals(Status.Code.DEADLINE_EXCEEDED, e.getStatus().getCode());
     }
   }
 


### PR DESCRIPTION
When a deadline expires, the underlying HTTP/2 stream is reset with CANCELLED (the only applicable HTTP/2 error code). VertxClientCall now checks deadline.isExpired() before closing and returns DEADLINE_EXCEEDED when appropriate.

Problem was found in Quarkus [here](https://github.com/quarkusio/quarkus/pull/53627#issue-4269065263).
