### PR TITLE
Transcoding/spec conformant message weaver

### DIFF
--- a/vertx-grpc-docs/src/main/asciidoc/transcoding.adoc
+++ b/vertx-grpc-docs/src/main/asciidoc/transcoding.adoc
@@ -115,6 +115,7 @@ service Greeter {
       get: "/v1/hello/{name}"
       additional_bindings {
         post: "/v1/hello"  // Alternative POST endpoint
+        body: "*"          // Use the HTTP body as the request message
       }
     };
   }
@@ -123,6 +124,7 @@ service Greeter {
   rpc SayHelloAgain (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
       post: "/v2/hello"
+      body: "*"
       additional_bindings {
         get: "/v2/hello/{name}"
       }
@@ -150,6 +152,15 @@ service Greeter {
 ----
 
 ==== Request Body Handling
+
+The `body` field on an `HttpRule` controls how the HTTP request body is mapped into the gRPC message:
+
+* Omitted: the HTTP request body is not used; the message is built only from path and query parameters.
+* `body: "*"`: the entire HTTP request body is mapped to the root of the gRPC message.
+* `body: "<field>"`: the HTTP request body is mapped to that specific top-level field.
+
+Path and query parameter bindings always take precedence over body fields on collision.
+
 [source,proto]
 ----
 service Greeter {

--- a/vertx-grpc-it/src/test/proto/helloworld.proto
+++ b/vertx-grpc-it/src/test/proto/helloworld.proto
@@ -46,6 +46,7 @@ service Greeter {
       get: "/v1/hello/{name}"
       additional_bindings {
         post: "/v1/hello"
+        body: "*"
       }
     };
   }
@@ -54,6 +55,7 @@ service Greeter {
   rpc SayHelloAgain (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
       post: "/v2/hello"
+      body: "*"
       additional_bindings {
         get: "/v2/hello/{name}"
       }
@@ -89,6 +91,7 @@ service Greeter {
   rpc SayHelloWithResponseBOdy (HelloRequest) returns (HelloBodyResponse) {
     option (google.api.http) = {
       post: "/v1/hello/body/response"
+      body: "*"
       response_body: "response"
     };
   }

--- a/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/MessageWeaver.java
+++ b/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/MessageWeaver.java
@@ -33,31 +33,31 @@ public final class MessageWeaver {
    * @throws DecodeException If JSON decoding fails
    */
   public static Buffer weaveRequestMessage(Buffer message, List<HttpVariableBinding> bindings, String transcodingRequestBody, Descriptors.Descriptor descriptor) throws DecodeException {
-    if ((bindings == null || bindings.isEmpty()) && transcodingRequestBody == null) {
-      return message;
+    boolean hasBindings = bindings != null && !bindings.isEmpty();
+    boolean hasBody = transcodingRequestBody != null && !transcodingRequestBody.isEmpty();
+
+    if (!hasBindings && !hasBody) {
+      return new JsonObject().toBuffer();
     }
 
     JsonObject result = new JsonObject();
 
-    if (bindings != null && !bindings.isEmpty()) {
-      applyBindings(result, bindings, descriptor);
-    }
-
-    JsonObject messageJson = null;
-    if (message != null && !message.toString().isBlank()) {
-      messageJson = message.toJsonObject();
-    }
-
-    if (messageJson != null && !messageJson.isEmpty()) {
-      if (transcodingRequestBody == null || transcodingRequestBody.isEmpty()) {
-        // No specific path, merge at root level with deep copy
-        result.mergeIn(messageJson, true);
-      } else if (ROOT_LEVEL.equals(transcodingRequestBody)) {
-        // Wildcard, merge at root level without overwriting bindings
-        result.mergeIn(messageJson);
-      } else {
-        applyAtPath(result, transcodingRequestBody.split("\\."), messageJson);
+    if (hasBody) {
+      JsonObject messageJson = null;
+      if (message != null && !message.toString().isBlank()) {
+        messageJson = message.toJsonObject();
       }
+      if (messageJson != null && !messageJson.isEmpty()) {
+        if (ROOT_LEVEL.equals(transcodingRequestBody)) {
+          result.mergeIn(messageJson, true);
+        } else {
+          applyAtPath(result, transcodingRequestBody.split("\\."), messageJson);
+        }
+      }
+    }
+
+    if (hasBindings) {
+      applyBindings(result, bindings, descriptor);
     }
 
     return result.toBuffer();

--- a/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/MessageWeaver.java
+++ b/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/MessageWeaver.java
@@ -13,6 +13,18 @@ import java.util.Objects;
 /**
  * The MessageWeaver class handles the merging and transformation of gRPC messages during HTTP-to-gRPC transcoding operations.
  *
+ * <p>The body-field semantics follow the {@code google.api.HttpRule} contract: when {@code body} is unset, the HTTP request
+ * body is ignored and the gRPC message is built only from path/query bindings; {@code body = "*"} maps the entire HTTP body
+ * to the root of the gRPC message; {@code body = "field"} (or a dotted path) maps the HTTP body to that field. Bindings
+ * are applied on top of the body content so path/query values take precedence on collision.
+ *
+ * <p>Reference implementations:
+ * <ul>
+ *   <li>Spec: <a href="https://github.com/googleapis/googleapis/blob/master/google/api/http.proto">google/api/http.proto</a> (the {@code HttpRule.body} field comment)</li>
+ *   <li>C++ (reference): <a href="https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/blob/master/src/include/grpc_transcoding/request_weaver.h">RequestWeaver</a></li>
+ *   <li>C# (ASP.NET Core): <a href="https://github.com/dotnet/aspnetcore/blob/main/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs">JsonRequestHelpers.ReadMessage</a></li>
+ * </ul>
+ *
  * @see HttpVariableBinding
  */
 public final class MessageWeaver {

--- a/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingServiceMethodImpl.java
+++ b/vertx-grpc-transcoding/src/main/java/io/vertx/grpc/transcoding/impl/TranscodingServiceMethodImpl.java
@@ -89,7 +89,7 @@ public class TranscodingServiceMethodImpl<I, O> implements TranscodingServiceMet
     if (res != null) {
       List<HttpVariableBinding> bindings = new ArrayList<>(res.getVariableBindings());
       io.vertx.core.internal.ContextInternal context = ((HttpServerRequestInternal) httpRequest).context();
-      TranscodingMessageDecoder<I> messageDecoder = new TranscodingMessageDecoder<>(decoder, options.getBody(), bindings);
+      TranscodingMessageDecoder<I> messageDecoder = new TranscodingMessageDecoder<>(decoder, res.getBodyFieldPath(), bindings);
       TranscodingMessageDeframer deframer = new TranscodingMessageDeframer();
       HttpGrpcOutboundStream protocolHandler = new TranscodingGrpcOutboundStream(context, httpRequest, options.getResponseBody(), deframer);
       return new GrpcInvocation(deframer, protocolHandler, messageDecoder);

--- a/vertx-grpc-transcoding/src/test/java/io/vertx/tests/transcoding/MessageWeaverTest.java
+++ b/vertx-grpc-transcoding/src/test/java/io/vertx/tests/transcoding/MessageWeaverTest.java
@@ -85,7 +85,7 @@ public class MessageWeaverTest {
     Buffer result = MessageWeaver.weaveRequestMessage(
       Buffer.buffer(message.encode()),
       new ArrayList<>(),
-      null,
+      "*",
       TEST_DESCRIPTOR
     );
 
@@ -112,7 +112,7 @@ public class MessageWeaverTest {
     Buffer result = MessageWeaver.weaveRequestMessage(
       Buffer.buffer(original.encode()),
       bindings,
-      null,
+      "*",
       TEST_DESCRIPTOR
     );
 
@@ -143,7 +143,7 @@ public class MessageWeaverTest {
     Buffer result = MessageWeaver.weaveRequestMessage(
       Buffer.buffer(original.encode()),
       bindings,
-      null,
+      "*",
       TEST_DESCRIPTOR
     );
 
@@ -182,7 +182,7 @@ public class MessageWeaverTest {
     Buffer result = MessageWeaver.weaveRequestMessage(
       Buffer.buffer(original.encode()),
       bindings,
-      null,
+      "*",
       TEST_DESCRIPTOR
     );
 
@@ -336,7 +336,7 @@ public class MessageWeaverTest {
     Buffer result = MessageWeaver.weaveRequestMessage(
       Buffer.buffer(body.encode()),
       bindings,
-      null,
+      "*",
       TEST_DESCRIPTOR
     );
 
@@ -379,6 +379,30 @@ public class MessageWeaverTest {
     );
 
     assertEquals(expected, new JsonObject(result.toString()));
+  }
+
+  @Test
+  public void testEmptyMessageReturnsEmptyObject() {
+    Buffer fromNull = MessageWeaver.weaveRequestMessage(null, new ArrayList<>(), null, TEST_DESCRIPTOR);
+    assertEquals(new JsonObject(), new JsonObject(fromNull.toString()));
+
+    Buffer fromEmpty = MessageWeaver.weaveRequestMessage(Buffer.buffer(), new ArrayList<>(), null, TEST_DESCRIPTOR);
+    assertEquals(new JsonObject(), new JsonObject(fromEmpty.toString()));
+
+    Buffer fromEmptyBody = MessageWeaver.weaveRequestMessage(Buffer.buffer(), new ArrayList<>(), "", TEST_DESCRIPTOR);
+    assertEquals(new JsonObject(), new JsonObject(fromEmptyBody.toString()));
+  }
+
+  @Test
+  public void testUnsetBodyIgnoresHttpBody() {
+    JsonObject httpBody = new JsonObject().put("field1", "value1");
+    Buffer result = MessageWeaver.weaveRequestMessage(
+      Buffer.buffer(httpBody.encode()),
+      new ArrayList<>(),
+      null,
+      TEST_DESCRIPTOR
+    );
+    assertEquals(new JsonObject(), new JsonObject(result.toString()));
   }
 
   @Test

--- a/vertx-grpc-transcoding/src/test/java/io/vertx/tests/transcoding/MessageWeaverTest.java
+++ b/vertx-grpc-transcoding/src/test/java/io/vertx/tests/transcoding/MessageWeaverTest.java
@@ -406,6 +406,151 @@ public class MessageWeaverTest {
   }
 
   @Test
+  public void testBindingOverridesBodyScalar() {
+    addBinding("y", "from-binding");
+
+    JsonObject body = new JsonObject()
+      .put("y", "from-body")
+      .put("A", new JsonObject().put("y", "nested-body"));
+
+    JsonObject expected = new JsonObject()
+      .put("y", "from-binding")
+      .put("A", new JsonObject().put("y", "nested-body"));
+
+    Buffer result = MessageWeaver.weaveRequestMessage(
+      Buffer.buffer(body.encode()),
+      bindings,
+      "*",
+      TEST_DESCRIPTOR
+    );
+
+    assertEquals(expected, new JsonObject(result.toString()));
+  }
+
+  @Test
+  public void testBindingOverridesNestedBodyScalar() {
+    addBinding("A.y", "from-binding");
+
+    JsonObject body = new JsonObject()
+      .put("A", new JsonObject().put("y", "from-body").put("x", new JsonArray().add("k")));
+
+    JsonObject expected = new JsonObject()
+      .put("A", new JsonObject().put("y", "from-binding").put("x", new JsonArray().add("k")));
+
+    Buffer result = MessageWeaver.weaveRequestMessage(
+      Buffer.buffer(body.encode()),
+      bindings,
+      "*",
+      TEST_DESCRIPTOR
+    );
+
+    assertEquals(expected, new JsonObject(result.toString()));
+  }
+
+  @Test
+  public void testBindingCreatesSubtreeAbsentFromBody() {
+    addBinding("A.y", "from-binding");
+
+    JsonObject body = new JsonObject().put("y", "root-body");
+
+    JsonObject expected = new JsonObject()
+      .put("y", "root-body")
+      .put("A", new JsonObject().put("y", "from-binding"));
+
+    Buffer result = MessageWeaver.weaveRequestMessage(
+      Buffer.buffer(body.encode()),
+      bindings,
+      "*",
+      TEST_DESCRIPTOR
+    );
+
+    assertEquals(expected, new JsonObject(result.toString()));
+  }
+
+  @Test
+  public void testRepeatedBindingAppendedToBodyValues() {
+    addBinding("x", "b");
+    addBinding("x", "c");
+
+    JsonObject body = new JsonObject().put("x", new JsonArray().add("a"));
+
+    JsonObject expected = new JsonObject()
+      .put("x", new JsonArray().add("a").add("b").add("c"));
+
+    Buffer result = MessageWeaver.weaveRequestMessage(
+      Buffer.buffer(body.encode()),
+      bindings,
+      "*",
+      TEST_DESCRIPTOR
+    );
+
+    assertEquals(expected, new JsonObject(result.toString()));
+  }
+
+  @Test
+  public void testBindingAndBodyAtSpecificPath() {
+    addBinding("A.y", "from-binding");
+
+    JsonObject body = new JsonObject().put("x", new JsonArray().add("b"));
+
+    JsonObject expected = new JsonObject()
+      .put("A", new JsonObject()
+        .put("x", new JsonArray().add("b"))
+        .put("y", "from-binding"));
+
+    Buffer result = MessageWeaver.weaveRequestMessage(
+      Buffer.buffer(body.encode()),
+      bindings,
+      "A",
+      TEST_DESCRIPTOR
+    );
+
+    assertEquals(expected, new JsonObject(result.toString()));
+  }
+
+  @Test
+  public void testBindingsDoNotDescendIntoArrayElements() {
+    addBinding("A.y", "from-binding");
+
+    JsonObject body = new JsonObject()
+      .put("L", new JsonArray()
+        .add(new JsonObject().put("A", new JsonObject().put("x", "in-array"))));
+
+    JsonObject expected = new JsonObject()
+      .put("L", new JsonArray()
+        .add(new JsonObject().put("A", new JsonObject().put("x", "in-array"))))
+      .put("A", new JsonObject().put("y", "from-binding"));
+
+    Buffer result = MessageWeaver.weaveRequestMessage(
+      Buffer.buffer(body.encode()),
+      bindings,
+      "*",
+      TEST_DESCRIPTOR
+    );
+
+    assertEquals(expected, new JsonObject(result.toString()));
+  }
+
+  @Test
+  public void testDeepBodyPath() {
+    JsonObject body = new JsonObject().put("payload", "v");
+
+    JsonObject expected = new JsonObject()
+      .put("a", new JsonObject()
+        .put("b", new JsonObject()
+          .put("c", body)));
+
+    Buffer result = MessageWeaver.weaveRequestMessage(
+      Buffer.buffer(body.encode()),
+      new ArrayList<>(),
+      "a.b.c",
+      TEST_DESCRIPTOR
+    );
+
+    assertEquals(expected, new JsonObject(result.toString()));
+  }
+
+  @Test
   public void testInvalidJson() {
     assertThrows(DecodeException.class, () -> MessageWeaver.weaveRequestMessage(
       Buffer.buffer("invalid json"),

--- a/vertx-grpc-transcoding/src/test/java/io/vertx/tests/transcoding/ServerTranscodingTest.java
+++ b/vertx-grpc-transcoding/src/test/java/io/vertx/tests/transcoding/ServerTranscodingTest.java
@@ -62,12 +62,12 @@ public class ServerTranscodingTest extends GrpcTestBase {
 
   public static final ServiceName TEST_SERVICE_NAME = ServiceName.create(TestServiceGrpc.SERVICE_NAME);
 
-  public static final MethodTranscodingOptions EMPTY_TRANSCODING = new MethodTranscodingOptions().setHttpMethod(HttpMethod.POST).setPath("/hello").setBody("");
-  public static final MethodTranscodingOptions UNARY_TRANSCODING = new MethodTranscodingOptions().setPath("/hello");
+  public static final MethodTranscodingOptions EMPTY_TRANSCODING = new MethodTranscodingOptions().setHttpMethod(HttpMethod.POST).setPath("/hello");
+  public static final MethodTranscodingOptions UNARY_TRANSCODING = new MethodTranscodingOptions().setPath("/hello").setBody("*");
   public static final MethodTranscodingOptions UNARY_TRANSCODING_WITH_PARAM = new MethodTranscodingOptions().setPath("/hello/{payload}");
-  public static final MethodTranscodingOptions UNARY_TRANSCODING_WITH_CUSTOM_METHOD = new MethodTranscodingOptions().setHttpMethod(HttpMethod.valueOf("ACL")).setPath("/hello");
+  public static final MethodTranscodingOptions UNARY_TRANSCODING_WITH_CUSTOM_METHOD = new MethodTranscodingOptions().setHttpMethod(HttpMethod.valueOf("ACL")).setPath("/hello").setBody("*");
   public static final MethodTranscodingOptions UNARY_TRANSCODING_WITH_BODY = new MethodTranscodingOptions().setPath("/body").setBody("request");
-  public static final MethodTranscodingOptions UNARY_TRANSCODING_WITH_RESPONSE_BODY = new MethodTranscodingOptions().setPath("/response").setResponseBody("response");
+  public static final MethodTranscodingOptions UNARY_TRANSCODING_WITH_RESPONSE_BODY = new MethodTranscodingOptions().setPath("/response").setResponseBody("response").setBody("*");
   public static final MethodTranscodingOptions UNARY_TRANSCODING_WITH_REPEATED_QUERY = new MethodTranscodingOptions().setPath("/keys");
 
   public static final TranscodingServiceMethod<Empty, Empty> EMPTY_CALL = TranscodingServiceMethod.server(TEST_SERVICE_NAME, "EmptyCall", EMPTY_ENCODER, EMPTY_DECODER, EMPTY_TRANSCODING);


### PR DESCRIPTION
## Motivation

Follow-up to #265. The original PR fixed the 400 on empty-message RPCs by adjusting the fast-track and adding `setBody("")` to the test, but the underlying `MessageWeaver` was not actually conforming to the `google.api.HttpRule` body semantics:

- When `body` was unset, the HTTP request body was still being merged at the root of the gRPC message, even though per the spec an unset `body` means the HTTP body should be ignored.
- When `body = "*"`, a shallow merge was used and path/query bindings did not consistently take precedence on collision.
- A latent bug in `TranscodingServiceMethodImpl.accept` always read the body field from the top-level `MethodTranscodingOptions`, silently ignoring any `body` declared on an `additional_bindings` entry.

This PR makes the behavior match the HttpRule contract, to align with the reference implementations in C++ ([grpc-ecosystem/grpc-httpjson-transcoding `request_weaver.h`](https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/blob/master/src/include/grpc_transcoding/request_weaver.h)) and C# ([Microsoft.AspNetCore.Grpc.JsonTranscoding `JsonRequestHelpers.ReadMessage`](https://github.com/dotnet/aspnetcore/blob/main/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs)). The spec itself is the `body` field comment in [`google/api/http.proto`](https://github.com/googleapis/googleapis/blob/master/google/api/http.proto).