### PR TITLE
Redefine the role of the io.vertx.grpc.server.Service interface.

### DIFF
--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
@@ -90,6 +90,18 @@ public class GreeterGrpcService extends GreeterService implements Service {
     SayHello_OPTIONS
   );
 
+  private final Invoker invoker = new Invoker(this, all());
+
+  @Override
+  public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+    invoker.handle(request);
+  }
+
+  @Override
+  public List<ServiceMethod<?, ?>> methods() {
+    return invoker.methods();
+  }
+
   /**
    * @return a free form builder that gives the opportunity to bind only certain methods of a service
    */
@@ -125,60 +137,66 @@ public class GreeterGrpcService extends GreeterService implements Service {
     }
 
     public Service build() {
-      return new Invoker();
+      return new Invoker(instance, new ArrayList<>(serviceMethods));
+    }
+  }
+
+  private static class Invoker implements Service {
+
+    private final GreeterService instance;
+    private final List<ServiceMethod<?, ?>> serviceMethods;
+    private final Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers;
+
+    public Invoker(GreeterService instance, List<ServiceMethod<?, ?>> serviceMethods) {
+      Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
+      for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+        Handler<? extends GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);
+        handlers.put(serviceMethod.methodName(), handler);
+      }
+
+      this.instance = instance;
+      this.handlers = handlers;
+      this.serviceMethods = serviceMethods;
     }
 
-    private class Invoker implements Service {
+    @Override
+    public ServiceName name() {
+      return SERVICE_NAME;
+    }
 
-      // Defensive copy
-      private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>(Builder.this.serviceMethods);
-      private final Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
+    @Override
+    public Descriptors.ServiceDescriptor descriptor() {
+      return SERVICE_DESCRIPTOR;
+    }
 
-      {
-        for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
-          Handler<? extends GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);
-          handlers.put(serviceMethod.methodName(), handler);
-        }
+    @Override
+    public List<ServiceMethod<?, ?>> methods() {
+      return serviceMethods;
+    }
+
+    @Override
+    public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+      Handler handler = handlers.get(request.methodName());
+      if (handler != null) {
+        handler.handle(request);
+      } else {
+        Service.super.handle(request);
       }
+    }
 
-      @Override
-      public ServiceName name() {
-        return SERVICE_NAME;
-      }
+    private <Req, Resp> void bindHandler(ServiceMethod<Req, Resp> serviceMethod, GrpcServer server) {
+      Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> handler = resolveHandler(serviceMethod);
+      server.callHandler(serviceMethod, handler);
+    }
 
-      @Override
-      public Descriptors.ServiceDescriptor descriptor() {
-        return SERVICE_DESCRIPTOR;
+    private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
+      if (SayHello == serviceMethod) {
+        Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.HelloRequest, examples.grpc.HelloReply>> handler = this::handle_sayHello;
+        Handler<?> handler2 = handler;
+        return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
       }
-
-      @Override
-      public List<ServiceMethod<?, ?>> methods() {
-        return serviceMethods;
-      }
-
-      @Override
-      public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
-        Handler handler = handlers.get(request.methodName());
-        if (handler != null) {
-          handler.handle(request);
-        } else {
-          Service.super.handle(request);
-        }
-      }
-
-      private <Req, Resp> void bindHandler(ServiceMethod<Req, Resp> serviceMethod, GrpcServer server) {
-        Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> handler = resolveHandler(serviceMethod);
-        server.callHandler(serviceMethod, handler);
-      }
-
-      private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
-        if (SayHello == serviceMethod) {
-          Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.HelloRequest, examples.grpc.HelloReply>> handler = this::handle_sayHello;
-          Handler<?> handler2 = handler;
-          return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
-        }
-        return null;
-      }
+      return null;
+    }
 
 
   private void handle_sayHello(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.HelloRequest, examples.grpc.HelloReply> request) {
@@ -192,6 +210,5 @@ public class GreeterGrpcService extends GreeterService implements Service {
       });
     });
   }
-    }
   }
 }

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
@@ -14,7 +14,6 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.ServiceBuilder;
 import io.vertx.grpc.server.StatusException;
 
 import com.google.protobuf.Descriptors;
@@ -22,6 +21,8 @@ import com.google.protobuf.Descriptors;
 import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * <p>Provides support for RPC methods implementations of the Greeter gRPC service.</p>
@@ -51,11 +52,6 @@ public class GreeterGrpcService extends GreeterService implements Service {
   @Override
   public Descriptors.ServiceDescriptor descriptor() {
     return SERVICE_DESCRIPTOR;
-  }
-
-  @Override
-  public void bind(GrpcServer server) {
-    builder(this).bind(all()).build().bind(server);
   }
 
   /**
@@ -104,28 +100,13 @@ public class GreeterGrpcService extends GreeterService implements Service {
   /**
    * Service builder.
    */
-  public static class Builder implements ServiceBuilder {
+  public static class Builder {
 
     private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>();
     private final GreeterService instance;
 
     private Builder(GreeterService instance) {
       this.instance = instance;
-    }
-
-//    private void validate() {
-//      for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
-//        if (resolveHandler(serviceMethod) == null) {
-//          throw new IllegalArgumentException("Invalid service method:" + serviceMethod);
-//        }
-//      }
-//    }
-
-    /**
-     * Throws {@code UnsupportedOperationException}.
-     */
-    public <Req, Resp> ServiceBuilder bind(ServiceMethod<Req, Resp> serviceMethod, Handler<GrpcServerRequest<Req, Resp>> handler) {
-      throw new UnsupportedOperationException();
     }
 
     /**
@@ -151,21 +132,37 @@ public class GreeterGrpcService extends GreeterService implements Service {
 
       // Defensive copy
       private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>(Builder.this.serviceMethods);
+      private final Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
 
+      {
+        for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+          Handler<? extends GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);
+          handlers.put(serviceMethod.methodName(), handler);
+        }
+      }
+
+      @Override
       public ServiceName name() {
         return SERVICE_NAME;
       }
 
+      @Override
       public Descriptors.ServiceDescriptor descriptor() {
         return SERVICE_DESCRIPTOR;
       }
 
-      /**
-       * Bind the contained service methods to the {@code server}.
-       */
-      public void bind(GrpcServer server) {
-        for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
-          bindHandler(serviceMethod, server);
+      @Override
+      public List<ServiceMethod<?, ?>> methods() {
+        return serviceMethods;
+      }
+
+      @Override
+      public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+        Handler handler = handlers.get(request.methodName());
+        if (handler != null) {
+          handler.handle(request);
+        } else {
+          Service.super.handle(request);
         }
       }
 

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
@@ -14,7 +14,6 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.ServiceBuilder;
 import io.vertx.grpc.server.StatusException;
 
 import com.google.protobuf.Descriptors;
@@ -22,6 +21,8 @@ import com.google.protobuf.Descriptors;
 import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * <p>Provides support for RPC methods implementations of the Streaming gRPC service.</p>
@@ -53,11 +54,6 @@ public class StreamingGrpcService extends StreamingService implements Service {
   @Override
   public Descriptors.ServiceDescriptor descriptor() {
     return SERVICE_DESCRIPTOR;
-  }
-
-  @Override
-  public void bind(GrpcServer server) {
-    builder(this).bind(all()).build().bind(server);
   }
 
   /**
@@ -116,28 +112,13 @@ public class StreamingGrpcService extends StreamingService implements Service {
   /**
    * Service builder.
    */
-  public static class Builder implements ServiceBuilder {
+  public static class Builder {
 
     private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>();
     private final StreamingService instance;
 
     private Builder(StreamingService instance) {
       this.instance = instance;
-    }
-
-//    private void validate() {
-//      for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
-//        if (resolveHandler(serviceMethod) == null) {
-//          throw new IllegalArgumentException("Invalid service method:" + serviceMethod);
-//        }
-//      }
-//    }
-
-    /**
-     * Throws {@code UnsupportedOperationException}.
-     */
-    public <Req, Resp> ServiceBuilder bind(ServiceMethod<Req, Resp> serviceMethod, Handler<GrpcServerRequest<Req, Resp>> handler) {
-      throw new UnsupportedOperationException();
     }
 
     /**
@@ -163,21 +144,37 @@ public class StreamingGrpcService extends StreamingService implements Service {
 
       // Defensive copy
       private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>(Builder.this.serviceMethods);
+      private final Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
 
+      {
+        for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+          Handler<? extends GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);
+          handlers.put(serviceMethod.methodName(), handler);
+        }
+      }
+
+      @Override
       public ServiceName name() {
         return SERVICE_NAME;
       }
 
+      @Override
       public Descriptors.ServiceDescriptor descriptor() {
         return SERVICE_DESCRIPTOR;
       }
 
-      /**
-       * Bind the contained service methods to the {@code server}.
-       */
-      public void bind(GrpcServer server) {
-        for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
-          bindHandler(serviceMethod, server);
+      @Override
+      public List<ServiceMethod<?, ?>> methods() {
+        return serviceMethods;
+      }
+
+      @Override
+      public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+        Handler handler = handlers.get(request.methodName());
+        if (handler != null) {
+          handler.handle(request);
+        } else {
+          Service.super.handle(request);
         }
       }
 

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
@@ -102,6 +102,18 @@ public class StreamingGrpcService extends StreamingService implements Service {
   }
 
 
+  private final Invoker invoker = new Invoker(this, all());
+
+  @Override
+  public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+    invoker.handle(request);
+  }
+
+  @Override
+  public List<ServiceMethod<?, ?>> methods() {
+    return invoker.methods();
+  }
+
   /**
    * @return a free form builder that gives the opportunity to bind only certain methods of a service
    */
@@ -137,70 +149,76 @@ public class StreamingGrpcService extends StreamingService implements Service {
     }
 
     public Service build() {
-      return new Invoker();
+      return new Invoker(instance, new ArrayList<>(serviceMethods));
+    }
+  }
+
+  private static class Invoker implements Service {
+
+    private final StreamingService instance;
+    private final List<ServiceMethod<?, ?>> serviceMethods;
+    private final Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers;
+
+    public Invoker(StreamingService instance, List<ServiceMethod<?, ?>> serviceMethods) {
+      Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
+      for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+        Handler<? extends GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);
+        handlers.put(serviceMethod.methodName(), handler);
+      }
+
+      this.instance = instance;
+      this.handlers = handlers;
+      this.serviceMethods = serviceMethods;
     }
 
-    private class Invoker implements Service {
+    @Override
+    public ServiceName name() {
+      return SERVICE_NAME;
+    }
 
-      // Defensive copy
-      private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>(Builder.this.serviceMethods);
-      private final Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
+    @Override
+    public Descriptors.ServiceDescriptor descriptor() {
+      return SERVICE_DESCRIPTOR;
+    }
 
-      {
-        for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
-          Handler<? extends GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);
-          handlers.put(serviceMethod.methodName(), handler);
-        }
+    @Override
+    public List<ServiceMethod<?, ?>> methods() {
+      return serviceMethods;
+    }
+
+    @Override
+    public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+      Handler handler = handlers.get(request.methodName());
+      if (handler != null) {
+        handler.handle(request);
+      } else {
+        Service.super.handle(request);
       }
+    }
 
-      @Override
-      public ServiceName name() {
-        return SERVICE_NAME;
-      }
+    private <Req, Resp> void bindHandler(ServiceMethod<Req, Resp> serviceMethod, GrpcServer server) {
+      Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> handler = resolveHandler(serviceMethod);
+      server.callHandler(serviceMethod, handler);
+    }
 
-      @Override
-      public Descriptors.ServiceDescriptor descriptor() {
-        return SERVICE_DESCRIPTOR;
+    private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
+      if (Source == serviceMethod) {
+        Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Empty, examples.grpc.Item>> handler = this::handle_source;
+        Handler<?> handler2 = handler;
+        return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
       }
-
-      @Override
-      public List<ServiceMethod<?, ?>> methods() {
-        return serviceMethods;
+      if (Sink == serviceMethod) {
+        Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Empty>> handler = this::handle_sink;
+        Handler<?> handler2 = handler;
+        return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
       }
-
-      @Override
-      public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
-        Handler handler = handlers.get(request.methodName());
-        if (handler != null) {
-          handler.handle(request);
-        } else {
-          Service.super.handle(request);
-        }
+      if (Pipe == serviceMethod) {
+        Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Item>> handler = this::handle_pipe;
+        Handler<?> handler2 = handler;
+        return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
       }
-
-      private <Req, Resp> void bindHandler(ServiceMethod<Req, Resp> serviceMethod, GrpcServer server) {
-        Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> handler = resolveHandler(serviceMethod);
-        server.callHandler(serviceMethod, handler);
-      }
-
-      private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
-        if (Source == serviceMethod) {
-          Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Empty, examples.grpc.Item>> handler = this::handle_source;
-          Handler<?> handler2 = handler;
-          return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
-        }
-        if (Sink == serviceMethod) {
-          Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Empty>> handler = this::handle_sink;
-          Handler<?> handler2 = handler;
-          return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
-        }
-        if (Pipe == serviceMethod) {
-          Handler<io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Item>> handler = this::handle_pipe;
-          Handler<?> handler2 = handler;
-          return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
-        }
-        return null;
-      }
+      return null;
+    }
 
 
   private void handle_source(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Empty, examples.grpc.Item> request) {
@@ -222,6 +240,5 @@ public class StreamingGrpcService extends StreamingService implements Service {
   private void handle_pipe(io.vertx.grpc.server.GrpcServerRequest<examples.grpc.Item, examples.grpc.Item> request) {
     instance.pipe(request, request.response());
   }
-    }
   }
 }

--- a/vertx-grpc-health/src/main/java/io/vertx/grpc/health/impl/HealthServiceImpl.java
+++ b/vertx-grpc-health/src/main/java/io/vertx/grpc/health/impl/HealthServiceImpl.java
@@ -2,8 +2,10 @@ package io.vertx.grpc.health.impl;
 
 import com.google.protobuf.Descriptors;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.health.HealthService;
 import io.vertx.grpc.health.HealthServiceOptions;
@@ -12,12 +14,15 @@ import io.vertx.grpc.health.handler.GrpcHealthListV1Handler;
 import io.vertx.grpc.health.handler.GrpcHealthWatchV1Handler;
 import io.vertx.grpc.health.v1.HealthProto;
 import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.impl.ServerAware;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
-public class HealthServiceImpl implements HealthService {
+public class HealthServiceImpl implements HealthService, ServerAware {
 
   private static final ServiceName V1_SERVICE_NAME = ServiceName.create("grpc.health.v1.Health");
   private static final Descriptors.ServiceDescriptor V1_SERVICE_DESCRIPTOR = HealthProto.getDescriptor().findServiceByName("Health");
@@ -25,6 +30,11 @@ public class HealthServiceImpl implements HealthService {
   private final Vertx vertx;
   private final HealthServiceOptions options;
   private final Map<String, Supplier<Future<Boolean>>> checks = new ConcurrentHashMap<>();
+
+  private GrpcServer server;
+  private Handler checkHandler;
+  private Handler listHandler;
+  private Handler watchHandler;
 
   public HealthServiceImpl(Vertx vertx) {
     this(vertx, new HealthServiceOptions());
@@ -47,10 +57,40 @@ public class HealthServiceImpl implements HealthService {
   }
 
   @Override
-  public void bind(GrpcServer server) {
-    server.callHandler(GrpcHealthCheckV1Handler.SERVICE_METHOD, new GrpcHealthCheckV1Handler(server, checks));
-    server.callHandler(GrpcHealthListV1Handler.SERVICE_METHOD, new GrpcHealthListV1Handler(server, checks));
-    server.callHandler(GrpcHealthWatchV1Handler.SERVICE_METHOD, new GrpcHealthWatchV1Handler(vertx, server, checks, options));
+  public List<ServiceMethod<?, ?>> methods() {
+    return List.of(GrpcHealthCheckV1Handler.SERVICE_METHOD, GrpcHealthListV1Handler.SERVICE_METHOD, GrpcHealthWatchV1Handler.SERVICE_METHOD);
+  }
+
+  @Override
+  public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+    Handler handler;
+    switch (request.methodName()) {
+      case "Check":
+        handler = checkHandler;
+        break;
+      case "List":
+        handler = listHandler;
+        break;
+      case "Watch":
+        handler = watchHandler;
+        break;
+      default:
+        handler = null;
+        break;
+    }
+    if (handler != null) {
+      handler.handle(request);
+    } else {
+      HealthService.super.handle(request);;
+    }
+  }
+
+  @Override
+  public void setServer(GrpcServer server) {
+    this.server = server;
+    this.checkHandler = new GrpcHealthCheckV1Handler(server, checks);
+    this.listHandler = new GrpcHealthListV1Handler(server, checks);
+    this.watchHandler = new GrpcHealthWatchV1Handler(vertx, server, checks, options);
   }
 
   @Override

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/DeadlineTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/DeadlineTest.java
@@ -41,14 +41,14 @@ public class DeadlineTest extends ProxyTestBase {
     GrpcClientOptions clientOptions = new GrpcClientOptions().setScheduleDeadlineAutomatically(true);
     GrpcServerOptions serverOptions = new GrpcServerOptions().setDeadlinePropagation(true);
     GrpcClient client = GrpcClient.client(vertx, clientOptions);
-    Future<HttpServer> server = vertx.createHttpServer().requestHandler(GrpcServer.server(vertx, serverOptions)
+    vertx.createHttpServer().requestHandler(GrpcServer.server(vertx, serverOptions)
       .callHandler(GreeterGrpcService.SayHello, call -> {
       should.assertTrue(call.timeout() > 0L);
       call.errorHandler(err -> {
         should.assertEquals(GrpcStatus.CANCELLED, err.status);
         latch.countDown();
       });
-    })).listen(8080, "localhost");
+    })).listen(8080, "localhost").await();
     GreeterGrpcClient stub = GreeterGrpcClient.create(client, SocketAddress.inetSocketAddress(8080, "localhost"));
     GreeterGrpcService service = new GreeterGrpcService() {
       @Override
@@ -74,18 +74,19 @@ public class DeadlineTest extends ProxyTestBase {
     GrpcServer proxy = GrpcServer.server(vertx, serverOptions);
     proxy.addService(service);
     HttpServer proxyServer = vertx.createHttpServer().requestHandler(proxy);
-    server.flatMap(v -> proxyServer.listen(8081, "localhost")).onComplete(should.asyncAssertSuccess(v -> {
-      client.request(SocketAddress.inetSocketAddress(8081, "localhost"), GreeterGrpcClient.SayHello)
-        .onComplete(should.asyncAssertSuccess(callRequest -> {
-          callRequest.response().onComplete(should.asyncAssertFailure(err -> {
-            should.assertTrue(err instanceof GrpcErrorException);
-            GrpcErrorException sre = (GrpcErrorException) err;
-            should.assertEquals(GrpcStatus.CANCELLED, sre.status());
-            latch.countDown();
-          }));
-          callRequest.timeout(2, TimeUnit.SECONDS).end(HelloRequest.newBuilder().setName("Julien").build());
+    proxyServer.listen(8081, "localhost").await();
+
+    client.request(SocketAddress.inetSocketAddress(8081, "localhost"), GreeterGrpcClient.SayHello)
+      .onComplete(should.asyncAssertSuccess(callRequest -> {
+        callRequest.response().onComplete(should.asyncAssertFailure(err -> {
+          should.assertTrue(err instanceof GrpcErrorException);
+          GrpcErrorException sre = (GrpcErrorException) err;
+          should.assertEquals(GrpcStatus.CANCELLED, sre.status());
+          latch.countDown();
         }));
-    }));
+        callRequest.timeout(2, TimeUnit.SECONDS).end(HelloRequest.newBuilder().setName("Julien").build());
+      }));
+
     latch.awaitSuccess();
   }
 }

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
@@ -16,7 +16,6 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.ServiceBuilder;
 import io.vertx.grpc.server.StatusException;
 
 import com.google.protobuf.Descriptors;
@@ -24,6 +23,8 @@ import com.google.protobuf.Descriptors;
 import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * <p>Provides support for RPC methods implementations of the {{serviceName}} gRPC service.</p>
@@ -55,11 +56,6 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
   @Override
   public Descriptors.ServiceDescriptor descriptor() {
     return SERVICE_DESCRIPTOR;
-  }
-
-  @Override
-  public void bind(GrpcServer server) {
-    builder(this).bind(all()).build().bind(server);
   }
 
   /**
@@ -133,28 +129,13 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
   /**
    * Service builder.
    */
-  public static class Builder implements ServiceBuilder {
+  public static class Builder {
 
     private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>();
     private final {{serviceFqn}} instance;
 
     private Builder({{serviceFqn}} instance) {
       this.instance = instance;
-    }
-
-//    private void validate() {
-//      for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
-//        if (resolveHandler(serviceMethod) == null) {
-//          throw new IllegalArgumentException("Invalid service method:" + serviceMethod);
-//        }
-//      }
-//    }
-
-    /**
-     * Throws {@code UnsupportedOperationException}.
-     */
-    public <Req, Resp> ServiceBuilder bind(ServiceMethod<Req, Resp> serviceMethod, Handler<GrpcServerRequest<Req, Resp>> handler) {
-      throw new UnsupportedOperationException();
     }
 
     /**
@@ -180,21 +161,37 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
 
       // Defensive copy
       private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>(Builder.this.serviceMethods);
+      private final Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
 
+      {
+        for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+          Handler<? extends GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);
+          handlers.put(serviceMethod.methodName(), handler);
+        }
+      }
+
+      @Override
       public ServiceName name() {
         return SERVICE_NAME;
       }
 
+      @Override
       public Descriptors.ServiceDescriptor descriptor() {
         return SERVICE_DESCRIPTOR;
       }
 
-      /**
-       * Bind the contained service methods to the {@code server}.
-       */
-      public void bind(GrpcServer server) {
-        for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
-          bindHandler(serviceMethod, server);
+      @Override
+      public List<ServiceMethod<?, ?>> methods() {
+        return serviceMethods;
+      }
+
+      @Override
+      public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+        Handler handler = handlers.get(request.methodName());
+        if (handler != null) {
+          handler.handle(request);
+        } else {
+          Service.super.handle(request);
         }
       }
 

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
@@ -119,6 +119,18 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
   );
 {{/transcodingMethods}}
 
+  private final Invoker invoker = new Invoker(this, all());
+
+  @Override
+  public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+    invoker.handle(request);
+  }
+
+  @Override
+  public List<ServiceMethod<?, ?>> methods() {
+    return invoker.methods();
+  }
+
   /**
    * @return a free form builder that gives the opportunity to bind only certain methods of a service
    */
@@ -154,62 +166,68 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
     }
 
     public Service build() {
-      return new Invoker();
+      return new Invoker(instance, new ArrayList<>(serviceMethods));
+    }
+  }
+
+  private static class Invoker implements Service {
+
+    private final {{serviceFqn}} instance;
+    private final List<ServiceMethod<?, ?>> serviceMethods;
+    private final Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers;
+
+    public Invoker({{serviceFqn}} instance, List<ServiceMethod<?, ?>> serviceMethods) {
+      Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
+      for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
+        Handler<? extends GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);
+        handlers.put(serviceMethod.methodName(), handler);
+      }
+
+      this.instance = instance;
+      this.handlers = handlers;
+      this.serviceMethods = serviceMethods;
     }
 
-    private class Invoker implements Service {
+    @Override
+    public ServiceName name() {
+      return SERVICE_NAME;
+    }
 
-      // Defensive copy
-      private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>(Builder.this.serviceMethods);
-      private final Map<String, Handler<? extends GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
+    @Override
+    public Descriptors.ServiceDescriptor descriptor() {
+      return SERVICE_DESCRIPTOR;
+    }
 
-      {
-        for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
-          Handler<? extends GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);
-          handlers.put(serviceMethod.methodName(), handler);
-        }
+    @Override
+    public List<ServiceMethod<?, ?>> methods() {
+      return serviceMethods;
+    }
+
+    @Override
+    public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+      Handler handler = handlers.get(request.methodName());
+      if (handler != null) {
+        handler.handle(request);
+      } else {
+        Service.super.handle(request);
       }
+    }
 
-      @Override
-      public ServiceName name() {
-        return SERVICE_NAME;
-      }
+    private <Req, Resp> void bindHandler(ServiceMethod<Req, Resp> serviceMethod, GrpcServer server) {
+      Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> handler = resolveHandler(serviceMethod);
+      server.callHandler(serviceMethod, handler);
+    }
 
-      @Override
-      public Descriptors.ServiceDescriptor descriptor() {
-        return SERVICE_DESCRIPTOR;
-      }
-
-      @Override
-      public List<ServiceMethod<?, ?>> methods() {
-        return serviceMethods;
-      }
-
-      @Override
-      public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
-        Handler handler = handlers.get(request.methodName());
-        if (handler != null) {
-          handler.handle(request);
-        } else {
-          Service.super.handle(request);
-        }
-      }
-
-      private <Req, Resp> void bindHandler(ServiceMethod<Req, Resp> serviceMethod, GrpcServer server) {
-        Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> handler = resolveHandler(serviceMethod);
-        server.callHandler(serviceMethod, handler);
-      }
-
-      private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
+    private <Req, Resp> Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>> resolveHandler(ServiceMethod<Req, Resp> serviceMethod) {
 {{#methods}}
-        if ({{methodName}} == serviceMethod) {
-          Handler<io.vertx.grpc.server.GrpcServerRequest<{{inputType}}, {{outputType}}>> handler = this::handle_{{vertxMethodName}};
-          Handler<?> handler2 = handler;
-          return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
-        }
-{{/methods}}
-        return null;
+      if ({{methodName}} == serviceMethod) {
+        Handler<io.vertx.grpc.server.GrpcServerRequest<{{inputType}}, {{outputType}}>> handler = this::handle_{{vertxMethodName}};
+        Handler<?> handler2 = handler;
+        return (Handler<io.vertx.grpc.server.GrpcServerRequest<Req, Resp>>) handler2;
       }
+{{/methods}}
+      return null;
+    }
 
 {{#unaryUnaryMethods}}
 
@@ -251,6 +269,5 @@ public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
     instance.{{vertxMethodName}}(request, request.response());
   }
 {{/manyManyMethods}}
-    }
   }
 }

--- a/vertx-grpc-reflection/src/main/java/io/vertx/grpc/reflection/ReflectionService.java
+++ b/vertx-grpc-reflection/src/main/java/io/vertx/grpc/reflection/ReflectionService.java
@@ -1,15 +1,21 @@
 package io.vertx.grpc.reflection;
 
 import com.google.protobuf.Descriptors;
+import io.vertx.core.Handler;
+import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.reflection.v1.ServerReflectionProto;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.server.GrpcServer;
+import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.Service;
+import io.vertx.grpc.server.impl.ServerAware;
+
+import java.util.List;
 
 /**
  * Reflection service implementing <a href="https://grpc.io/docs/guides/reflection/">Reflection</a>.
  */
-public class ReflectionService implements Service {
+public class ReflectionService implements Service, ServerAware {
 
   private static final ServiceName V1_SERVICE_NAME = ServiceName.create("grpc.reflection.v1.ServerReflection");
   private static final Descriptors.ServiceDescriptor V1_SERVICE_DESCRIPTOR = ServerReflectionProto.getDescriptor().findServiceByName("ServerReflection");
@@ -40,7 +46,25 @@ public class ReflectionService implements Service {
   }
 
   @Override
-  public void bind(GrpcServer server) {
-    server.callHandler(GrpcServerReflectionV1Handler.SERVICE_METHOD, new GrpcServerReflectionV1Handler(server));
+  public List<ServiceMethod<?, ?>> methods() {
+    return List.of(GrpcServerReflectionV1Handler.SERVICE_METHOD);
   }
+
+  @Override
+  public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+    if (request.methodName().equals(GrpcServerReflectionV1Handler.SERVICE_METHOD.methodName())) {
+      Handler handler = new GrpcServerReflectionV1Handler(server);
+      handler.handle(request);
+    } else {
+      Service.super.handle(request);
+    }
+  }
+
+  private GrpcServer server;
+
+  @Override
+  public void setServer(GrpcServer server) {
+    this.server = server;
+  }
+
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/Service.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/Service.java
@@ -3,17 +3,22 @@ package io.vertx.grpc.server;
 import com.google.protobuf.Descriptors;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.Future;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.server.impl.ServiceBuilderImpl;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 /**
- * Provides metadata about a gRPC service.
- * <p>
- * This interface gives access to both the name and the service descriptor, which contains detailed information about the service's methods, input and output types, and other
- * metadata defined in the protobuf service definition.
+ * A gRPC service.
+ * <ul>
+ *   <li>gives access to both the name and the service descriptor, which contains detailed information about the service's
+ *   methods, input and output types, and other metadata defined in the protobuf service definition</li>
+ *   <li>handle service calls</li>
+ * </ul>
  */
 @GenIgnore(GenIgnore.PERMITTED_TYPE)
 public interface Service {
@@ -43,13 +48,27 @@ public interface Service {
    */
   Descriptors.ServiceDescriptor descriptor();
 
+
   /**
-   * Binds this service and all its registered method handlers to the specified gRPC server.
-   * This allows the server to handle requests for this service.
+   * Get the list of all methods implemented by this service.
    *
-   * @param server the gRPC server to bind this service to
+   * @return the list of service methods
    */
-  void bind(GrpcServer server);
+  default List<ServiceMethod<?, ?>> methods() {
+    return Collections.emptyList();
+  }
+
+  /**
+   * Handle the method call.
+   *
+   * @param request the service request
+   */
+  default <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+    request
+      .response()
+      .status(GrpcStatus.UNIMPLEMENTED)
+      .end();
+  }
 
   /**
    * Close the service.
@@ -97,9 +116,6 @@ public interface Service {
    * @throws IllegalArgumentException if the method does not exist
    */
   default String pathOfMethod(String methodName) {
-    if (!hasMethod(methodName)) {
-      throw new IllegalArgumentException("Method not found: " + methodName);
-    }
     return name().pathOf(methodName);
   }
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -10,6 +10,8 @@
  */
 package io.vertx.grpc.server.impl;
 
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.MessageLite;
 import io.vertx.core.Closeable;
 import io.vertx.core.Completable;
 import io.vertx.core.Future;
@@ -283,10 +285,15 @@ public class GrpcServerImpl implements GrpcServer, Closeable {
           throw new IllegalStateException("Duplicated name: " + service.name().name());
         }
       }
+      if (service instanceof ServerAware) {
+        ((ServerAware)service).setServer(this);
+      }
+      for (ServiceMethod method : service.methods()) {
+        registerMethodCallHandler(service.pathOfMethod(method.methodName()), new MethodCallHandler<Object, Object>(method, method.decoder(), method.encoder(), service::handle));
+      }
 
       this.services.add(service);
     }
-    service.bind(this);
 
     return this;
   }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/ServerAware.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/ServerAware.java
@@ -1,0 +1,12 @@
+package io.vertx.grpc.server.impl;
+
+import io.vertx.grpc.server.GrpcServer;
+
+/**
+ * Hook for reflection service.
+ */
+public interface ServerAware {
+
+  void setServer(GrpcServer server);
+
+}

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/ServiceBuilderImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/ServiceBuilderImpl.java
@@ -42,9 +42,16 @@ public class ServiceBuilderImpl implements ServiceBuilder {
       public Descriptors.ServiceDescriptor descriptor() {
         return descriptor;
       }
+
       @Override
-      public void bind(GrpcServer server) {
-        handlers.forEach(h -> h.bind(server));
+      public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+        for (ServiceMethodBinding<?, ?> handler : handlers) {
+          if (handler.serviceMethod.methodName().equals(request.methodName())) {
+            handler.handler.handle((GrpcServerRequest)request);
+            return;
+          }
+        }
+        Service.super.handle(request);
       }
     };
   }

--- a/vertx-grpc-server/src/main/java/module-info.java
+++ b/vertx-grpc-server/src/main/java/module-info.java
@@ -14,5 +14,5 @@ module io.vertx.grpc.server {
   uses io.vertx.grpc.server.impl.GrpcHttpInvoker;
 
   exports io.vertx.grpc.server;
-  exports io.vertx.grpc.server.impl to io.vertx.grpc.transcoding;
+  exports io.vertx.grpc.server.impl to io.vertx.grpc.transcoding, io.vertx.grpc.reflection, io.vertx.grpc.health;
 }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/LifecycleTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/LifecycleTest.java
@@ -42,9 +42,6 @@ public class LifecycleTest extends ServerTestBase {
           return null;
         }
         @Override
-        public void bind(GrpcServer server) {
-        }
-        @Override
         public Future<Void> close() {
           closed.incrementAndGet();
           return Service.super.close().timeout(10, TimeUnit.MILLISECONDS);
@@ -71,9 +68,6 @@ public class LifecycleTest extends ServerTestBase {
         @Override
         public Descriptors.ServiceDescriptor descriptor() {
           return null;
-        }
-        @Override
-        public void bind(GrpcServer server) {
         }
       });
       fail();

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServiceRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServiceRequestTest.java
@@ -1,0 +1,62 @@
+package io.vertx.tests.server;
+
+import com.google.protobuf.Descriptors;
+import io.grpc.*;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.ServiceName;
+import io.vertx.grpc.server.*;
+import io.vertx.tests.common.grpc.Reply;
+import io.vertx.tests.common.grpc.Request;
+import io.vertx.tests.common.grpc.TestServiceGrpc;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+@RunWith(VertxUnitRunner.class)
+public class ServiceRequestTest extends ServerTestBase {
+
+  @Test
+  public void testUnary(TestContext should) {
+
+    Service service = new Service() {
+      @Override
+      public ServiceName name() {
+        return UNARY.serviceName();
+      }
+      @Override
+      public Descriptors.ServiceDescriptor descriptor() {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public List<ServiceMethod<?, ?>> methods() {
+        return List.of(UNARY);
+      }
+      @Override
+      public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+        handleUnary((GrpcServerRequest)request);
+      }
+      public void handleUnary(GrpcServerRequest<Request, Reply> request) {
+        GrpcServerResponse<Request, Reply> response = request.response();
+        request.handler(helloRequest -> {
+          Reply helloReply = Reply.newBuilder().setMessage("Hello " + helloRequest.getName()).build();
+          response
+            .end(helloReply);
+        });
+      }
+    };
+
+    startServer(GrpcServer.server(vertx).addService(service));
+
+    channel = ManagedChannelBuilder.forAddress("localhost", port)
+      .usePlaintext()
+      .build();
+
+    TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
+    Request request = Request.newBuilder().setName("Julien").build();
+    Reply res = stub.unary(request);
+    should.assertEquals("Hello Julien", res.getMessage());
+  }
+}

--- a/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/GrpcIoServiceBridge.java
+++ b/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/GrpcIoServiceBridge.java
@@ -48,11 +48,6 @@ public interface GrpcIoServiceBridge extends Service {
    */
   void bind(GrpcIoServer server);
 
-  @Override
-  default void bind(GrpcServer server) {
-    bind((GrpcIoServer) server);
-  }
-
   /**
    * Unbind all service methods from the @{code server}.
    *

--- a/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServerImpl.java
+++ b/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServerImpl.java
@@ -148,10 +148,6 @@ public class GrpcIoServerImpl extends GrpcServerImpl implements GrpcIoServer {
         return methodDescriptors;
       }
 
-      @Override
-      public void bind(GrpcServer server) {
-        // Handlers are already registered via callHandler(MethodDescriptor, Handler).
-      }
     };
   }
 }

--- a/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServiceBridgeImpl.java
+++ b/vertx-grpcio-server/src/main/java/io/vertx/grpcio/server/impl/GrpcIoServiceBridgeImpl.java
@@ -26,10 +26,12 @@ import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.Status;
 import io.grpc.protobuf.ProtoServiceDescriptorSupplier;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.common.impl.*;
 import io.vertx.grpc.server.GrpcServerRequest;
@@ -45,14 +47,19 @@ import io.vertx.grpcio.server.GrpcIoServiceBridge;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class GrpcIoServiceBridgeImpl implements GrpcIoServiceBridge {
 
   private final ServiceName serviceName;
   private final ServerServiceDefinition serviceDef;
   private final ProtoServiceDescriptorSupplier protoServiceDescriptorSupplier;
+  private Map<String, ServiceMethodHandler<?, ?>> handlers;
 
   public GrpcIoServiceBridgeImpl(ServerServiceDefinition serviceDef) {
 
@@ -65,9 +72,18 @@ public class GrpcIoServiceBridgeImpl implements GrpcIoServiceBridge {
       throw new IllegalArgumentException("Service definition must have a FileDescriptor");
     }
 
+    HashMap<String, ServiceMethodHandler<?, ?>> handlers = new HashMap<>();
+    serviceDef
+      .getMethods()
+      .forEach(smd -> {
+        ServiceMethodHandler<?, ?> handler = new ServiceMethodHandler<>(smd);
+        handlers.put(handler.serviceMethod.methodName(), handler);
+      });
+
     this.protoServiceDescriptorSupplier = supplier;
     this.serviceName = ServiceName.create(serviceDef.getServiceDescriptor().getName());
     this.serviceDef = serviceDef;
+    this.handlers = handlers;
   }
 
   @Override
@@ -91,31 +107,26 @@ public class GrpcIoServiceBridgeImpl implements GrpcIoServiceBridge {
 
   @Override
   public void bind(GrpcIoServer server) {
-    serviceDef.getMethods().forEach(m -> bind(server, m));
+    server.addService(this);
   }
 
-  private <Req, Resp> void bind(GrpcIoServer server, ServerMethodDefinition<Req, Resp> methodDef) {
-    server.callHandler(methodDef.getMethodDescriptor(), req -> {
-      ServerCallHandler<Req, Resp> callHandler = methodDef.getServerCallHandler();
-      Context context = Context.current();
-      if (req.timeout() > 0L) {
-        Context.CancellableContext cancellable = context.withDeadlineAfter(req.timeout(), TimeUnit.MILLISECONDS, new VertxScheduledExecutorService(Vertx.currentContext()));
-        context = cancellable;
-        context.addListener(context1 -> ((GrpcServerResponseImpl)req.response()).handleTimeout(), new Executor() {
-          @Override
-          public void execute(Runnable command) {
-            command.run();
-          }
-        });
-      }
-      Context theContext = context;
-      Runnable task = theContext.wrap(() -> {
-        ServerCallImpl<Req, Resp> call = new ServerCallImpl<>(theContext, req, methodDef);
-        ServerCall.Listener<Req> listener = callHandler.startCall(call, io.vertx.grpcio.common.impl.Utils.readMetadata(req.headers()));
-        call.init(listener);
-      });
-      task.run();
-    });
+  @Override
+  public List<ServiceMethod<?, ?>> methods() {
+    return handlers
+      .values()
+      .stream()
+      .map(h -> h.serviceMethod)
+      .collect(Collectors.toList());
+  }
+
+ @Override
+  public <Req, Resp> void handle(GrpcServerRequest<Req, Resp> request) {
+    ServiceMethodHandler handler = handlers.get(request.methodName());
+    if (handler != null) {
+      handler.handle(request);
+    } else {
+      GrpcIoServiceBridge.super.handle(request);
+    }
   }
 
   private static class ServerCallImpl<Req, Resp> extends ServerCall<Req, Resp> {
@@ -143,7 +154,7 @@ public class GrpcIoServiceBridgeImpl implements GrpcIoServiceBridge {
       this.decompressor = DecompressorRegistry.getDefaultInstance().lookupDecompressor(encoding);
       this.req = req;
       this.methodDef = methodDef;
-      this.readAdapter = new ReadStreamAdapter<Req>() {
+      this.readAdapter = new ReadStreamAdapter<>() {
         @Override
         protected void handleClose() {
           halfClosed = true;
@@ -286,6 +297,50 @@ public class GrpcIoServiceBridgeImpl implements GrpcIoServiceBridge {
     @Override
     public Attributes getAttributes() {
       return this.attributes;
+    }
+  }
+
+  private static class ServiceMethodHandler<Req, Resp> implements Handler<GrpcServerRequest<Req, Resp>> {
+
+    private final ServerMethodDefinition<Req, Resp> methodDef;
+    private final ServiceMethod<Req, Resp> serviceMethod;
+
+    public ServiceMethodHandler(ServerMethodDefinition<Req, Resp> methodDef) {
+
+      MethodDescriptor<Req, Resp> methodDesc = methodDef.getMethodDescriptor();
+
+      ServiceMethod<Req, Resp> serviceMethod = ServiceMethod.server(
+        ServiceName.create(methodDesc.getServiceName()),
+        methodDesc.getBareMethodName(),
+        new BridgeMessageEncoder<>(methodDesc.getResponseMarshaller(), null),
+        new BridgeMessageDecoder<>(methodDesc.getRequestMarshaller(), null)
+      );
+
+      this.methodDef = methodDef;
+      this.serviceMethod = serviceMethod;
+    }
+
+    @Override
+    public void handle(GrpcServerRequest<Req, Resp> req) {
+      ServerCallHandler<Req, Resp> callHandler = methodDef.getServerCallHandler();
+      Context context = Context.current();
+      if (req.timeout() > 0L) {
+        Context.CancellableContext cancellable = context.withDeadlineAfter(req.timeout(), TimeUnit.MILLISECONDS, new VertxScheduledExecutorService(Vertx.currentContext()));
+        context = cancellable;
+        context.addListener(context1 -> ((GrpcServerResponseImpl)req.response()).handleTimeout(), new Executor() {
+          @Override
+          public void execute(Runnable command) {
+            command.run();
+          }
+        });
+      }
+      Context theContext = context;
+      Runnable task = theContext.wrap(() -> {
+        ServerCallImpl<Req, Resp> call = new ServerCallImpl<>(theContext, req, methodDef);
+        ServerCall.Listener<Req> listener = callHandler.startCall(call, io.vertx.grpcio.common.impl.Utils.readMetadata(req.headers()));
+        call.init(listener);
+      });
+      task.run();
     }
   }
 }


### PR DESCRIPTION
Motivation:

The `Service` interface acts for now as a IoC contract for its implementation to configure a` GrpcServer`.

This implies that the `Service` interface is intimate with a server.

Instead we can decouple it from the server contract and make it handle service calls.

Changes:

`Service` does not bind anymore to the server, instead it handles service calls.

The default server implementation now delegates calls to the service contract.
