### PR TITLE
Add canteen maven plugin back.

### DIFF
--- a/vertx-grpc-protoc-plugin2/pom.xml
+++ b/vertx-grpc-protoc-plugin2/pom.xml
@@ -29,6 +29,7 @@
   <artifactId>vertx-grpc-protoc-plugin2</artifactId>
 
   <properties>
+    <canteen.version>1.1.0</canteen.version>
     <protoc.version>3.21.12</protoc.version>
   </properties>
 
@@ -107,6 +108,18 @@
             </manifest>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>canteen-maven-plugin</artifactId>
+        <version>${canteen.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bootstrap</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Motivation:

The canteen maven plugin is useful to package a jar file as an executable, Gradle gRPC relies on this to generate protobuf artifacts.
