### PR TITLE
Avoid quadratic buffer reassembly in GrpcReadStreamBase.handle

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcReadStreamBase.java
@@ -162,10 +162,15 @@ public abstract class GrpcReadStreamBase<S extends GrpcReadStreamBase<S, T>, T> 
     if (pause) {
       stream.pause();
     }
-    if (idx < buffer.length()) {
-      buffer = buffer.getBuffer(idx, buffer.length());
-    } else {
+    if (idx == buffer.length()) {
       buffer = null;
+    } else if (idx > 0) {
+      // Only compact after at least one message was consumed. Compacting
+      // unconditionally re-copied the entire accumulated buffer on every
+      // arriving frame while a message larger than one HTTP/2 frame was
+      // still accumulating (idx == 0), making reassembly O(n^2) in the
+      // message size.
+      buffer = buffer.getBuffer(idx, buffer.length());
     }
   }
 


### PR DESCRIPTION
`handle()` compacts the accumulated buffer on every arriving HTTP/2 DATA frame, even when no complete message was consumed (`idx == 0`). `Buffer.getBuffer()` copies, so while a message larger than one frame accumulates, every frame re-copies everything received so far — reassembly is O(n²) in message size, on the event loop. With 16 KB frames, an 8 MB message costs ~2 GB of memcpy and one full-size allocation per frame, and every other stream multiplexed on the same connection stalls behind it.

This change compacts only after at least one message was consumed, so each byte is copied at most twice (append + one compaction) and an accumulating message is left in place.

Measured on a unary service whose handler does identical linear work per byte (p50, single stream, plaintext localhost, window large enough that the sender never stalls on flow control):

| message size | before | after |
|---|---|---|
| 1 MB | 30.4 ms | 22.8 ms |
| 2 MB | 63.8 ms | 39.5 ms |
| 4 MB | 174.3 ms | 68.7 ms |
| 8 MB | 585.8 ms | 138.5 ms |

Before: latency grows 2.1×, 2.7×, 3.4× per size doubling (approaching the quadratic 4×). After: linear in message size.

Applies to the 4.x line (present in 4.5.28 and 4.5.29). The 5.x deframer (`Http2GrpcMessageDeframer`) accumulates in place and does not have the quadratic path.