### PR TITLE
Prebuild gRPC-Web interop image with BuildKit (5.1 backport)

### DIFF
--- a/.github/workflows/ci-matrix-5.x.yml
+++ b/.github/workflows/ci-matrix-5.x.yml
@@ -41,8 +41,16 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
+      # Build the interop image with BuildKit (the docker CLI default) rather than
+      # letting Testcontainers build it in-process. Testcontainers' ImageFromDockerfile
+      # uses the legacy Docker Engine API builder, which chokes on grpc-web's multi-stage
+      # prereqs/Dockerfile with "failed to get layer <sha> ... layer does not exist"
+      # (moby/moby#33974). Testcontainers can't drive BuildKit itself
+      # (testcontainers/testcontainers-java#2857), so we prebuild and pass the tag.
+      - name: Build gRPC-Web interop image
+        run: DOCKER_BUILDKIT=1 docker build -t grpcweb-interop:ci -f _grpc-web/net/grpc/gateway/docker/prereqs/Dockerfile _grpc-web
       - name: Run tests
-        run: mvn -s .github/maven-ci-settings.xml -q clean verify -B -pl :vertx-grpc-server -am -Dgrpc-web.repo.path="$GITHUB_WORKSPACE/_grpc-web"
+        run: mvn -s .github/maven-ci-settings.xml -q clean verify -B -pl :vertx-grpc-server -am -Dgrpc-web.repo.path="$GITHUB_WORKSPACE/_grpc-web" -Dgrpc-web.image=grpcweb-interop:ci
   Deploy:
     if: ${{ github.repository_owner == 'eclipse-vertx' && (github.event_name == 'push' || github.event_name == 'schedule') }}
     needs: CI

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/interop/InteropITest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/web/interop/InteropITest.java
@@ -24,6 +24,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.ToStringConsumer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
 import java.time.Duration;
@@ -35,6 +36,11 @@ import static org.junit.Assume.assumeFalse;
 public class InteropITest {
 
   private static final String GRPC_WEB_REPO_PATH = System.getProperty("grpc-web.repo.path");
+
+  // When set, an image built ahead of time (by CI, with BuildKit) is used instead of building it
+  // in-process. Testcontainers' ImageFromDockerfile uses the legacy Docker builder, which fails on
+  // grpc-web's multi-stage Dockerfile with "layer does not exist" (testcontainers/testcontainers-java#2857).
+  private static final String GRPC_WEB_IMAGE = System.getProperty("grpc-web.image");
 
   @Rule
   public Timeout rule = Timeout.millis(Duration.ofMinutes(10).toMillis());
@@ -59,15 +65,20 @@ public class InteropITest {
   public void interopTests() {
     File repoFile = new File(GRPC_WEB_REPO_PATH);
     assertTrue("grpc-web repo path doesn't denote a directory", repoFile.isDirectory());
-    File dockerfile = new File(repoFile, "net/grpc/gateway/docker/prereqs/Dockerfile");
-    assertTrue("Dockerfile doesn't exists or isn't a normal file", dockerfile.isFile());
 
-    ImageFromDockerfile image = new ImageFromDockerfile()
-      .withFileFromFile(".", repoFile)
-      .withFileFromFile("Dockerfile", dockerfile);
+    GenericContainer<?> image;
+    if (GRPC_WEB_IMAGE != null) {
+      image = new GenericContainer<>(DockerImageName.parse(GRPC_WEB_IMAGE));
+    } else {
+      File dockerfile = new File(repoFile, "net/grpc/gateway/docker/prereqs/Dockerfile");
+      assertTrue("Dockerfile doesn't exists or isn't a normal file", dockerfile.isFile());
+      image = new GenericContainer<>(new ImageFromDockerfile()
+        .withFileFromFile(".", repoFile)
+        .withFileFromFile("Dockerfile", dockerfile));
+    }
 
     ToStringConsumer logConsumer = new ToStringConsumer();
-    try (GenericContainer<?> container = new GenericContainer<>(image)) {
+    try (GenericContainer<?> container = image) {
       container
         .withLogConsumer(logConsumer)
         .withNetworkMode("host")


### PR DESCRIPTION
Backport of #290 to 5.1.

The gRPC-Web interop job builds grpc-web's multi-stage prereqs/Dockerfile with Testcontainers' ImageFromDockerfile, which uses the old Docker Engine builder. That builder fails on this Dockerfile with "failed to get layer <sha> ... layer does not exist" (moby/moby#33974), so the job has been red. Testcontainers can't build with BuildKit itself (testcontainers/testcontainers-java#2857), so this builds the image in a CI step with docker build (BuildKit default) and passes the tag via -Dgrpc-web.image. The test still builds from the Dockerfile when that property isn't set, so local runs don't change.
