### PR TITLE
Fix mismatched outer class name in vertx-grpc-protoc-plugin2 (5.1 backport)

### DIFF
--- a/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/protoc/ProtobufTypeMapper.java
+++ b/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/protoc/ProtobufTypeMapper.java
@@ -61,7 +61,64 @@ public class ProtobufTypeMapper {
       basename = basename.substring(0, basename.length() - 6);
     }
 
-    return toCamelCase(basename);
+    String outerClass = toCamelCase(basename);
+
+    // protoc appends "OuterClass" when the derived name collides with a message
+    // (or any of its nested types), enum or service defined in the same file.
+    // See ClassNameResolver in protobuf's Java generator:
+    // https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/compiler/java/name_resolver.cc
+    //
+    // TODO: this replicates protobuf's pre-editions default only. From edition
+    // 2024 the java feature use_old_outer_classname_default is false, and
+    // protobuf-java instead appends "Proto" unconditionally and skips this
+    // conflict check entirely (see link above). We advertise
+    // FEATURE_SUPPORTS_EDITIONS, so once the protoc/protobuf-java version is
+    // bumped to one where edition 2024 is generatable, edition-2024 files will
+    // get a mismatched outer class name here. The correct fix is to read the
+    // resolved pb.java.use_old_outer_classname_default feature off
+    // file.getOptions().getFeatures() and branch, rather than keying off the
+    // edition number (the feature can be overridden per-file).
+    if (hasConflictingClassName(file, outerClass)) {
+      outerClass += "OuterClass";
+    }
+
+    return outerClass;
+  }
+
+  private boolean hasConflictingClassName(DescriptorProtos.FileDescriptorProto file, String name) {
+    for (DescriptorProtos.EnumDescriptorProto enumType : file.getEnumTypeList()) {
+      if (name.equals(enumType.getName())) {
+        return true;
+      }
+    }
+    for (DescriptorProtos.ServiceDescriptorProto service : file.getServiceList()) {
+      if (name.equals(service.getName())) {
+        return true;
+      }
+    }
+    for (DescriptorProtos.DescriptorProto message : file.getMessageTypeList()) {
+      if (messageHasConflictingClassName(message, name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean messageHasConflictingClassName(DescriptorProtos.DescriptorProto message, String name) {
+    if (name.equals(message.getName())) {
+      return true;
+    }
+    for (DescriptorProtos.DescriptorProto nested : message.getNestedTypeList()) {
+      if (messageHasConflictingClassName(nested, name)) {
+        return true;
+      }
+    }
+    for (DescriptorProtos.EnumDescriptorProto nested : message.getEnumTypeList()) {
+      if (name.equals(nested.getName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
Backport of #288 to 5.1.

Fixes #286.

When `java_outer_classname` isn't set, `ProtobufTypeMapper` derives the outer class name by camel-casing the filename, but it skipped the `OuterClass` suffix protoc adds when that name clashes with a message, enum, or service in the same file. So `hello.proto` with `service Hello` produced `Hello` instead of `HelloOuterClass`, and the generated code referenced a class that doesn't exist.

This ports protobuf's `ClassNameResolver` conflict check: append `OuterClass` when the derived name matches a top-level enum, a service, or a message including its nested types.