### PR TITLE
Reuse gRPC dispatcher in event bus server

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerImpl.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerImpl.java
@@ -8,13 +8,13 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.grpc.common.*;
-import io.vertx.grpc.common.impl.GrpcMessageFrame;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
 import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
 import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.Service;
 import io.vertx.grpc.server.ServiceMethodInvoker;
+import io.vertx.grpc.server.impl.GrpcDispatcher;
 import io.vertx.grpc.server.impl.GrpcServerRequestImpl;
 import io.vertx.grpc.server.impl.GrpcServerResponseImpl;
 
@@ -318,16 +318,32 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
 
         registration.bind(stream, clientAddress, remoteTimeout);
 
+        ServiceMethodInvoker<Req, Resp> invoker;
+        try {
+          invoker = service.invoker(serviceMethod);
+        } catch (Exception e) {
+          throw new UnsupportedOperationException("Handle me");
+        }
+
         GrpcMethodCall methodCall = new GrpcMethodCall(serviceMethod.serviceName().pathOf(serviceMethod.methodName()));
-        GrpcServerRequestImpl<Req, Resp> request = new GrpcServerRequestImpl<>(context(), headers, null, wireFormat, stream, null, "identity", serviceMethod.decoder(), methodCall);
-        GrpcServerResponseImpl<Req, Resp> response = new GrpcServerResponseImpl<>(context(), request, stream, null, serviceMethod.encoder());
 
-        response.format(wireFormat);
-        request.init(response, false);
+        GrpcDispatcher<Req, Resp> dispatcher = new GrpcDispatcher<>(
+          stream,
+          context(),
+          null,
+          wireFormat,
+          serviceMethod.decoder(),
+          serviceMethod.encoder(),
+          methodCall,
+          null,
+          invoker::invoke,
+          false,
+          false);
 
-        stream.handler(frame -> request.handleMessage(((GrpcMessageFrame) frame).message()));
-        stream.endHandler(x -> request.handleEnd());
-        stream.exceptionHandler(request::handleException);
+
+        stream.handler(dispatcher);
+        stream.exceptionHandler(dispatcher::handleException);
+        stream.endHandler(v2 -> dispatcher.handleEnd());
 
         DeliveryOptions replyOptions = new DeliveryOptions()
           .addHeader(EventBusHeaders.SERVER_ADDRESS, address())
@@ -336,12 +352,7 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
 
         message.reply(Buffer.buffer(), replyOptions);
 
-        try {
-          ServiceMethodInvoker<Req, Resp> invoker = service.invoker(serviceMethod);
-          invoker.invoke(request);
-        } catch (Exception e) {
-          response.fail(e);
-        }
+        stream.init(headers);
       });
     }
   }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerStreamingCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerStreamingCall.java
@@ -132,6 +132,11 @@ class EventBusGrpcServerStreamingCall extends EventBusGrpcStreamBase {
     return last;
   }
 
+  void init(MultiMap headers) {
+    GrpcHeadersFrame frame = new DefaultGrpcHeadersFrame(wireFormat, "identity, ", headers);
+    emit(frame);
+  }
+
   private Future<Void> sendResponseHeaders(MultiMap headers) {
     DeliveryOptions options = new DeliveryOptions();
     if (headers != null && !headers.isEmpty()) {

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcDispatcher.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcDispatcher.java
@@ -13,7 +13,7 @@ import io.vertx.grpc.common.impl.GrpcMethodCall;
 import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServerRequest;
 
-class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
+public class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
 
   private final GrpcStream stream;
   private final ContextInternal context;
@@ -29,17 +29,17 @@ class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
   private GrpcServerRequestImpl<Req, Resp> grpcRequest;
   private GrpcServerResponseImpl<Req, Resp> grpcResponse;
 
-  GrpcDispatcher(GrpcStream stream,
-                 ContextInternal context,
-                 GrpcProtocol protocol,
-                 WireFormat format,
-                 GrpcMessageDecoder<Req> messageDecoder,
-                 GrpcMessageEncoder<Resp> messageEncoder,
-                 GrpcMethodCall methodCall,
-                 HttpConnection httpConnection,
-                 Handler<GrpcServerRequest<Req, Resp>> method,
-                 boolean propagateDeadline,
-                 boolean scheduleDeadline) {
+  public GrpcDispatcher(GrpcStream stream,
+                        ContextInternal context,
+                        GrpcProtocol protocol,
+                        WireFormat format,
+                        GrpcMessageDecoder<Req> messageDecoder,
+                        GrpcMessageEncoder<Resp> messageEncoder,
+                        GrpcMethodCall methodCall,
+                        HttpConnection httpConnection,
+                        Handler<GrpcServerRequest<Req, Resp>> method,
+                        boolean propagateDeadline,
+                        boolean scheduleDeadline) {
     this.stream = stream;
     this.context = context;
     this.protocol = protocol;
@@ -126,13 +126,13 @@ class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
     }
   }
 
-  void handleException(Throwable exception) {
+  public void handleException(Throwable exception) {
     if (grpcRequest != null) {
       grpcRequest.handleException(exception);
     }
   }
 
-  void handleEnd() {
+  public void handleEnd() {
     if (grpcRequest != null) {
       grpcRequest.handleEnd();
     }


### PR DESCRIPTION
- **Make GrpcDispatcher and some of its members public**
- **Update EventBusGrpcServerImpl to use GrpcDispatcher instead of using directly gRPC server request/response**
