### PR TITLE
Fail the response when a service method invocation throws in GrpcDispatcher

### DIFF
--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcDispatcher.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcDispatcher.java
@@ -109,7 +109,21 @@ public class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
         grpcResponse.cancel();
       }
     });
-    grpcRequest.context().dispatch(grpcRequest, method);
+    grpcRequest.context().dispatch(grpcRequest, req -> {
+      try {
+        method.handle(req);
+      } catch (Exception e) {
+        handleInvocationFailure(e);
+      }
+    });
+  }
+
+  private void handleInvocationFailure(Exception e) {
+    if (grpcResponse.isCancelled() || grpcResponse.isTrailersSent()) {
+      context.reportException(e);
+    } else {
+      grpcResponse.fail(e);
+    }
   }
 
   private void handleMessage(GrpcMessageFrame frame) {

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -336,11 +336,7 @@ public class GrpcServerImpl implements GrpcServer, Closeable {
 
     @Override
     public void handle(GrpcServerRequest<Req, Resp> grpcRequest) {
-      try {
-        invoker.invoke(grpcRequest);
-      } catch (Exception e) {
-        grpcRequest.response().fail(e);
-      }
+      invoker.invoke(grpcRequest);
     }
   }
 }

--- a/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/tests/server/ServerRequestTest.java
@@ -146,6 +146,30 @@ public class ServerRequestTest extends ServerTest {
   }
 
   @Test
+  public void testStatusUnary5(TestContext should) {
+    startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
+      throw new RuntimeException("Unexpected error");
+    }));
+
+    super.testStatusUnary(should, Status.UNKNOWN, null);
+  }
+
+  @Test
+  public void testCallHandlerThrowsAfterResponseEnded(TestContext should) {
+    startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
+      call.response().end(Reply.newBuilder().setMessage("Hello Julien").build());
+      throw new RuntimeException("Unexpected error");
+    }));
+
+    channel = ManagedChannelBuilder.forAddress("localhost", port)
+      .usePlaintext()
+      .build();
+    TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(channel);
+    Reply res = stub.unary(Request.newBuilder().setName("Julien").build());
+    should.assertEquals("Hello Julien", res.getMessage());
+  }
+
+  @Test
   public void testStatusStreaming(TestContext should) {
     startServer(GrpcServer.server(vertx).callHandler(SOURCE, call -> {
       call.response().write(Reply.newBuilder().setMessage("msg1").build());


### PR DESCRIPTION
Motivation:

- A service method handler that throws before terminating the response leaves the call unended, since the dispatcher invokes it through `context.dispatch` which reports the throwable instead of propagating it, so the caller waits on its own deadline instead of getting a status.
- The guard lived in `GrpcServerImpl.MethodCallHandler`, so it only covered transports going through it, and any transport handing the dispatcher an unwrapped invoker had none.

Changes:

- Added `handleInvocationFailure` to `GrpcDispatcher`, failing the response when the service method throws, and only reporting the exception when the response was cancelled or already sent its trailers, since `fail` ends the response and would throw on those.
- Removed the now redundant try/catch from `GrpcServerImpl.MethodCallHandler`.
- Added tests for a call handler throwing before it responds and after it ended the response.