### PR TITLE
Use the gRPC dispatcher for event bus unary calls

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCallBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCallBase.java
@@ -1,0 +1,165 @@
+package io.vertx.grpc.eventbus.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.grpc.common.impl.GrpcFrame;
+import io.vertx.grpc.common.impl.GrpcFrameType;
+import io.vertx.grpc.common.impl.GrpcInboundStream;
+import io.vertx.grpc.common.impl.GrpcOutboundStream;
+import io.vertx.grpc.common.impl.GrpcStream;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+abstract class EventBusGrpcCallBase implements GrpcStream {
+
+  private static final Object END_MARKER = new Object();
+
+  protected final ContextInternal context;
+
+  private final Deque<Object> inboundQueue = new ArrayDeque<>();
+  private boolean draining;
+  private boolean flowing = true;
+
+  private Handler<GrpcFrame> frameHandler;
+  private Handler<Void> endHandler;
+  private Handler<Throwable> exceptionHandler;
+  private Handler<Void> drainHandler;
+
+  EventBusGrpcCallBase(ContextInternal context) {
+    this.context = context;
+  }
+
+  @Override
+  public GrpcStream handler(Handler<GrpcFrame> handler) {
+    this.frameHandler = handler;
+    return this;
+  }
+
+  @Override
+  public GrpcStream endHandler(Handler<Void> handler) {
+    this.endHandler = handler;
+    return this;
+  }
+
+  @Override
+  public GrpcStream exceptionHandler(Handler<Throwable> handler) {
+    this.exceptionHandler = handler;
+    return this;
+  }
+
+  @Override
+  public GrpcOutboundStream drainHandler(Handler<Void> handler) {
+    this.drainHandler = handler;
+    return this;
+  }
+
+  @Override
+  public GrpcOutboundStream setWriteQueueMaxSize(int maxSize) {
+    return this;
+  }
+
+  @Override
+  public boolean writeQueueFull() {
+    return false;
+  }
+
+  @Override
+  public GrpcInboundStream pause() {
+    flowing = false;
+    return this;
+  }
+
+  @Override
+  public GrpcInboundStream resume() {
+    return fetch(Long.MAX_VALUE);
+  }
+
+  @Override
+  public GrpcInboundStream fetch(long amount) {
+    if (amount > 0) {
+      flowing = true;
+      drainInbound();
+      handleInboundFlowing();
+    }
+    return this;
+  }
+
+  protected final boolean flowing() {
+    return flowing;
+  }
+
+  protected void emit(GrpcFrame frame) {
+    inboundQueue.add(frame);
+    drainInbound();
+  }
+
+  protected void emitEnd() {
+    inboundQueue.add(END_MARKER);
+    drainInbound();
+  }
+
+  protected void emitException(Throwable t) {
+    inboundQueue.add(t);
+    drainInbound();
+  }
+
+  private void drainInbound() {
+    if (draining) {
+      return;
+    }
+    draining = true;
+    try {
+      while (flowing && !inboundQueue.isEmpty()) {
+        dispatchInbound(inboundQueue.poll());
+      }
+    } finally {
+      draining = false;
+    }
+  }
+
+  private void dispatchInbound(Object event) {
+    if (event == END_MARKER) {
+      Handler<Void> handler = endHandler;
+      if (handler != null) {
+        handler.handle(null);
+      }
+    } else if (event instanceof Throwable) {
+      Handler<Throwable> handler = exceptionHandler;
+      if (handler != null) {
+        handler.handle((Throwable) event);
+      }
+    } else {
+      GrpcFrame frame = (GrpcFrame) event;
+      Handler<GrpcFrame> handler = frameHandler;
+      if (handler != null) {
+        handler.handle(frame);
+      }
+      if (frame.type() == GrpcFrameType.MESSAGE) {
+        handleInboundMessage();
+      }
+    }
+  }
+
+  /**
+   * Notify the drain handler, to be called by subclasses when the write queue drained.
+   */
+  protected void handleDrain() {
+    Handler<Void> handler = drainHandler;
+    if (handler != null) {
+      context.runOnContext(v -> handler.handle(null));
+    }
+  }
+
+  /**
+   * Called after a message frame has been dispatched to the frame handler.
+   */
+  protected void handleInboundMessage() {
+  }
+
+  /**
+   * Called when the inbound stream resumes, after the queued events have been dispatched.
+   */
+  protected void handleInboundFlowing() {
+  }
+}

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientUnaryCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientUnaryCall.java
@@ -1,7 +1,6 @@
 package io.vertx.grpc.eventbus.impl;
 
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
@@ -19,9 +18,8 @@ import java.time.Duration;
 import static io.vertx.grpc.eventbus.impl.EventBusHeaders.HEADER_PREFIX;
 import static io.vertx.grpc.eventbus.impl.EventBusHeaders.TRAILER_PREFIX;
 
-public class EventBusGrpcClientUnaryCall implements GrpcStream {
+public class EventBusGrpcClientUnaryCall extends EventBusGrpcCallBase {
 
-  private final ContextInternal context;
   private final EventBus eventBus;
   private final ServiceName serviceName;
   private final String methodName;
@@ -32,11 +30,8 @@ public class EventBusGrpcClientUnaryCall implements GrpcStream {
   private Duration timeout;
   private boolean sent;
 
-  private Handler<GrpcFrame> frameHandler;
-  private Handler<Void> endHandler;
-
   public EventBusGrpcClientUnaryCall(ContextInternal context, EventBus eventBus, ServiceName serviceName, String methodName) {
-    this.context = context;
+    super(context);
     this.eventBus = eventBus;
     this.serviceName = serviceName;
     this.methodName = methodName;
@@ -127,64 +122,4 @@ public class EventBusGrpcClientUnaryCall implements GrpcStream {
     emitEnd();
   }
 
-  private void emit(GrpcFrame frame) {
-    Handler<GrpcFrame> handler = frameHandler;
-    if (handler != null) {
-      handler.handle(frame);
-    }
-  }
-
-  private void emitEnd() {
-    Handler<Void> handler = endHandler;
-    if (handler != null) {
-      handler.handle(null);
-    }
-  }
-
-  @Override
-  public GrpcStream handler(Handler<GrpcFrame> handler) {
-    this.frameHandler = handler;
-    return this;
-  }
-
-  @Override
-  public GrpcStream endHandler(Handler<Void> handler) {
-    this.endHandler = handler;
-    return this;
-  }
-
-  @Override
-  public GrpcStream exceptionHandler(Handler<Throwable> handler) {
-    return this;
-  }
-
-  @Override
-  public GrpcInboundStream pause() {
-    return this;
-  }
-
-  @Override
-  public GrpcInboundStream resume() {
-    return this;
-  }
-
-  @Override
-  public GrpcInboundStream fetch(long amount) {
-    return this;
-  }
-
-  @Override
-  public GrpcOutboundStream setWriteQueueMaxSize(int maxSize) {
-    return this;
-  }
-
-  @Override
-  public boolean writeQueueFull() {
-    return false;
-  }
-
-  @Override
-  public GrpcOutboundStream drainHandler(Handler<Void> handler) {
-    return this;
-  }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerImpl.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerImpl.java
@@ -15,8 +15,6 @@ import io.vertx.grpc.server.GrpcServerRequest;
 import io.vertx.grpc.server.Service;
 import io.vertx.grpc.server.ServiceMethodInvoker;
 import io.vertx.grpc.server.impl.GrpcDispatcher;
-import io.vertx.grpc.server.impl.GrpcServerRequestImpl;
-import io.vertx.grpc.server.impl.GrpcServerResponseImpl;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -254,31 +252,38 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
     private <Req, Resp> void dispatchUnary(Message<Object> message, ServiceMethod<Req, Resp> serviceMethod, WireFormat wireFormat) {
       ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
 
-      Buffer payload = EventBusGrpcCodec.decodeBody(message.body());
+      ServiceMethodInvoker<Req, Resp> invoker;
+      try {
+        invoker = service.invoker(serviceMethod);
+      } catch (Exception e) {
+        message.fail(GrpcStatus.INTERNAL.code, GrpcStatus.INTERNAL.name());
+        return;
+      }
 
       MultiMap headers = MultiMap.caseInsensitiveMultiMap();
       EventBusHeaders.decodeMultimap(HEADER_PREFIX, message.headers(), headers);
 
       EventBusGrpcServerUnaryCall stream = new EventBusGrpcServerUnaryCall(context, message, wireFormat);
+
       GrpcMethodCall methodCall = new GrpcMethodCall(serviceMethod.serviceName().pathOf(serviceMethod.methodName()));
-      GrpcServerRequestImpl<Req, Resp> request = new GrpcServerRequestImpl<>(context, headers, null, wireFormat, stream, null, "identity", serviceMethod.decoder(), methodCall);
 
-      GrpcMessage grpcMessage = GrpcMessage.message("identity", wireFormat, payload);
-      GrpcServerResponseImpl<Req, Resp> response = new GrpcServerResponseImpl<>(context, request, stream, null, serviceMethod.encoder());
+      GrpcDispatcher<Req, Resp> dispatcher = new GrpcDispatcher<>(
+        stream,
+        context,
+        null,
+        wireFormat,
+        serviceMethod.decoder(),
+        serviceMethod.encoder(),
+        methodCall,
+        null,
+        invoker::invoke,
+        false,
+        false);
 
-      response.format(wireFormat);
-      request.init(response, false);
+      stream.handler(dispatcher);
+      stream.exceptionHandler(dispatcher::handleException);
 
-      try {
-        ServiceMethodInvoker<Req, Resp> invoker = service.invoker(serviceMethod);
-        invoker.invoke(request);
-      } catch (Exception e) {
-        response.fail(e);
-        return;
-      }
-
-      request.handleMessage(grpcMessage);
-      request.handleEnd();
+      stream.init(headers, EventBusGrpcCodec.decodeBody(message.body()));
     }
 
     private <Req, Resp> void dispatchStreaming(Message<Object> message, ServiceMethod<Req, Resp> serviceMethod, WireFormat wireFormat) {
@@ -343,7 +348,6 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
 
         stream.handler(dispatcher);
         stream.exceptionHandler(dispatcher::handleException);
-        stream.endHandler(v2 -> dispatcher.handleEnd());
 
         DeliveryOptions replyOptions = new DeliveryOptions()
           .addHeader(EventBusHeaders.SERVER_ADDRESS, address())

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerUnaryCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerUnaryCall.java
@@ -1,7 +1,6 @@
 package io.vertx.grpc.eventbus.impl;
 
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
@@ -15,9 +14,8 @@ import io.vertx.grpc.common.impl.*;
 import static io.vertx.grpc.eventbus.impl.EventBusHeaders.HEADER_PREFIX;
 import static io.vertx.grpc.eventbus.impl.EventBusHeaders.TRAILER_PREFIX;
 
-public class EventBusGrpcServerUnaryCall implements GrpcStream {
+public class EventBusGrpcServerUnaryCall extends EventBusGrpcCallBase {
 
-  private final ContextInternal context;
   private final Message<Object> eventBusMessage;
   private final WireFormat wireFormat;
 
@@ -26,9 +24,15 @@ public class EventBusGrpcServerUnaryCall implements GrpcStream {
   private MultiMap headers;
 
   public EventBusGrpcServerUnaryCall(ContextInternal context, Message<Object> eventBusMessage, WireFormat wireFormat) {
-    this.context = context;
+    super(context);
     this.eventBusMessage = eventBusMessage;
     this.wireFormat = wireFormat;
+  }
+
+  void init(MultiMap headers, Buffer payload) {
+    emit(new DefaultGrpcHeadersFrame(wireFormat, "identity", headers));
+    emit(new DefaultGrpcMessageFrame(GrpcMessage.message("identity", wireFormat, payload)));
+    emitEnd();
   }
 
   @Override
@@ -78,50 +82,5 @@ public class EventBusGrpcServerUnaryCall implements GrpcStream {
       eventBusMessage.reply(EventBusGrpcCodec.encodeBody(payload, wireFormat), options);
     }
     return context.succeededFuture();
-  }
-
-  @Override
-  public GrpcStream handler(Handler<GrpcFrame> handler) {
-    return this;
-  }
-
-  @Override
-  public GrpcStream endHandler(Handler<Void> handler) {
-    return this;
-  }
-
-  @Override
-  public GrpcStream exceptionHandler(Handler<Throwable> handler) {
-    return this;
-  }
-
-  @Override
-  public GrpcInboundStream pause() {
-    return this;
-  }
-
-  @Override
-  public GrpcInboundStream resume() {
-    return this;
-  }
-
-  @Override
-  public GrpcInboundStream fetch(long amount) {
-    return this;
-  }
-
-  @Override
-  public GrpcOutboundStream setWriteQueueMaxSize(int maxSize) {
-    return this;
-  }
-
-  @Override
-  public boolean writeQueueFull() {
-    return false;
-  }
-
-  @Override
-  public GrpcOutboundStream drainHandler(Handler<Void> handler) {
-    return this;
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -3,15 +3,9 @@ package io.vertx.grpc.eventbus.impl;
 import com.google.protobuf.ByteString;
 import io.vertx.core.Closeable;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.grpc.common.GrpcMessage;
-import io.vertx.grpc.common.impl.GrpcFrame;
-import io.vertx.grpc.common.impl.GrpcFrameType;
-import io.vertx.grpc.common.impl.GrpcInboundStream;
-import io.vertx.grpc.common.impl.GrpcOutboundStream;
-import io.vertx.grpc.common.impl.GrpcStream;
 import io.vertx.grpc.eventbus.transport.v1alpha.Message;
 import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
 import io.vertx.grpc.eventbus.transport.v1alpha.WindowUpdate;
@@ -19,31 +13,20 @@ import io.vertx.grpc.eventbus.transport.v1alpha.WindowUpdate;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
+abstract class EventBusGrpcStreamBase extends EventBusGrpcCallBase implements Closeable {
 
   static final int DEFAULT_WINDOW = 64;
 
-  protected final ContextInternal context;
   protected final int window;
 
   private final Deque<MessageWrite> outboundQueue = new ArrayDeque<>();
 
-  private static final Object END_MARKER = new Object();
-  private final Deque<Object> inboundQueue = new ArrayDeque<>();
-  private boolean draining;
-
-  private Handler<GrpcFrame> frameHandler;
-  private Handler<Void> endHandler;
-  private Handler<Throwable> exceptionHandler;
-  private Handler<Void> drainHandler;
-
-  private boolean flowing = true;
   private int granted;
   private int sendWindow;
   private long sequence;
 
   EventBusGrpcStreamBase(ContextInternal context, int window) {
-    this.context = context;
+    super(context);
     this.window = window;
     this.granted = window;
   }
@@ -54,13 +37,19 @@ abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
 
   abstract void handleRemoteEndpointDown(Throwable cause);
 
-  private void onInboundMessage() {
+  @Override
+  protected void handleInboundMessage() {
     granted--;
     topUpWindow();
   }
 
+  @Override
+  protected void handleInboundFlowing() {
+    topUpWindow();
+  }
+
   private void topUpWindow() {
-    if (flowing && granted <= window / 2) {
+    if (flowing() && granted <= window / 2) {
       int delta = window - granted;
       if (delta > 0) {
         granted += delta;
@@ -103,10 +92,7 @@ abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
     sendWindow += delta;
     drainOutbound();
     if (wasFull && !writeQueueFull()) {
-      Handler<Void> h = drainHandler;
-      if (h != null) {
-        context.runOnContext(v -> h.handle(null));
-      }
+      handleDrain();
     }
   }
 
@@ -120,108 +106,6 @@ abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
   @Override
   public boolean writeQueueFull() {
     return sendWindow <= 0 || !outboundQueue.isEmpty();
-  }
-
-  @Override
-  public GrpcOutboundStream setWriteQueueMaxSize(int maxSize) {
-    return this;
-  }
-
-  @Override
-  public GrpcOutboundStream drainHandler(Handler<Void> handler) {
-    this.drainHandler = handler;
-    return this;
-  }
-
-  @Override
-  public GrpcStream handler(Handler<GrpcFrame> handler) {
-    this.frameHandler = handler;
-    return this;
-  }
-
-  @Override
-  public GrpcStream endHandler(Handler<Void> handler) {
-    this.endHandler = handler;
-    return this;
-  }
-
-  @Override
-  public GrpcStream exceptionHandler(Handler<Throwable> handler) {
-    this.exceptionHandler = handler;
-    return this;
-  }
-
-  @Override
-  public GrpcInboundStream pause() {
-    flowing = false;
-    return this;
-  }
-
-  @Override
-  public GrpcInboundStream resume() {
-    return fetch(Long.MAX_VALUE);
-  }
-
-  @Override
-  public GrpcInboundStream fetch(long amount) {
-    if (amount > 0) {
-      flowing = true;
-      drainInbound();
-      topUpWindow();
-    }
-    return this;
-  }
-
-  protected void emit(GrpcFrame frame) {
-    inboundQueue.add(frame);
-    drainInbound();
-  }
-
-  protected void emitEnd() {
-    inboundQueue.add(END_MARKER);
-    drainInbound();
-  }
-
-  protected void emitException(Throwable t) {
-    inboundQueue.add(t);
-    drainInbound();
-  }
-
-  private void drainInbound() {
-    if (draining) {
-      return;
-    }
-    draining = true;
-    try {
-      while (flowing && !inboundQueue.isEmpty()) {
-        dispatchInbound(inboundQueue.poll());
-      }
-    } finally {
-      draining = false;
-    }
-  }
-
-  private void dispatchInbound(Object event) {
-    if (event == END_MARKER) {
-      Handler<Void> handler = endHandler;
-      if (handler != null) {
-        handler.handle(null);
-      }
-    } else if (event instanceof Throwable) {
-      Handler<Throwable> handler = exceptionHandler;
-      if (handler != null) {
-        handler.handle((Throwable) event);
-      }
-    } else {
-      GrpcFrame frame = (GrpcFrame) event;
-      Handler<GrpcFrame> handler = frameHandler;
-      if (handler != null) {
-        handler.handle(frame);
-      }
-      if (frame.type() == GrpcFrameType.MESSAGE) {
-        onInboundMessage();
-      }
-    }
   }
 
   private static final class MessageFrameWrite implements MessageWrite {


### PR DESCRIPTION
Motivation:

- The unary path built `GrpcServerRequestImpl` and `GrpcServerResponseImpl` by hand instead of going through `GrpcDispatcher` like the streaming path, so the internal gRPC frame protocol was not the only way into a service method.
- `EventBusGrpcServerUnaryCall` and `EventBusGrpcClientUnaryCall` returned themselves from every handler setter and from `pause`/`resume`/`fetch`, duplicating handler fields already present in `EventBusGrpcStreamBase` while dropping the events and the back pressure on the floor.

Changes:

- Introduced `EventBusGrpcCallBase` holding the stream handlers, the inbound queue feeding them and the read stream flow control gating it, with `handleInboundMessage` and `handleInboundFlowing` hooks for the receive window accounting only streaming calls need.
- Refactored `EventBusGrpcStreamBase`, `EventBusGrpcServerUnaryCall` and `EventBusGrpcClientUnaryCall` to extend it, leaving `EventBusGrpcStreamBase` with the transport frames, the send window and the outbound queue.
- Updated `EventBusGrpcServerImpl.dispatchUnary` to wire a `GrpcDispatcher` the way `dispatchStreaming` does, and added `EventBusGrpcServerUnaryCall.init` publishing the call as a headers frame, a message frame and an end event.
- Dropped the `endHandler` registered by both dispatch methods, `GrpcDispatcher.handleHeadersFrame` overwrites it with its own before it can fire.

Depends on #295, without it a call handler that throws before responding leaves the caller waiting on its send timeout instead of getting `UNKNOWN`.