### PR TITLE
Rework the event-bus flow control to use internal message queues.

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCallBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCallBase.java
@@ -1,33 +1,60 @@
 package io.vertx.grpc.eventbus.impl;
 
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.grpc.common.impl.GrpcFrame;
-import io.vertx.grpc.common.impl.GrpcFrameType;
-import io.vertx.grpc.common.impl.GrpcInboundStream;
-import io.vertx.grpc.common.impl.GrpcOutboundStream;
-import io.vertx.grpc.common.impl.GrpcStream;
-
-import java.util.ArrayDeque;
-import java.util.Deque;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
+import io.vertx.grpc.common.impl.*;
+import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
+import io.vertx.grpc.eventbus.transport.v1alpha.WindowUpdate;
 
 abstract class EventBusGrpcCallBase implements GrpcStream {
 
-  private static final Object END_MARKER = new Object();
+  static final int DEFAULT_WINDOW = 64;
 
-  protected final ContextInternal context;
+  static final Object END_MARKER = new Object();
 
-  private final Deque<Object> inboundQueue = new ArrayDeque<>();
-  private boolean draining;
-  private boolean flowing = true;
+  protected final EventBusGrpcEndpoint.StreamRegistration registration;
+  protected final ContextInternal consumerContext;
+  protected final ContextInternal producerContext;
+
+  private final InboundMessageQueue<Object> inboundQueue;
 
   private Handler<GrpcFrame> frameHandler;
   private Handler<Void> endHandler;
   private Handler<Throwable> exceptionHandler;
-  private Handler<Void> drainHandler;
+  private int window = DEFAULT_WINDOW;
 
-  EventBusGrpcCallBase(ContextInternal context) {
-    this.context = context;
+  EventBusGrpcCallBase(EventBusGrpcEndpoint.StreamRegistration registration, ContextInternal consumerContext) {
+    InboundMessageQueue<Object> queue = new InboundMessageQueue<>(registration.localEndpoint().producerContext.executor(), consumerContext.executor()) {
+      @Override
+      protected void handleResume() {
+      }
+
+      @Override
+      protected void handlePause() {
+      }
+
+      @Override
+      protected void handleMessage(Object msg) {
+        if (--window == 0) {
+          // Replenish
+          window = DEFAULT_WINDOW;
+          sendTransportFrame(TransportFrame.newBuilder().setWindowUpdate(WindowUpdate.newBuilder().setDelta(DEFAULT_WINDOW)));
+        }
+        dispatchInbound(msg);
+      }
+
+      @Override
+      protected void handleDispose(Object msg) {
+        //
+      }
+    };
+
+    this.registration = registration;
+    this.consumerContext = consumerContext;
+    this.producerContext = registration.localEndpoint().producerContext;
+    this.inboundQueue = queue;
   }
 
   @Override
@@ -49,24 +76,13 @@ abstract class EventBusGrpcCallBase implements GrpcStream {
   }
 
   @Override
-  public GrpcOutboundStream drainHandler(Handler<Void> handler) {
-    this.drainHandler = handler;
-    return this;
-  }
-
-  @Override
   public GrpcOutboundStream setWriteQueueMaxSize(int maxSize) {
     return this;
   }
 
   @Override
-  public boolean writeQueueFull() {
-    return false;
-  }
-
-  @Override
   public GrpcInboundStream pause() {
-    flowing = false;
+    inboundQueue.pause();
     return this;
   }
 
@@ -77,48 +93,37 @@ abstract class EventBusGrpcCallBase implements GrpcStream {
 
   @Override
   public GrpcInboundStream fetch(long amount) {
-    if (amount > 0) {
-      flowing = true;
-      drainInbound();
-      handleInboundFlowing();
-    }
+    inboundQueue.fetch(amount);
     return this;
   }
 
-  protected final boolean flowing() {
-    return flowing;
+  private void emitInbound(Object o) {
+    assert producerContext.inThread();
+    inboundQueue.write(o);
   }
 
-  protected void emit(GrpcFrame frame) {
-    inboundQueue.add(frame);
-    drainInbound();
+  protected void emitFrameInbound(GrpcFrame frame) {
+    emitInbound(frame);
   }
 
-  protected void emitEnd() {
-    inboundQueue.add(END_MARKER);
-    drainInbound();
+  protected void emitEndInbound() {
+    emitInbound(END_MARKER);
   }
 
-  protected void emitException(Throwable t) {
-    inboundQueue.add(t);
-    drainInbound();
+  protected void emitExceptionInbound(Throwable t) {
+    emitInbound(t);
   }
 
-  private void drainInbound() {
-    if (draining) {
-      return;
-    }
-    draining = true;
-    try {
-      while (flowing && !inboundQueue.isEmpty()) {
-        dispatchInbound(inboundQueue.poll());
-      }
-    } finally {
-      draining = false;
-    }
+  protected void dispatchFrameInbound(GrpcFrame frame) {
+    dispatchInbound(frame);
+  }
+
+  protected void dispatchEndInbound() {
+    dispatchInbound(END_MARKER);
   }
 
   private void dispatchInbound(Object event) {
+    assert consumerContext.inThread();
     if (event == END_MARKER) {
       Handler<Void> handler = endHandler;
       if (handler != null) {
@@ -135,31 +140,9 @@ abstract class EventBusGrpcCallBase implements GrpcStream {
       if (handler != null) {
         handler.handle(frame);
       }
-      if (frame.type() == GrpcFrameType.MESSAGE) {
-        handleInboundMessage();
-      }
     }
   }
 
-  /**
-   * Notify the drain handler, to be called by subclasses when the write queue drained.
-   */
-  protected void handleDrain() {
-    Handler<Void> handler = drainHandler;
-    if (handler != null) {
-      context.runOnContext(v -> handler.handle(null));
-    }
-  }
+  protected abstract Future<Void> sendTransportFrame(TransportFrame.Builder frame);
 
-  /**
-   * Called after a message frame has been dispatched to the frame handler.
-   */
-  protected void handleInboundMessage() {
-  }
-
-  /**
-   * Called when the inbound stream resumes, after the queued events have been dispatched.
-   */
-  protected void handleInboundFlowing() {
-  }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
@@ -6,7 +6,6 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
-import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.grpc.client.InvalidStatusException;
@@ -29,7 +28,6 @@ import static io.vertx.grpc.eventbus.impl.EventBusHeaders.TRAILER_PREFIX;
 class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
 
   private final EventBusGrpcEndpoint endpoint;
-  private final EventBus eventBus;
   private final ServiceName serviceName;
   private final String methodName;
   private final Deque<MessageWrite> pending;
@@ -48,7 +46,6 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
   public EventBusGrpcClientCall(ContextInternal context, boolean localUnary, boolean remoteUnary, EventBusGrpcEndpoint.StreamRegistration registration, EventBusGrpcEndpoint endpoint, ServiceName serviceName, String methodName) {
     super(context, localUnary, remoteUnary, registration, DEFAULT_WINDOW);
     this.endpoint = endpoint;
-    this.eventBus = endpoint.eventBus();
     this.serviceName = serviceName;
     this.methodName = methodName;
     this.pending = new ArrayDeque<>();
@@ -81,12 +78,12 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
           }
           requestHeaders = headersFrame.headers();
           timeout = headersFrame.timeout();
-          return context.succeededFuture();
+          return consumerContext.succeededFuture();
         case MESSAGE:
           message = ((GrpcMessageFrame) frame).message();
-          return context.succeededFuture();
+          return consumerContext.succeededFuture();
         default:
-          return context.failedFuture("Frame not handled");
+          return consumerContext.failedFuture("Frame not handled");
       }
     }
 
@@ -94,7 +91,7 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
     public Future<Void> end() {
       GrpcMessage msg = message;
       if (msg == null) {
-        return context.failedFuture("No message to send");
+        return consumerContext.failedFuture("No message to send");
       }
       ended = true;
       message = null;
@@ -120,9 +117,9 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
       Buffer payload = message != null ? message.payload() : Buffer.buffer();
       Object body = EventBusGrpcCodec.encodeBody(payload, wireFormat);
 
-      Promise<Void> promise = context.promise();
+      Promise<Void> promise = consumerContext.promise();
 
-      eventBus.request(serviceName.fullyQualifiedName(), body, options).onComplete(ar -> {
+      endpoint.request(consumerContext, serviceName.fullyQualifiedName(), body, options).onComplete(ar -> {
         if (ar.succeeded()) {
           Throwable malformed = inbound.handleReply(ar.result(), encoding, wireFormat);
           if (malformed == null) {
@@ -159,7 +156,7 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
         case MESSAGE:
           return onMessageWrite(((GrpcMessageFrame) frame).message());
         default:
-          return context.failedFuture("Invalid message: " + frame.type());
+          return consumerContext.failedFuture("Invalid message: " + frame.type());
       }
     }
 
@@ -168,7 +165,7 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
       if (state == State.STREAMING) {
         sendHalfClose();
       }
-      return context.succeededFuture();
+      return consumerContext.succeededFuture();
     }
 
     private Future<Void> open() {
@@ -192,8 +189,8 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
         EventBusHeaders.encodeMultiMap(HEADER_PREFIX, requestHeaders, options.getHeaders());
       }
 
-      Promise<Void> promise = context.promise();
-      eventBus.request(serviceName.fullyQualifiedName(), Buffer.buffer(), options).onComplete(ar -> {
+      Promise<Void> promise = consumerContext.promise();
+      endpoint.request(consumerContext, serviceName.fullyQualifiedName(), Buffer.buffer(), options).onComplete(ar -> {
         if (ar.failed()) {
           handleFailure(ar.cause(), encoding, wireFormat);
           promise.fail(ar.cause());
@@ -261,11 +258,8 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
       EventBusGrpcClientCall.this.wireFormat = wireFormat;
       EventBusGrpcClientCall.this.state = State.STREAMING;
 
+      // This could be racy since we are on the request/reply context ...
       registration.bind(EventBusGrpcClientCall.this, serverAddress, endpoint.pingTimeout());
-
-      grantSendWindow(initialWindow);
-
-      sendTransportFrame(TransportFrame.newBuilder().setWindowUpdate(WindowUpdate.newBuilder().setDelta(window)));
 
       return null;
     }
@@ -280,10 +274,10 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
       EventBusHeaders.decodeMultimap(HEADER_PREFIX, reply.headers(), headers);
       EventBusHeaders.decodeMultimap(TRAILER_PREFIX, reply.headers(), trailers);
       Buffer payload = EventBusGrpcCodec.decodeBody(reply.body());
-      emit(new DefaultGrpcHeadersFrame(wireFormat, encoding, headers));
-      emit(new DefaultGrpcMessageFrame(GrpcMessage.message(encoding, wireFormat, payload)));
-      emit(new DefaultGrpcTrailersFrame(GrpcStatus.OK, null, trailers));
-      emitEnd();
+      dispatchFrameInbound(new DefaultGrpcHeadersFrame(wireFormat, encoding, headers));
+      dispatchFrameInbound(new DefaultGrpcMessageFrame(GrpcMessage.message(encoding, wireFormat, payload)));
+      dispatchFrameInbound(new DefaultGrpcTrailersFrame(GrpcStatus.OK, null, trailers));
+      dispatchEndInbound();
       return null;
     }
   }
@@ -298,15 +292,16 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
   }
 
   private Future<Void> onMessageWrite(GrpcMessage message) {
-    switch (state) {
+    State s = state;
+    switch (s) {
       case OPENING:
-        Promise<Void> promise = context.promise();
+        Promise<Void> promise = consumerContext.promise();
         pending.add(messageWrite(message, promise));
         return promise.future();
       case STREAMING:
         return writeMessage(message);
       default:
-        return context.failedFuture(new IllegalStateException("Stream closed"));
+        return consumerContext.failedFuture(new IllegalStateException("Stream closed"));
     }
   }
 
@@ -323,10 +318,10 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
 
   private InvalidStatusException handleFailure(Throwable cause, String encoding, WireFormat wireFormat) {
     GrpcStatus status = EventBusGrpcCodec.mapFailure(cause);
-    emit(new DefaultGrpcHeadersFrame(wireFormat, encoding, MultiMap.caseInsensitiveMultiMap()));
-    emit(new DefaultGrpcTrailersFrame(status, cause.getMessage(), MultiMap.caseInsensitiveMultiMap()));
+    emitFrameInbound(new DefaultGrpcHeadersFrame(wireFormat, encoding, MultiMap.caseInsensitiveMultiMap()));
+    emitFrameInbound(new DefaultGrpcTrailersFrame(status, cause.getMessage(), MultiMap.caseInsensitiveMultiMap()));
     terminate();
-    emitEnd();
+    emitEndInbound();
     return new InvalidStatusException(GrpcStatus.OK, status);
   }
 
@@ -336,10 +331,10 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
       case HEADERS:
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         EventBusHeaders.decodeMultimap(HEADER_PREFIX, message.headers(), headers);
-        emit(new DefaultGrpcHeadersFrame(wireFormat, encoding, headers));
+        emitFrameInbound(new DefaultGrpcHeadersFrame(wireFormat, encoding, headers));
         break;
       case MESSAGE:
-        emit(new DefaultGrpcMessageFrame(EventBusGrpcCodec.message(frame, encoding, wireFormat)));
+        emitFrameInbound(new DefaultGrpcMessageFrame(EventBusGrpcCodec.message(frame, encoding, wireFormat)));
         break;
       case WINDOW_UPDATE:
         grantSendWindow(frame.getWindowUpdate().getDelta());
@@ -349,14 +344,14 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
         MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
         EventBusHeaders.decodeMultimap(TRAILER_PREFIX, message.headers(), trailers);
         GrpcStatus status = Optional.ofNullable(GrpcStatus.valueOf(t.getStatus())).orElse(GrpcStatus.UNKNOWN);
-        emit(new DefaultGrpcTrailersFrame(status, t.getStatusMessage().isEmpty() ? null : t.getStatusMessage(), trailers));
+        emitFrameInbound(new DefaultGrpcTrailersFrame(status, t.getStatusMessage().isEmpty() ? null : t.getStatusMessage(), trailers));
         terminate();
-        emitEnd();
+        emitEndInbound();
         break;
       case CANCEL:
-        emitException(new CancellationException(frame.getCancel().getReason()));
+        emitExceptionInbound(new CancellationException(frame.getCancel().getReason()));
         terminate();
-        emitEnd();
+        emitEndInbound();
         break;
       default:
         break;
@@ -368,7 +363,7 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
       sendTransportFrame(TransportFrame.newBuilder().setCancel(Cancel.newBuilder().setStatus(GrpcStatus.CANCELLED.code)));
     }
     terminate();
-    return context.succeededFuture();
+    return consumerContext.succeededFuture();
   }
 
   @Override
@@ -378,8 +373,8 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
         sendTransportFrame(TransportFrame.newBuilder().setCancel(Cancel.newBuilder().setStatus(GrpcStatus.CANCELLED.code).setReason("Client closed")));
       }
       terminate();
-      emitException(new CancellationException("Client closed"));
-      emitEnd();
+      emitExceptionInbound(new CancellationException("Client closed"));
+      emitEndInbound();
     }
     completion.succeed();
   }
@@ -406,8 +401,8 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
     }
 
     failPending(cause);
-    emitException(cause);
-    emitEnd();
+    emitExceptionInbound(cause);
+    emitEndInbound();
   }
 
   private void failPending(Throwable cause) {

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientImpl.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientImpl.java
@@ -2,6 +2,8 @@ package io.vertx.grpc.eventbus.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.PromiseInternal;
 import io.vertx.grpc.client.GrpcClientRequest;
 import io.vertx.grpc.client.impl.GrpcClientRequestImpl;
 import io.vertx.grpc.common.ServiceMethod;
@@ -16,8 +18,8 @@ public class EventBusGrpcClientImpl extends EventBusGrpcEndpoint implements Even
   private final WireFormat wireFormat;
   private final AtomicInteger sequence = new AtomicInteger();
 
-  private EventBusGrpcClientImpl(Vertx vertx, EventBusGrpcClientOptions options) {
-    super(vertx, vertx.eventBus(), "grpc.eb.client.", options.getWireFormat(), options.getPingInterval().toMillis(), pingTimeout(options));
+  private EventBusGrpcClientImpl(ContextInternal producerContext, EventBusGrpcClientOptions options) {
+    super(producerContext, "grpc.eb.client.", options.getWireFormat(), options.getPingInterval().toMillis(), pingTimeout(options));
     this.wireFormat = options.getWireFormat();
   }
 
@@ -34,8 +36,14 @@ public class EventBusGrpcClientImpl extends EventBusGrpcEndpoint implements Even
   }
 
   public static Future<EventBusGrpcClient> create(Vertx vertx, EventBusGrpcClientOptions options) {
-    EventBusGrpcClientImpl client = new EventBusGrpcClientImpl(vertx, options);
-    return client.bind().map(client);
+    ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
+    ContextInternal producerContext = Utils.eventLoopCtx(context);
+    EventBusGrpcClientImpl client = new EventBusGrpcClientImpl(producerContext, options);
+    PromiseInternal<Void> promise = context.promise();
+    client.bind(promise);
+    return promise
+      .future()
+      .map(client);
   }
 
   @Override
@@ -45,19 +53,19 @@ public class EventBusGrpcClientImpl extends EventBusGrpcEndpoint implements Even
 
   @Override
   public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(ServiceMethod<Resp, Req> method) {
-    EventBusGrpcClientInvoker invoker = new EventBusGrpcClientInvoker(context(), this, !method.clientStreaming(), !method.serverStreaming());
+    ContextInternal consumerContext = vertx.getOrCreateContext();
+    EventBusGrpcClientInvoker invoker = new EventBusGrpcClientInvoker(consumerContext, this, !method.clientStreaming(), !method.serverStreaming());
     GrpcClientRequestImpl<Req, Resp> request = new GrpcClientRequestImpl<>(
-      context(),
+      consumerContext,
       invoker,
       false,
       method.encoder(),
       method.decoder()
     );
-
     request.serviceName(method.serviceName());
     request.methodName(method.methodName());
     request.format(wireFormat);
-    return context().succeededFuture(request);
+    return consumerContext.succeededFuture(request);
   }
 
   @Override

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientInvoker.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientInvoker.java
@@ -7,14 +7,14 @@ import io.vertx.grpc.common.impl.GrpcStream;
 
 public class EventBusGrpcClientInvoker implements GrpcClientInvoker {
 
-  private final boolean remoteUnary;
   private final ContextInternal context;
+  private final boolean remoteUnary;
   private final EventBusGrpcClientImpl client;
   private final boolean localUnary;
 
   public EventBusGrpcClientInvoker(ContextInternal context, EventBusGrpcClientImpl client, boolean localUnary, boolean remoteUnary) {
-    this.context = context;
     this.client = client;
+    this.context = context;
     this.localUnary = localUnary;
     this.remoteUnary = remoteUnary;
   }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -1,14 +1,12 @@
 package io.vertx.grpc.eventbus.impl;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.DeliveryOptions;
-import io.vertx.core.eventbus.EventBus;
-import io.vertx.core.eventbus.Message;
-import io.vertx.core.eventbus.MessageConsumer;
-import io.vertx.core.eventbus.MessageProducer;
+import io.vertx.core.eventbus.*;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.eventbus.EventBusInternal;
 import io.vertx.grpc.common.JsonWireFormat;
 import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.eventbus.transport.v1alpha.Ping;
@@ -25,8 +23,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 abstract class EventBusGrpcEndpoint {
 
-  private final ContextInternal context;
-  private final EventBus eventBus;
+  protected final ContextInternal producerContext;
+  protected final VertxInternal vertx;
+  private final EventBusInternal eventBus;
   private final String address;
   private final int id;
   private final WireFormat pingWireFormat;
@@ -40,12 +39,13 @@ abstract class EventBusGrpcEndpoint {
   private long livenessTimerId = -1L;
   private boolean stopped;
 
-  EventBusGrpcEndpoint(Vertx vertx, EventBus eventBus, String prefix, WireFormat pingWireFormat, long pingInterval, long pingTimeout) {
+  EventBusGrpcEndpoint(ContextInternal producerContext, String prefix, WireFormat pingWireFormat, long pingInterval, long pingTimeout) {
 
     UUID uuid = UUID.randomUUID();
 
-    this.context = (ContextInternal) vertx.getOrCreateContext();
-    this.eventBus = eventBus;
+    this.vertx = producerContext.owner();
+    this.producerContext = producerContext;
+    this.eventBus = vertx.eventBus();
     this.id = uuid.hashCode();
     this.address = prefix + uuid;
     this.pingWireFormat = pingWireFormat;
@@ -55,14 +55,6 @@ abstract class EventBusGrpcEndpoint {
 
   int id() {
     return id;
-  }
-
-  ContextInternal context() {
-    return context;
-  }
-
-  EventBus eventBus() {
-    return eventBus;
   }
 
   String address() {
@@ -81,14 +73,15 @@ abstract class EventBusGrpcEndpoint {
     return new StreamRegistration(id);
   }
 
-  Future<Void> bind() {
-    Promise<Void> promise = context.promise();
-    context.runOnContext(v -> {
-      consumer = eventBus.consumer(address, this::dispatch);
-      consumer.completion().onComplete(promise);
-      scheduleLivenessCheck();
-    });
-    return promise.future();
+  void bind(Promise<Void> promise) {
+    consumer = consumer(address, this::dispatch);
+    consumer
+      .completion()
+      .andThen(ar -> {
+        if (ar.succeeded()) {
+          scheduleLivenessCheck();
+        }
+      }).onComplete(promise);
   }
 
   private void scheduleLivenessCheck() {
@@ -97,7 +90,7 @@ abstract class EventBusGrpcEndpoint {
     }
     long period = checkPeriod();
     if (period > 0) {
-      livenessTimerId = context.setTimer(period, id -> {
+      livenessTimerId = producerContext.setTimer(period, id -> {
         livenessTimerId = -1L;
         long now = System.currentTimeMillis();
         pingRemoteEndpoints();
@@ -115,6 +108,16 @@ abstract class EventBusGrpcEndpoint {
       }
     }
     return period == Long.MAX_VALUE ? -1L : period;
+  }
+
+  Future<Message<Object>> request(ContextInternal context, String address, Object body, DeliveryOptions options) {
+    return eventBus.request(context, address, body, options);
+  }
+
+  MessageConsumer<Object> consumer(String address, Handler<Message<Object>> handler) {
+    MessageConsumer<Object> consumer = eventBus.consumer(producerContext, new MessageConsumerOptions().setAddress(address));
+    consumer.handler(handler);
+    return consumer;
   }
 
   private void pingRemoteEndpoints() {
@@ -191,7 +194,7 @@ abstract class EventBusGrpcEndpoint {
   Future<Void> closeStreams() {
     stopped = true;
     if (livenessTimerId >= 0) {
-      context.owner().cancelTimer(livenessTimerId);
+      vertx.cancelTimer(livenessTimerId);
       livenessTimerId = -1L;
     }
     for (RemoteEndpoint remoteEndpoint : remoteEndpoints.values()) {
@@ -240,6 +243,14 @@ abstract class EventBusGrpcEndpoint {
 
     private StreamRegistration(long id) {
       this.id = id;
+    }
+
+    EventBusGrpcEndpoint localEndpoint() {
+      return EventBusGrpcEndpoint.this;
+    }
+
+    RemoteEndpoint remoteEndpoint() {
+      return remoteEndpoint;
     }
 
     long id() {

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
@@ -23,9 +23,6 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
   private final WireFormat wireFormat;
   private final String encoding;
 
-  private boolean clientListening;
-  private MultiMap pendingHeaders;
-  private Promise<Void> pendingHeadersPromise;
   private boolean closed;
 
   private final Inbound inbound;
@@ -56,9 +53,9 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
     @Override
     void init(MultiMap headers, Message<Object> message) {
       Buffer payload = EventBusGrpcCodec.decodeBody(message.body());
-      emit(new DefaultGrpcHeadersFrame(wireFormat, "identity", headers));
-      emit(new DefaultGrpcMessageFrame(GrpcMessage.message("identity", wireFormat, payload)));
-      emitEnd();
+      emitFrameInbound(new DefaultGrpcHeadersFrame(wireFormat, "identity", headers));
+      emitFrameInbound(new DefaultGrpcMessageFrame(GrpcMessage.message("identity", wireFormat, payload)));
+      emitEndInbound();
     }
   }
 
@@ -66,7 +63,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
     @Override
     void init(MultiMap headers, Message<Object> message) {
       GrpcHeadersFrame frame = new DefaultGrpcHeadersFrame(wireFormat, "identity, ", headers);
-      emit(frame);
+      emitFrameInbound(frame);
     }
   }
 
@@ -96,23 +93,23 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
       switch (frame.type()) {
         case HEADERS:
           headers = ((GrpcHeadersFrame) frame).headers();
-          return context.succeededFuture();
+          return consumerContext.succeededFuture();
         case MESSAGE:
           encodedMessage = ((GrpcMessageFrame) frame).message();
-          return context.succeededFuture();
+          return consumerContext.succeededFuture();
         case TRAILERS:
           assert !replied;
           replied = true;
           GrpcTrailersFrame trailersFrame = (GrpcTrailersFrame) frame;
           return handleTrailers(trailersFrame.status(), trailersFrame.statusMessage(), encodedMessage, headers, trailersFrame.trailers());
         default:
-          return context.succeededFuture();
+          return consumerContext.succeededFuture();
       }
     }
 
     @Override
     Future<Void> end() {
-      return context.succeededFuture();
+      return consumerContext.succeededFuture();
     }
 
     private Future<Void> handleTrailers(GrpcStatus status, String statusMessage, GrpcMessage grpcMsg, MultiMap headers, MultiMap trailers) {
@@ -132,7 +129,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
         options.setHeaders(multiMap);
         message.reply(EventBusGrpcCodec.encodeBody(payload, wireFormat), options);
       }
-      return context.succeededFuture();
+      return consumerContext.succeededFuture();
     }
   }
 
@@ -144,7 +141,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
     void init(String address, Message<Object> msg) {
       DeliveryOptions replyOptions = new DeliveryOptions()
         .addHeader(EventBusHeaders.SERVER_ADDRESS, address)
-        .addHeader(EventBusHeaders.INITIAL_WINDOW, Integer.toString(window));
+        .addHeader(EventBusHeaders.INITIAL_WINDOW, Integer.toString(DEFAULT_WINDOW));
 
       msg.reply(Buffer.buffer(), replyOptions);
     }
@@ -155,24 +152,18 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
       switch (frame.type()) {
         case HEADERS:
           MultiMap responseHeaders = ((GrpcHeadersFrame) frame).headers();
-          if (clientListening) {
-            written = sendResponseHeaders(responseHeaders);
-          } else {
-            pendingHeaders = responseHeaders;
-            pendingHeadersPromise = context.promise();
-            written = pendingHeadersPromise.future();
-          }
+          written = sendResponseHeaders(responseHeaders);
           break;
         case MESSAGE:
           written = writeMessage(((GrpcMessageFrame) frame).message());
           break;
         case TRAILERS:
-          Promise<Void> promise = context.promise();
+          Promise<Void> promise = consumerContext.promise();
           enqueue(new TrailersWrite((GrpcTrailersFrame) frame, promise));
           written = promise.future();
           break;
         default:
-          return context.failedFuture("Invalid message: " + frame.type());
+          return consumerContext.failedFuture("Invalid message: " + frame.type());
       }
       lastWrite = written;
       return written;
@@ -181,7 +172,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
     public Future<Void> end() {
       Future<Void> last = lastWrite;
       if (last == null) {
-        return context.failedFuture(new IllegalStateException("Cannot end a stream that did not write any frame"));
+        return consumerContext.failedFuture(new IllegalStateException("Cannot end a stream that did not write any frame"));
       }
       return last;
     }
@@ -189,23 +180,12 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
 
   @Override
   public void handle(TransportFrame frame, Message<Object> message) {
-    if (!clientListening) {
-      clientListening = true;
-      Promise<Void> promise = pendingHeadersPromise;
-      if (promise != null) {
-        MultiMap headers = pendingHeaders;
-        pendingHeaders = null;
-        pendingHeadersPromise = null;
-        sendResponseHeaders(headers).onComplete(promise);
-      }
-    }
-
     switch (frame.getFrameCase()) {
       case MESSAGE:
-        emit(new DefaultGrpcMessageFrame(EventBusGrpcCodec.message(frame, encoding, wireFormat)));
+        emitFrameInbound(new DefaultGrpcMessageFrame(EventBusGrpcCodec.message(frame, encoding, wireFormat)));
         break;
       case HALF_CLOSE:
-        emitEnd();
+        emitEndInbound();
         break;
       case WINDOW_UPDATE:
         grantSendWindow(frame.getWindowUpdate().getDelta());
@@ -215,7 +195,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
           break;
         }
         terminate();
-        emitException(new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED));
+        emitExceptionInbound(new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED));
         break;
       default:
         break;
@@ -278,7 +258,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
       terminate();
       GrpcErrorException failure = new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED);
       failPending(failure);
-      emitException(failure);
+      emitExceptionInbound(failure);
     }
     completion.succeed();
   }
@@ -302,16 +282,10 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
     terminate();
     sendTransportFrame(TransportFrame.newBuilder().setCancel(Cancel.newBuilder().setStatus(GrpcStatus.UNAVAILABLE.code).setReason("Remote endpoint down")));
     failPending(cause);
-    emitException(new GrpcErrorException(GrpcError.UNAVAILABLE, GrpcStatus.UNAVAILABLE));
+    emitExceptionInbound(new GrpcErrorException(GrpcError.UNAVAILABLE, GrpcStatus.UNAVAILABLE));
   }
 
   private void failPending(Throwable cause) {
-    Promise<Void> promise = pendingHeadersPromise;
-    if (promise != null) {
-      pendingHeaders = null;
-      pendingHeadersPromise = null;
-      promise.fail(cause);
-    }
     failPendingWrites(cause);
   }
 

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerImpl.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerImpl.java
@@ -4,6 +4,8 @@ import com.google.protobuf.Descriptors;
 import io.vertx.core.*;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.PromiseInternal;
 import io.vertx.grpc.common.*;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
@@ -18,14 +20,14 @@ import java.util.stream.Collectors;
 
 public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements EventBusGrpcServer {
 
-  private final Vertx vertx;
   private final Map<String, ServiceConsumer> consumers = new HashMap<>();
   private final Set<WireFormat> supportedWireFormats;
   private final long maxPingTimeout;
+  protected final ContextInternal consumerContext;
 
-  private EventBusGrpcServerImpl(Vertx vertx, EventBusGrpcServerOptions options) {
-    super(vertx, vertx.eventBus(), "grpc.eb.server.", WireFormat.PROTOBUF, 0L, 0L);
-    this.vertx = vertx;
+  private EventBusGrpcServerImpl(ContextInternal consumerContext, EventBusGrpcServerOptions options) {
+    super(Utils.eventLoopCtx(consumerContext),  "grpc.eb.server.", WireFormat.PROTOBUF, 0L, 0L);
+    this.consumerContext = consumerContext;
     this.supportedWireFormats = new LinkedHashSet<>(options.getSupportedWireFormats());
     this.maxPingTimeout = options.getMaxPingTimeout().toMillis();
   }
@@ -49,8 +51,13 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
   }
 
   public static Future<EventBusGrpcServer> create(Vertx vertx, EventBusGrpcServerOptions options) {
-    EventBusGrpcServerImpl server = new EventBusGrpcServerImpl(vertx, options);
-    return server.bind().map(server);
+    ContextInternal consumerContext = (ContextInternal) vertx.getOrCreateContext();
+    EventBusGrpcServerImpl server = new EventBusGrpcServerImpl(consumerContext, options);
+    PromiseInternal<Void> promise = consumerContext.promise();
+    server.bind(promise);
+    return promise
+      .future()
+      .map(server);
   }
 
   @Override
@@ -96,7 +103,7 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
 
     String serviceFqn = service.name().fullyQualifiedName();
     Adapter adapter = new Adapter(serviceFqn, service);
-    MessageConsumer<Object> consumer = eventBus().consumer(serviceFqn, adapter);
+    MessageConsumer<Object> consumer = consumer(serviceFqn, adapter);
     consumers.put(serviceFqn, new ServiceConsumer(consumer, service));
 
     return this;
@@ -113,17 +120,31 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
 
   @Override
   public Future<Void> close() {
-    List<Future<Void>> futures = new ArrayList<>();
-    for (ServiceConsumer consumer : consumers.values()) {
-      futures.add(consumer.consumer.unregister());
-      futures.add(consumer.service.close());
-    }
-    consumers.clear();
-    futures.add(closeStreams());
-    return Future.all(futures).mapEmpty();
+    PromiseInternal<Void> result = consumerContext.owner().promise();
+    close(result);
+    return result;
   }
 
-  private static class MethodHandler<Req, Resp> implements ServiceMethodInvoker<Req, Resp> {
+  private void close(Promise<Void> result) {
+    if (consumerContext.inThread()) {
+      List<Future<Void>> futures = new ArrayList<>();
+      for (ServiceConsumer consumer : consumers.values()) {
+        futures.add(consumer.consumer.unregister());
+        futures.add(consumer.service.close());
+      }
+      consumers.clear();
+      futures.add(closeStreams());
+      Future.all(futures).<Void>mapEmpty().onComplete(result);
+    } else {
+      consumerContext.runOnContext(v -> {
+        close(result);
+      });
+    }
+  }
+
+  private class MethodHandler<Req, Resp> implements ServiceMethodInvoker<Req, Resp> {
+
+
     final ServiceMethod<Req, Resp> serviceMethod;
     final Handler<GrpcServerRequest<Req, Resp>> handler;
 
@@ -134,7 +155,13 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
 
     @Override
     public void invoke(GrpcServerRequest<Req, Resp> request) {
-      handler.handle(request);
+      assert consumerContext.inThread();
+      ContextInternal prev = consumerContext.beginDispatch();
+      try {
+        handler.handle(request);
+      } finally {
+        consumerContext.endDispatch(prev);
+      }
     }
   }
 
@@ -267,49 +294,47 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
       int window = EventBusGrpcStreamBase.DEFAULT_WINDOW;
       long remoteTimeout = remoteTimeout(message.headers().get(EventBusHeaders.PING_TIMEOUT));
 
-      context().runOnContext(v -> {
-        EventBusGrpcEndpoint.StreamRegistration registration = createStream(streamId);
-        EventBusGrpcServerCall stream = new EventBusGrpcServerCall(
-          context(),
-          !serviceMethod.serverStreaming(),
-          !serviceMethod.clientStreaming(),
-          registration,
-          wireFormat,
-          "identity",
-          window
-        );
+      EventBusGrpcEndpoint.StreamRegistration registration = createStream(streamId);
+      EventBusGrpcServerCall stream = new EventBusGrpcServerCall(
+        consumerContext,
+        !serviceMethod.serverStreaming(),
+        !serviceMethod.clientStreaming(),
+        registration,
+        wireFormat,
+        "identity",
+        window
+      );
 
-        if (stream.registration.id() != 0) {
-          registration.bind(stream, clientAddress, remoteTimeout);
-        }
+      if (stream.registration.id() != 0) {
+        registration.bind(stream, clientAddress, remoteTimeout);
+      }
 
-        ServiceMethodInvoker<Req, Resp> invoker;
-        try {
-          invoker = service.invoker(serviceMethod);
-        } catch (Exception e) {
-          throw new UnsupportedOperationException("Handle me");
-        }
+      ServiceMethodInvoker<Req, Resp> invoker;
+      try {
+        invoker = service.invoker(serviceMethod);
+      } catch (Exception e) {
+        throw new UnsupportedOperationException("Handle me");
+      }
 
-        GrpcMethodCall methodCall = new GrpcMethodCall(serviceMethod.serviceName().pathOf(serviceMethod.methodName()));
+      GrpcMethodCall methodCall = new GrpcMethodCall(serviceMethod.serviceName().pathOf(serviceMethod.methodName()));
 
-        GrpcDispatcher<Req, Resp> dispatcher = new GrpcDispatcher<>(
-          stream,
-          context(),
-          null,
-          wireFormat,
-          serviceMethod.decoder(),
-          serviceMethod.encoder(),
-          methodCall,
-          null,
-          invoker::invoke,
-          false,
-          false);
+      GrpcDispatcher<Req, Resp> dispatcher = new GrpcDispatcher<>(
+        stream,
+        consumerContext,
+        null,
+        wireFormat,
+        serviceMethod.decoder(),
+        serviceMethod.encoder(),
+        methodCall,
+        null,
+        invoker::invoke,
+        false,
+        false);
 
-        stream.handler(dispatcher);
-        stream.exceptionHandler(dispatcher::handleException);
+      stream.handler(dispatcher);
+      stream.exceptionHandler(dispatcher::handleException);
 
-        stream.init(address(), message);
-      });
+      stream.init(address(), message);
     }
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -3,70 +3,67 @@ package io.vertx.grpc.eventbus.impl;
 import com.google.protobuf.ByteString;
 import io.vertx.core.Closeable;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.concurrent.OutboundMessageQueue;
 import io.vertx.grpc.common.GrpcMessage;
+import io.vertx.grpc.common.impl.GrpcOutboundStream;
 import io.vertx.grpc.eventbus.transport.v1alpha.Message;
 import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
-import io.vertx.grpc.eventbus.transport.v1alpha.WindowUpdate;
-
-import java.util.ArrayDeque;
-import java.util.Deque;
 
 abstract class EventBusGrpcStreamBase extends EventBusGrpcCallBase implements Closeable {
 
-  static final int DEFAULT_WINDOW = 64;
-
   protected final boolean localUnary;
   protected final boolean remoteUnary;
-  protected final EventBusGrpcEndpoint.StreamRegistration registration;
 
-  protected final int window;
+  private Handler<Void> drainHandler;
 
-  private final Deque<MessageWrite> outboundQueue = new ArrayDeque<>();
+  private final OutboundMessageQueue<MessageWrite> outboundQueue;
 
-  private int granted;
-  private int sendWindow;
   private long sequence;
 
+  private long outboundInflight;
+
   EventBusGrpcStreamBase(ContextInternal context, boolean localUnary, boolean remoteUnary, EventBusGrpcEndpoint.StreamRegistration registration, int window) {
-    super(context);
+    super(registration, context);
     this.localUnary = localUnary;
     this.remoteUnary = remoteUnary;
-    this.window = window;
-    this.granted = window;
-    this.registration = registration;
+    this.outboundInflight = window;
+    this.outboundQueue = new OutboundMessageQueue<>(context.eventLoop()) {
+      @Override
+      public boolean test(MessageWrite msg) {
+        if (outboundInflight > 0) {
+          outboundInflight--;
+          msg.write();
+          return true;
+        } else {
+          return false;
+        }
+      }
+      @Override
+      protected void handleDrained() {
+        Handler<Void> handler = drainHandler;
+        if (handler != null) {
+          handler.handle(null);
+        }
+      }
+      @Override
+      protected void handleDispose(MessageWrite msg) {
+        Throwable c = cause;
+        if (c != null) {
+          msg.fail(cause);
+        }
+      }
+    };
   }
-
-  protected abstract Future<Void> sendTransportFrame(TransportFrame.Builder frame);
 
   abstract void handle(TransportFrame frame, io.vertx.core.eventbus.Message<Object> message);
 
   abstract void handleRemoteEndpointDown(Throwable cause);
 
-  @Override
-  protected void handleInboundMessage() {
-    granted--;
-    topUpWindow();
-  }
-
-  @Override
-  protected void handleInboundFlowing() {
-    topUpWindow();
-  }
-
-  private void topUpWindow() {
-    if (flowing() && granted <= window / 2) {
-      int delta = window - granted;
-      if (delta > 0) {
-        granted += delta;
-        sendTransportFrame(TransportFrame.newBuilder().setWindowUpdate(WindowUpdate.newBuilder().setDelta(delta)));
-      }
-    }
-  }
-
   protected Future<Void> writeMessage(GrpcMessage message) {
-    Promise<Void> promise = context.promise();
+    Promise<Void> promise = consumerContext.promise();
     enqueue(messageWrite(message, promise));
     return promise.future();
   }
@@ -76,43 +73,36 @@ abstract class EventBusGrpcStreamBase extends EventBusGrpcCallBase implements Cl
   }
 
   private Future<Void> doSendMessage(GrpcMessage message) {
-    sendWindow--;
     return sendTransportFrame(TransportFrame.newBuilder()
       .setStreamSequence(++sequence)
       .setMessage(Message.newBuilder().setPayload(ByteString.copyFrom(message.payload().getBytes()))));
   }
 
   protected void enqueue(MessageWrite write) {
-    outboundQueue.add(write);
-    drainOutbound();
-  }
-
-  private void drainOutbound() {
-    MessageWrite head;
-    while ((head = outboundQueue.peek()) != null && !(head.flowControlled() && sendWindow <= 0)) {
-      outboundQueue.poll().write();
-    }
+    outboundQueue.write(write);
   }
 
   protected void grantSendWindow(int delta) {
-    boolean wasFull = writeQueueFull();
-    sendWindow += delta;
-    drainOutbound();
-    if (wasFull && !writeQueueFull()) {
-      handleDrain();
-    }
+    outboundInflight += delta;
+    outboundQueue.tryDrain();
   }
 
+  private Throwable cause;
+
   protected void failPendingWrites(Throwable cause) {
-    MessageWrite write;
-    while ((write = outboundQueue.poll()) != null) {
-      write.fail(cause);
-    }
+    this.cause = cause;
+    outboundQueue.close();
   }
 
   @Override
   public boolean writeQueueFull() {
-    return sendWindow <= 0 || !outboundQueue.isEmpty();
+    return !outboundQueue.isWritable();
+  }
+
+  @Override
+  public GrpcOutboundStream drainHandler(Handler<Void> handler) {
+    this.drainHandler = handler;
+    return this;
   }
 
   private static final class MessageFrameWrite implements MessageWrite {

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/Utils.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/Utils.java
@@ -1,0 +1,18 @@
+package io.vertx.grpc.eventbus.impl;
+
+import io.vertx.core.ThreadingModel;
+import io.vertx.core.internal.ContextInternal;
+
+class Utils {
+
+  static ContextInternal eventLoopCtx(ContextInternal context) {
+    if (context.threadingModel() == ThreadingModel.EVENT_LOOP) {
+      return context;
+    } else {
+      return context
+        .toBuilder()
+        .withThreadingModel(ThreadingModel.EVENT_LOOP)
+        .build();
+    }
+  }
+}

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcClientTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcClientTest.java
@@ -8,14 +8,11 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.client.InvalidStatusException;
 import io.vertx.grpc.common.GrpcReadStream;
 import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
 import io.vertx.grpc.eventbus.impl.EventBusHeaders;
-import io.vertx.tests.common.GrpcTestBase;
 import io.vertx.tests.common.grpc.Reply;
 import io.vertx.tests.common.grpc.Request;
-import io.vertx.tests.common.grpc.TestConstants;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,16 +22,7 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class EventBusGrpcClientTest extends GrpcTestBase {
-
-  private static final ServiceMethod<Reply, Request> UNARY = ServiceMethod.client(
-    TestConstants.TEST_SERVICE,
-    "Unary",
-    false,
-    false,
-    TestConstants.REQUEST_ENC,
-    TestConstants.REPLY_DEC
-  );
+public class EventBusGrpcClientTest extends EventBusGrpcTestBase {
 
   private EventBusGrpcClient client;
 
@@ -46,7 +34,7 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
 
   @Test
   public void testRequestReplyProtobuf(TestContext testContext) throws Exception {
-    vertx.eventBus().<Buffer> consumer(UNARY.serviceName().fullyQualifiedName(), msg -> {
+    vertx.eventBus().<Buffer> consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> {
       testContext.assertEquals("Unary", msg.headers().get("action"));
       testContext.assertEquals(WireFormat.PROTOBUF.name(), msg.headers().get("grpc-wire-format"));
       try {
@@ -58,7 +46,7 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
       }
     });
 
-    Reply reply = client.request(UNARY)
+    Reply reply = client.request(UNARY_CLIENT)
       .compose(request -> {
         request.end(Request.newBuilder().setName("Julien").build());
         return request.response();
@@ -71,14 +59,14 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
 
   @Test
   public void testRequestReplyJson(TestContext testContext) throws TimeoutException {
-    vertx.eventBus().<JsonObject> consumer(UNARY.serviceName().fullyQualifiedName(), msg -> {
+    vertx.eventBus().<JsonObject> consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> {
       testContext.assertEquals("Unary", msg.headers().get("action"));
       testContext.assertEquals(WireFormat.JSON.name(), msg.headers().get("grpc-wire-format"));
       String name = msg.body().getString("name");
       msg.reply(new JsonObject().put("message", "Hello " + name));
     });
 
-    Reply reply = client.request(UNARY)
+    Reply reply = client.request(UNARY_CLIENT)
       .compose(request -> {
         request.format(WireFormat.JSON);
         request.end(Request.newBuilder().setName("Julien").build());
@@ -92,7 +80,7 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
 
   @Test
   public void testRequestReplyWithDelay() throws Exception {
-    vertx.eventBus().<Buffer> consumer(UNARY.serviceName().fullyQualifiedName(), msg -> vertx.setTimer(50, id -> {
+    vertx.eventBus().<Buffer> consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> vertx.setTimer(50, id -> {
       try {
         Request request = Request.parseFrom(msg.body().getBytes());
         Reply reply = Reply.newBuilder().setMessage("Delayed " + request.getName()).build();
@@ -102,7 +90,7 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
       }
     }));
 
-    Reply reply = client.request(UNARY)
+    Reply reply = client.request(UNARY_CLIENT)
       .compose(request -> {
         request.end(Request.newBuilder().setName("Julien").build());
         return request.response();
@@ -116,7 +104,7 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
   @Test
   public void testNoHandler() throws TimeoutException {
     try {
-      client.request(UNARY)
+      client.request(UNARY_CLIENT)
         .compose(request -> {
           request.end(Request.newBuilder().setName("Julien").build());
           return request.response();
@@ -131,10 +119,10 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
 
   @Test
   public void testConsumerFailureUnmappedCode() throws TimeoutException {
-    vertx.eventBus().<Buffer> consumer(UNARY.serviceName().fullyQualifiedName(), msg -> msg.fail(500, "Service error"));
+    vertx.eventBus().<Buffer> consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> msg.fail(500, "Service error"));
 
     try {
-      client.request(UNARY)
+      client.request(UNARY_CLIENT)
         .compose(request -> {
           request.end(Request.newBuilder().setName("Julien").build());
           return request.response();
@@ -154,12 +142,12 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
         continue;
       }
 
-      MessageConsumer<Buffer> consumer = vertx.eventBus().consumer(UNARY.serviceName().fullyQualifiedName(), msg -> msg.fail(status.code, status.name()));
+      MessageConsumer<Buffer> consumer = vertx.eventBus().consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> msg.fail(status.code, status.name()));
 
       consumer.completion().await(10, TimeUnit.SECONDS);
 
       try {
-        client.request(UNARY)
+        client.request(UNARY_CLIENT)
           .compose(request -> {
             request.end(Request.newBuilder().setName("Julien").build());
             return request.response();
@@ -177,7 +165,7 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
 
   @Test
   public void testRequestHeaders(TestContext testContext) throws Exception {
-    vertx.eventBus().<Buffer> consumer(UNARY.serviceName().fullyQualifiedName(), msg -> {
+    vertx.eventBus().<Buffer> consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> {
       String customHeader = msg.headers().get(EventBusHeaders.HEADER_PREFIX + "x-custom");
       Reply reply = Reply.newBuilder().setMessage("Header: " + customHeader).build();
       msg.reply(Buffer.buffer(reply.toByteArray()), new DeliveryOptions()
@@ -186,7 +174,7 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
       );
     });
 
-    Reply reply = client.request(UNARY)
+    Reply reply = client.request(UNARY_CLIENT)
       .compose(request -> {
         request.headers().add("x-custom", "request_header_value");
         request.end(Request.newBuilder().setName("Julien").build());
@@ -208,12 +196,12 @@ public class EventBusGrpcClientTest extends GrpcTestBase {
 
   @Test
   public void testDeadlineExceeded() throws TimeoutException {
-    vertx.eventBus().<Buffer> consumer(UNARY.serviceName().fullyQualifiedName(), msg -> {
+    vertx.eventBus().<Buffer> consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> {
       // do nothing
     });
 
     try {
-      client.request(UNARY)
+      client.request(UNARY_CLIENT)
         .compose(request -> {
           request.timeout(1, TimeUnit.SECONDS);
           request.end(Request.newBuilder().setName("Julien").build());

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcContestTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcContestTest.java
@@ -1,0 +1,106 @@
+package io.vertx.tests.eventbus;
+
+import io.vertx.core.*;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.client.GrpcClientRequest;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.eventbus.EventBusGrpcClient;
+import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.tests.common.grpc.Reply;
+import io.vertx.tests.common.grpc.Request;
+import org.junit.Test;
+
+public class EventBusGrpcContestTest extends EventBusGrpcTestBase {
+
+  Context serverContext;
+  Context clientContext;
+  EventBusGrpcServer server;
+  EventBusGrpcClient client;
+
+  @Test
+  public void testEventLoopUnary(TestContext should) {
+    test(should, ThreadingModel.EVENT_LOOP, UNARY_SERVER, UNARY_CLIENT);
+  }
+
+  @Test
+  public void testEventLoopBidi(TestContext should) {
+    test(should, ThreadingModel.EVENT_LOOP, PIPE_SERVER, PIPE_CLIENT);
+  }
+
+  @Test
+  public void testWorkerUnary(TestContext should) {
+    test(should, ThreadingModel.WORKER, UNARY_SERVER, UNARY_CLIENT);
+  }
+
+  @Test
+  public void testWorkerBidi(TestContext should) {
+    test(should, ThreadingModel.WORKER, PIPE_SERVER, PIPE_CLIENT);
+  }
+
+  public void test(TestContext should,
+                   ThreadingModel threadingModel,
+                   ServiceMethod<Request, Reply> serverMethod,
+                   ServiceMethod<Reply, Request> clientMethod) {
+
+    clientContext = ((VertxInternal)vertx).createContext(threadingModel);
+    serverContext = ((VertxInternal)vertx).createContext(threadingModel);
+    Async async1 = should.async(2);
+    clientContext.runOnContext(v -> {
+      EventBusGrpcClient.client(vertx).onComplete(should.asyncAssertSuccess(c -> {
+        client = c;
+        async1.countDown();
+      }));
+    });
+    serverContext.runOnContext(v -> {
+      EventBusGrpcServer.server(vertx).onComplete(should.asyncAssertSuccess(s -> {
+        server = s;
+        async1.countDown();
+      }));
+    });
+
+    async1.awaitSuccess(20_000);
+
+    Async async2 = should.async(2);
+
+    server.callHandler(serverMethod, new Handler<>() {
+      private Request message;
+      @Override
+      public void handle(GrpcServerRequest<Request, Reply> request) {
+        should.assertEquals(serverContext, Vertx.currentContext());
+        request.handler(msg -> {
+          should.assertEquals(serverContext, Vertx.currentContext());
+          message = msg;
+        });
+        request.endHandler(v -> {
+          should.assertEquals(serverContext, Vertx.currentContext());
+          request.response().end(Reply.newBuilder().setMessage("Hello " + message.getName()).build());
+        });
+      }
+    });
+
+    Context ctx = vertx.getOrCreateContext();
+    ctx.runOnContext(v -> {
+      Future<GrpcClientRequest<Request, Reply>> fut = client.request(clientMethod);
+      fut.onComplete(should.asyncAssertSuccess(request -> {
+        should.assertEquals(ctx, Vertx.currentContext());
+        request.response().onComplete(should.asyncAssertSuccess(response -> {
+          should.assertEquals(ctx, Vertx.currentContext());
+          response.handler(msg -> {
+            should.assertEquals(ctx, Vertx.currentContext());
+            async2.countDown();
+          });
+          response.endHandler(v2 -> {
+            should.assertEquals(ctx, Vertx.currentContext());
+            async2.countDown();
+          });
+        }));
+        request.end(Request.newBuilder().setName("Julien").build());
+      }));
+    });
+
+    async2.awaitSuccess();
+  }
+}

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcServerTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcServerTest.java
@@ -14,7 +14,6 @@ import io.vertx.grpc.eventbus.EventBusGrpcServer;
 import io.vertx.grpc.eventbus.impl.EventBusHeaders;
 import io.vertx.grpc.server.GrpcServerResponse;
 import io.vertx.grpc.server.StatusException;
-import io.vertx.tests.common.GrpcTestBase;
 import io.vertx.tests.common.grpc.Reply;
 import io.vertx.tests.common.grpc.Request;
 import io.vertx.tests.common.grpc.TestConstants;
@@ -27,16 +26,7 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class EventBusGrpcServerTest extends GrpcTestBase {
-
-  private static final ServiceMethod<Request, Reply> UNARY = ServiceMethod.server(
-    TestConstants.TEST_SERVICE,
-    "Unary",
-    false,
-    false,
-    TestConstants.REPLY_ENC,
-    TestConstants.REQUEST_DEC
-  );
+public class EventBusGrpcServerTest extends EventBusGrpcTestBase {
 
   private static final String ADDRESS = TestConstants.TEST_SERVICE.fullyQualifiedName();
 
@@ -50,7 +40,7 @@ public class EventBusGrpcServerTest extends GrpcTestBase {
 
   @Test
   public void testRequestReplyProtobuf() throws Exception {
-    server.callHandler(UNARY, request -> request.handler(msg -> {
+    server.callHandler(UNARY_SERVER, request -> request.handler(msg -> {
       Reply reply = Reply.newBuilder().setMessage("Hello " + msg.getName()).build();
       request.response().end(reply);
     }));
@@ -68,7 +58,7 @@ public class EventBusGrpcServerTest extends GrpcTestBase {
 
   @Test
   public void testRequestReplyJson() throws Exception {
-    server.callHandler(UNARY, request -> request.handler(msg -> {
+    server.callHandler(UNARY_SERVER, request -> request.handler(msg -> {
       Reply reply = Reply.newBuilder().setMessage("Hello " + msg.getName()).build();
       request.response().end(reply);
     }));
@@ -85,7 +75,7 @@ public class EventBusGrpcServerTest extends GrpcTestBase {
 
   @Test
   public void testHandlerFailure() throws TimeoutException {
-    server.callHandler(UNARY, request -> request.handler(msg -> request.response().fail(new StatusException(GrpcStatus.PERMISSION_DENIED, "Not allowed"))));
+    server.callHandler(UNARY_SERVER, request -> request.handler(msg -> request.response().fail(new StatusException(GrpcStatus.PERMISSION_DENIED, "Not allowed"))));
 
     Buffer payload = Buffer.buffer(Request.newBuilder().setName("Julien").build().toByteArray());
     DeliveryOptions opts = new DeliveryOptions()
@@ -103,7 +93,7 @@ public class EventBusGrpcServerTest extends GrpcTestBase {
 
   @Test
   public void testHandlerThrows() throws TimeoutException {
-    server.callHandler(UNARY, request -> request.handler(msg -> {
+    server.callHandler(UNARY_SERVER, request -> request.handler(msg -> {
       throw new RuntimeException("Unexpected error");
     }));
 
@@ -142,7 +132,7 @@ public class EventBusGrpcServerTest extends GrpcTestBase {
 
   @Test
   public void testServerClose() throws Exception {
-    server.callHandler(UNARY, request -> request.handler(msg -> {
+    server.callHandler(UNARY_SERVER, request -> request.handler(msg -> {
       Reply reply = Reply.newBuilder().setMessage("Hello " + msg.getName()).build();
       request.response().end(reply);
     }));
@@ -168,7 +158,7 @@ public class EventBusGrpcServerTest extends GrpcTestBase {
 
   @Test
   public void testHeaders() throws Exception {
-    server.callHandler(UNARY, request -> request.handler(msg -> {
+    server.callHandler(UNARY_SERVER, request -> request.handler(msg -> {
       String customHeader = request.headers().get("x-custom");
       Reply reply = Reply.newBuilder().setMessage("Header: " + customHeader).build();
       GrpcServerResponse<Request, Reply> response = request.response();

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcStreamingTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcStreamingTest.java
@@ -18,7 +18,6 @@ import io.vertx.grpc.eventbus.EventBusGrpcServer;
 import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
 import io.vertx.grpc.eventbus.impl.EventBusHeaders;
 import io.vertx.grpc.server.GrpcServerResponse;
-import io.vertx.tests.common.GrpcTestBase;
 import io.vertx.tests.common.grpc.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,24 +39,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class EventBusGrpcStreamingTest extends GrpcTestBase {
-
-  private static final ServiceMethod<Empty, Reply> SOURCE_SERVER =
-    ServiceMethod.server(TestConstants.TEST_SERVICE, "Source", false, true, TestConstants.REPLY_ENC, TestConstants.EMPTY_DEC);
-  private static final ServiceMethod<Request, Empty> SINK_SERVER =
-    ServiceMethod.server(TestConstants.TEST_SERVICE, "Sink", true, false, TestConstants.EMPTY_ENC, TestConstants.REQUEST_DEC);
-  private static final ServiceMethod<Request, Reply> PIPE_SERVER =
-    ServiceMethod.server(TestConstants.TEST_SERVICE, "Pipe", true, true, TestConstants.REPLY_ENC, TestConstants.REQUEST_DEC);
-
-  private static final ServiceMethod<Reply, Empty> SOURCE_CLIENT =
-    ServiceMethod.client(TestConstants.TEST_SERVICE, "Source", false, true, TestConstants.EMPTY_ENC, TestConstants.REPLY_DEC);
-  private static final ServiceMethod<Empty, Request> SINK_CLIENT =
-    ServiceMethod.client(TestConstants.TEST_SERVICE, "Sink", true, false, TestConstants.REQUEST_ENC, TestConstants.EMPTY_DEC);
-  private static final ServiceMethod<Reply, Request> PIPE_CLIENT =
-    ServiceMethod.client(TestConstants.TEST_SERVICE, "Pipe", true, true, TestConstants.REQUEST_ENC, TestConstants.REPLY_DEC);
-
-  private static final ServiceMethod<Reply, Empty> UNKNOWN_CLIENT =
-    ServiceMethod.client(TestConstants.TEST_SERVICE, "Unknown", false, true, TestConstants.EMPTY_ENC, TestConstants.REPLY_DEC);
+public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
 
   private EventBusGrpcServer server;
   private EventBusGrpcClient client;
@@ -303,31 +285,39 @@ public class EventBusGrpcStreamingTest extends GrpcTestBase {
   @Test
   public void testQueuedWriteCompletesOnDrain() throws Exception {
     AtomicBoolean stalled = new AtomicBoolean();
+    AtomicInteger written = new AtomicInteger();
+    AtomicInteger drains = new AtomicInteger();
     Promise<Void> queued = Promise.promise();
 
     server.callHandler(SOURCE_SERVER, request -> request.handler(empty -> {
       GrpcServerResponse<Empty, Reply> response = request.response();
-      int i = 0;
+      int cnt = 0;
       while (!response.writeQueueFull()) {
-        response.write(Reply.newBuilder().setMessage("m-" + i++).build());
+        response.write(Reply.newBuilder().setMessage("m-" + cnt++).build());
       }
+      response.drainHandler(v -> drains.incrementAndGet());
       Future<Void> write = response.write(Reply.newBuilder().setMessage("queued").build());
       stalled.set(!write.isComplete());
+      written.set(1 + cnt);
       write.onComplete(queued);
       response.end();
     }));
 
+
     List<Reply> replies = client.request(SOURCE_CLIENT)
       .compose(request -> {
+        Future<List<Reply>> res = request.response().compose(EventBusGrpcStreamingTest::collect);
         request.end(Empty.getDefaultInstance());
-        return request.response();
+        return res;
       })
-      .compose(EventBusGrpcStreamingTest::collect)
       .await(20, TimeUnit.SECONDS);
 
+    assertTrue("Expected to have more than one message: " + written.get(), written.get() > 1);
+    assertEquals(written.get(), replies.size());
     assertTrue("the write must not complete while the message sits behind a closed window", stalled.get());
     queued.future().await(20, TimeUnit.SECONDS);
     assertEquals("queued", replies.get(replies.size() - 1).getMessage());
+    assertEquals(1, drains.get());
   }
 
   @Test

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcTestBase.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcTestBase.java
@@ -1,0 +1,47 @@
+package io.vertx.tests.eventbus;
+
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.tests.common.GrpcTestBase;
+import io.vertx.tests.common.grpc.Empty;
+import io.vertx.tests.common.grpc.Reply;
+import io.vertx.tests.common.grpc.Request;
+import io.vertx.tests.common.grpc.TestConstants;
+
+public abstract class EventBusGrpcTestBase extends GrpcTestBase {
+
+  static final ServiceMethod<Reply, Request> UNARY_CLIENT = ServiceMethod.client(
+    TestConstants.TEST_SERVICE,
+    "Unary",
+    false,
+    false,
+    TestConstants.REQUEST_ENC,
+    TestConstants.REPLY_DEC
+  );
+
+  static final ServiceMethod<Request, Reply> UNARY_SERVER = ServiceMethod.server(
+    TestConstants.TEST_SERVICE,
+    "Unary",
+    false,
+    false,
+    TestConstants.REPLY_ENC,
+    TestConstants.REQUEST_DEC
+  );
+
+  static final ServiceMethod<Empty, Reply> SOURCE_SERVER =
+    ServiceMethod.server(TestConstants.TEST_SERVICE, "Source", false, true, TestConstants.REPLY_ENC, TestConstants.EMPTY_DEC);
+  static final ServiceMethod<Request, Empty> SINK_SERVER =
+    ServiceMethod.server(TestConstants.TEST_SERVICE, "Sink", true, false, TestConstants.EMPTY_ENC, TestConstants.REQUEST_DEC);
+  static final ServiceMethod<Request, Reply> PIPE_SERVER =
+    ServiceMethod.server(TestConstants.TEST_SERVICE, "Pipe", true, true, TestConstants.REPLY_ENC, TestConstants.REQUEST_DEC);
+
+  static final ServiceMethod<Reply, Empty> SOURCE_CLIENT =
+    ServiceMethod.client(TestConstants.TEST_SERVICE, "Source", false, true, TestConstants.EMPTY_ENC, TestConstants.REPLY_DEC);
+  static final ServiceMethod<Empty, Request> SINK_CLIENT =
+    ServiceMethod.client(TestConstants.TEST_SERVICE, "Sink", true, false, TestConstants.REQUEST_ENC, TestConstants.EMPTY_DEC);
+  static final ServiceMethod<Reply, Request> PIPE_CLIENT =
+    ServiceMethod.client(TestConstants.TEST_SERVICE, "Pipe", true, true, TestConstants.REQUEST_ENC, TestConstants.REPLY_DEC);
+
+  static final ServiceMethod<Reply, Empty> UNKNOWN_CLIENT =
+    ServiceMethod.client(TestConstants.TEST_SERVICE, "Unknown", false, true, TestConstants.EMPTY_ENC, TestConstants.REPLY_DEC);
+
+}


### PR DESCRIPTION
Motivation:

Event-bus flow control currently relies on a custom implementation for flow control.

Vert.x has existing inbound/outbound message queues that handle this and can be reused.

Changes:

Reuse inbound/outbound message queues.

Explicitely distinguish producer event-loop context (coming from event-bus invocation) and consumer context (interacting with the application).
