### PR TITLE
Promote GrpcServerResponse#writeHead to GrpcWriteStream interface

### DIFF
--- a/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/tests/client/ClientRequestTest.java
@@ -15,6 +15,7 @@ import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.json.JsonObject;
@@ -41,6 +42,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertFalse;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -890,5 +893,43 @@ public class ClientRequestTest extends ClientTest {
         .send(Empty.getDefaultInstance())
         .map(GrpcClientResponse::status));
     Assert.assertEquals(GrpcStatus.UNAUTHENTICATED, status.await());
+  }
+
+  @Test
+  public void testEarlyHeaders() throws Exception {
+
+    Promise<Void> requestReceived = Promise.promise();
+    TestServiceGrpc.TestServiceImplBase called = new TestServiceGrpc.TestServiceImplBase() {
+      @Override
+      public void unary(Request request, StreamObserver<Reply> plainResponseObserver) {
+        requestReceived.succeed();
+        plainResponseObserver.onNext(Reply.newBuilder().setMessage("Hello " + request.getName()).build());
+        plainResponseObserver.onCompleted();
+      }
+    };
+
+    Promise<String> headersReceived = Promise.promise();
+    startServer(called, ServerBuilder.forPort(port).intercept(new ServerInterceptor() {
+      @Override
+      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        String header = headers.get(Metadata.Key.of("custom_request_header", Metadata.ASCII_STRING_MARSHALLER));
+        headersReceived.succeed(header);
+        return next.startCall(call, headers);
+      }
+    }));
+
+    client = GrpcClient.client(vertx);
+    GrpcClientRequest<Request, Reply> request = client.request(SocketAddress.inetSocketAddress(port, "localhost"), UNARY).await();
+    request.format(WireFormat.PROTOBUF);
+    String expectedCustomRequestHeaderValue = "custom_request_header_value";
+    request.headers().add("custom_request_header", expectedCustomRequestHeaderValue);
+    request.writeHead().await();
+
+    String customRequestHeaderValue = headersReceived.future().await();
+    Assert.assertEquals(expectedCustomRequestHeaderValue, customRequestHeaderValue);
+    assertFalse(requestReceived.future().isComplete());
+
+    request.end(Request.newBuilder().setName("Julien").build()).await();
+    requestReceived.future().await();
   }
 }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
@@ -51,6 +51,13 @@ public interface GrpcWriteStream<T> extends WriteStream<T> {
   GrpcWriteStream<T> drainHandler(@Nullable Handler<Void> handler);
 
   /**
+   * Send the headers.
+   *
+   * @return a future notified by the success or failure of the write operation
+   */
+  Future<Void> writeHead();
+
+  /**
    * Write an encoded gRPC message.
    *
    * @param message the message

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcServerResponse.java
@@ -71,13 +71,6 @@ public interface GrpcServerResponse<Req, Resp> extends GrpcWriteStream<Resp> {
   @Override
   GrpcServerResponse<Req, Resp> drainHandler(@Nullable Handler<Void> handler);
 
-  /**
-   * Send the response headers.
-   *
-   * @return a future notified by the success or failure of the write
-   */
-  Future<Void> writeHead();
-
   default Future<Void> send(Resp item) {
     return end(item);
   }


### PR DESCRIPTION
Motivation:

`GrpcServerResponse#writeHead` method does not actually depend on the nature of the server response, it can equally be on a client request.

It can be useful for writing tests, e.g. trigger gRPC interaction without sending a message, useful for testing flow control.

Changes:

Move `GrpcServerResponse#writeHead` to `GrpcWriteStream` interface, add a test for it.
