### PR TITLE
Configurable event-bus flow control.

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
@@ -54,7 +54,6 @@ public class GrpcClientRequestImpl<Req, Resp> extends GrpcWriteStreamBase<GrpcCl
   private Timer deadline;
   private GrpcClientResponseImpl<Req, Resp> response;
   private Handler<Void> drainHandler;
-  private boolean ended;
   private boolean headWritten;
 
   public GrpcClientRequestImpl(ContextInternal context,
@@ -163,6 +162,7 @@ public class GrpcClientRequestImpl<Req, Resp> extends GrpcWriteStreamBase<GrpcCl
 
     ServiceName serviceName = this.serviceName;
     String methodName = this.methodName;
+    Handler<Void> drainHandler = this.drainHandler;
     if (serviceName == null) {
       throw new IllegalStateException();
     }
@@ -187,11 +187,19 @@ public class GrpcClientRequestImpl<Req, Resp> extends GrpcWriteStreamBase<GrpcCl
 
     GrpcHeadersFrame frame = new DefaultGrpcHeadersFrame(format, encoding, headers, to);
 
+    Future<Void> result;
     if (end) {
-      return stream.end(frame);
+      result = stream.end(frame);
     } else {
-      return stream.write(frame);
+      result = stream.write(frame);
     }
+
+    // If we have been observed full while waiting for the stream, we should signal it
+    if (drainHandler != null) {
+      context.dispatch(null, drainHandler);
+    }
+
+    return result;
   }
 
   @Override

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcClientOptions.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcClientOptions.java
@@ -28,9 +28,15 @@ public class EventBusGrpcClientOptions {
    */
   public static final Duration DEFAULT_PING_TIMEOUT = Duration.ofSeconds(60);
 
+  /**
+   * The default initial window size for inbound messages = {@code 64}
+   */
+  public static final int DEFAULT_INITIAL_WINDOW_SIZE = 64;
+
   private WireFormat wireFormat;
   private Duration pingInterval;
   private Duration pingTimeout;
+  private int initialWindowSize;
 
   /**
    * Default options.
@@ -39,6 +45,7 @@ public class EventBusGrpcClientOptions {
     wireFormat = DEFAULT_WIRE_FORMAT;
     pingInterval = DEFAULT_PING_INTERVAL;
     pingTimeout = DEFAULT_PING_TIMEOUT;
+    initialWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
   }
 
   /**
@@ -48,6 +55,7 @@ public class EventBusGrpcClientOptions {
     wireFormat = other.wireFormat;
     pingInterval = other.pingInterval;
     pingTimeout = other.pingTimeout;
+    initialWindowSize = other.initialWindowSize;
   }
 
   /**
@@ -114,6 +122,27 @@ public class EventBusGrpcClientOptions {
       throw new IllegalArgumentException("pingTimeout must be positive");
     }
     this.pingTimeout = pingTimeout;
+    return this;
+  }
+
+  /**
+   * @return the initial window size
+   */
+  public int getInitialWindowSize() {
+    return initialWindowSize;
+  }
+
+  /**
+   * Set the initial window size.
+   *
+   * @param initialWindowSize the new value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EventBusGrpcClientOptions setInitialWindowSize(int initialWindowSize) {
+    if (initialWindowSize < 1) {
+      throw new IllegalArgumentException("initialWindowSize must be > 0");
+    }
+    this.initialWindowSize = initialWindowSize;
     return this;
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcServerOptions.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcServerOptions.java
@@ -27,8 +27,14 @@ public class EventBusGrpcServerOptions {
    */
   public static final Duration DEFAULT_MAX_PING_TIMEOUT = Duration.ofMinutes(2);
 
+  /**
+   * The default initial window size for inbound messages = {@code 64}
+   */
+  public static final int DEFAULT_INITIAL_WINDOW_SIZE = 64;
+
   private Set<WireFormat> supportedWireFormats;
   private Duration maxPingTimeout;
+  private int initialWindowSize;
 
   /**
    * Default options.
@@ -36,6 +42,7 @@ public class EventBusGrpcServerOptions {
   public EventBusGrpcServerOptions() {
     supportedWireFormats = new LinkedHashSet<>(DEFAULT_SUPPORTED_WIRE_FORMATS);
     maxPingTimeout = DEFAULT_MAX_PING_TIMEOUT;
+    initialWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
   }
 
   /**
@@ -44,6 +51,7 @@ public class EventBusGrpcServerOptions {
   public EventBusGrpcServerOptions(EventBusGrpcServerOptions other) {
     supportedWireFormats = new LinkedHashSet<>(other.supportedWireFormats);
     maxPingTimeout = other.maxPingTimeout;
+    initialWindowSize = other.initialWindowSize;
   }
 
   /**
@@ -98,6 +106,27 @@ public class EventBusGrpcServerOptions {
       throw new IllegalArgumentException("maxPingTimeout must be positive");
     }
     this.maxPingTimeout = maxPingTimeout;
+    return this;
+  }
+
+  /**
+   * @return the initial window size
+   */
+  public int getInitialWindowSize() {
+    return initialWindowSize;
+  }
+
+  /**
+   * Set the initial window size.
+   *
+   * @param initialWindowSize the new value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EventBusGrpcServerOptions setInitialWindowSize(int initialWindowSize) {
+    if (initialWindowSize < 1) {
+      throw new IllegalArgumentException("initialWindowSize must be > 0");
+    }
+    this.initialWindowSize = initialWindowSize;
     return this;
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
@@ -14,11 +14,10 @@ import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.common.impl.*;
+import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
 import io.vertx.grpc.eventbus.transport.v1alpha.*;
 
 import java.time.Duration;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 
@@ -30,7 +29,6 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
   private final EventBusGrpcEndpoint endpoint;
   private final ServiceName serviceName;
   private final String methodName;
-  private final Deque<MessageWrite> pending;
 
   private WireFormat wireFormat;
   private String encoding;
@@ -43,12 +41,13 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
   private final Outbound outbound;
   private final Inbound inbound;
 
-  public EventBusGrpcClientCall(ContextInternal context, boolean localUnary, boolean remoteUnary, EventBusGrpcEndpoint.StreamRegistration registration, EventBusGrpcEndpoint endpoint, ServiceName serviceName, String methodName) {
-    super(context, localUnary, remoteUnary, registration, DEFAULT_WINDOW);
+  public EventBusGrpcClientCall(ContextInternal context, boolean localUnary, boolean remoteUnary,
+                                EventBusGrpcEndpoint.StreamRegistration registration, EventBusGrpcEndpoint endpoint,
+                                ServiceName serviceName, String methodName, int initialInboundWindowSize, int initialOutboundWindowSize) {
+    super(context, localUnary, remoteUnary, registration, initialInboundWindowSize, initialOutboundWindowSize);
     this.endpoint = endpoint;
     this.serviceName = serviceName;
     this.methodName = methodName;
-    this.pending = new ArrayDeque<>();
     this.state = State.IDLE;
     this.outbound = localUnary ? new UnaryOutbound() : new StreamingOutbound();
     this.encoding = "identity";
@@ -106,6 +105,10 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
         .addHeader(EventBusHeaders.CLIENT_ADDRESS, endpoint.address())
         .addHeader(EventBusHeaders.STREAM_ID, Long.toString(registration.id()));
 
+      if (!remoteUnary) {
+        options.addHeader(EventBusHeaders.INITIAL_WINDOW, "" + endpoint.initialWindowSize);
+      }
+
       if (timeout != null) {
         options.setSendTimeout(timeout.toMillis());
       }
@@ -121,7 +124,7 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
 
       endpoint.request(consumerContext, serviceName.fullyQualifiedName(), body, options).onComplete(ar -> {
         if (ar.succeeded()) {
-          Throwable malformed = inbound.handleReply(ar.result(), encoding, wireFormat);
+          Throwable malformed = inbound._handleReply(ar.result(), encoding, wireFormat);
           if (malformed == null) {
             // Something specific to do ?
           } else {
@@ -177,6 +180,10 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
         .addHeader(EventBusHeaders.CLIENT_ADDRESS, endpoint.address())
         .addHeader(EventBusHeaders.STREAM_ID, Long.toString(registration.id()));
 
+      if (!remoteUnary) {
+        options.addHeader(EventBusHeaders.INITIAL_WINDOW, "" + endpoint.initialWindowSize);
+      }
+
       if (endpoint.pingTimeout() > 0) {
         options.addHeader(EventBusHeaders.PING_TIMEOUT, Long.toString(endpoint.pingTimeout()));
       }
@@ -197,13 +204,9 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
           return;
         }
 
-        Throwable malformed = inbound.handleReply(ar.result(), encoding, wireFormat);
+        Throwable malformed = inbound._handleReply(ar.result(), encoding, wireFormat);
         if (malformed == null) {
 
-          MessageWrite write;
-          while ((write = pending.poll()) != null) {
-            enqueue(write);
-          }
           if (ended) {
             sendHalfClose();
           }
@@ -222,61 +225,98 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
 
     private final class HalfCloseWrite implements MessageWrite {
       @Override
-      public void write() {
-        sendTransportFrame(TransportFrame.newBuilder().setHalfClose(HalfClose.newBuilder()));
+      public boolean write() {
+        return sendTransportFrame(TransportFrame.newBuilder().setHalfClose(HalfClose.newBuilder())) != null;
       }
     }
   }
 
-  private interface Inbound {
-    Throwable handleReply(Message<Object> reply, String encoding, WireFormat wireFormat);
-  }
+  private abstract class Inbound {
+    Throwable _handleReply(Message<Object> reply, String encoding, WireFormat wireFormat) {
 
-  class StreamingInbound implements Inbound {
-
-    @Override
-    public Throwable handleReply(Message<Object> reply, String encoding, WireFormat wireFormat) {
-      MultiMap replyHeaders = reply.headers();
-      String serverAddress = replyHeaders.get(EventBusHeaders.SERVER_ADDRESS);
-      String initialWindowHeader = replyHeaders.get(EventBusHeaders.INITIAL_WINDOW);
-
-      if (serverAddress == null || initialWindowHeader == null) {
-        return new IllegalStateException("Malformed stream handshake reply: missing handshake headers");
+      String serverAddress;
+      if (!localUnary || !remoteUnary) {
+        MultiMap replyHeaders = reply.headers();
+        serverAddress = replyHeaders.get(EventBusHeaders.SERVER_ADDRESS);
+        if (serverAddress == null) {
+          return new IllegalStateException("Malformed handshake reply: missing grpc-server-address header");
+        }
+      } else {
+        serverAddress = null;
       }
 
-      int initialWindow;
-
-      try {
-        initialWindow = Integer.parseInt(initialWindowHeader);
-      } catch (NumberFormatException e) {
-        return new IllegalStateException("Malformed stream handshake reply: non-numeric handshake headers");
+      if (serverAddress != null) {
+        // This could be racy since we are on the request/reply context ...
+        registration.bind(EventBusGrpcClientCall.this, serverAddress, endpoint.pingTimeout());
       }
 
-      EventBusGrpcClientCall.this.encoding = encoding;
-      EventBusGrpcClientCall.this.wireFormat = wireFormat;
-      EventBusGrpcClientCall.this.state = State.STREAMING;
+      Throwable err = handleReply(reply, encoding, wireFormat);
 
-      // This could be racy since we are on the request/reply context ...
-      registration.bind(EventBusGrpcClientCall.this, serverAddress, endpoint.pingTimeout());
+      if (err != null && serverAddress != null) {
+        registration.unbind();
+      }
 
+      return err;
+    }
+    Throwable handleReply(Message<Object> reply, String encoding, WireFormat wireFormat) {
+
+      int initialOutboundWindowSize;
+      if (remoteUnary) {
+        initialOutboundWindowSize = EventBusGrpcServerOptions.DEFAULT_INITIAL_WINDOW_SIZE;
+      } else {
+        String initialWindowHeader = reply.headers().get(EventBusHeaders.INITIAL_WINDOW);
+        if (initialWindowHeader == null) {
+          return new IllegalStateException("Malformed handshake reply: missing grpc-initial-window header");
+        }
+        try {
+          initialOutboundWindowSize = Integer.parseInt(initialWindowHeader);
+        } catch (NumberFormatException e) {
+          return new IllegalStateException("Malformed handshake reply: non-numeric grpc-initial-window header");
+        }
+        if (initialOutboundWindowSize <= 0) {
+          return new IllegalStateException("Malformed handshake reply: invalid grpc-initial-window header");
+        }
+      }
+      updateOutboundWindow(initialOutboundWindowSize - EventBusGrpcServerOptions.DEFAULT_INITIAL_WINDOW_SIZE);
       return null;
     }
   }
 
-  class UnaryInbound implements Inbound {
+  class StreamingInbound extends Inbound {
 
     @Override
-    public Throwable handleReply(Message<Object> reply, String encoding, WireFormat wireFormat) {
-      MultiMap headers = MultiMap.caseInsensitiveMultiMap();
-      MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
-      EventBusHeaders.decodeMultimap(HEADER_PREFIX, reply.headers(), headers);
-      EventBusHeaders.decodeMultimap(TRAILER_PREFIX, reply.headers(), trailers);
-      Buffer payload = EventBusGrpcCodec.decodeBody(reply.body());
-      dispatchFrameInbound(new DefaultGrpcHeadersFrame(wireFormat, encoding, headers));
-      dispatchFrameInbound(new DefaultGrpcMessageFrame(GrpcMessage.message(encoding, wireFormat, payload)));
-      dispatchFrameInbound(new DefaultGrpcTrailersFrame(GrpcStatus.OK, null, trailers));
-      dispatchEndInbound();
-      return null;
+    Throwable handleReply(Message<Object> reply, String encoding, WireFormat wireFormat) {
+
+      Throwable err = super.handleReply(reply, encoding, wireFormat);
+      if (err == null) {
+        EventBusGrpcClientCall.this.encoding = encoding;
+        EventBusGrpcClientCall.this.wireFormat = wireFormat;
+        EventBusGrpcClientCall.this.state = State.STREAMING;
+      }
+
+      return err;
+    }
+  }
+
+  class UnaryInbound extends Inbound {
+
+    @Override
+    Throwable handleReply(Message<Object> reply, String encoding, WireFormat wireFormat) {
+
+      Throwable err = super.handleReply(reply, encoding, wireFormat);
+      if (err == null) {
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
+        EventBusHeaders.decodeMultimap(HEADER_PREFIX, reply.headers(), headers);
+        EventBusHeaders.decodeMultimap(TRAILER_PREFIX, reply.headers(), trailers);
+        Buffer payload = EventBusGrpcCodec.decodeBody(reply.body());
+        dispatchFrameInbound(new DefaultGrpcHeadersFrame(wireFormat, encoding, headers));
+        dispatchFrameInbound(new DefaultGrpcMessageFrame(GrpcMessage.message(encoding, wireFormat, payload)));
+        dispatchFrameInbound(new DefaultGrpcTrailersFrame(GrpcStatus.OK, null, trailers));
+        dispatchEndInbound();
+      }
+
+      return err;
     }
   }
 
@@ -294,7 +334,7 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
     switch (s) {
       case OPENING:
         Promise<Void> promise = consumerContext.promise();
-        pending.add(messageWrite(message, promise));
+        enqueue(messageWrite(message, promise));
         return promise.future();
       case STREAMING:
         return writeMessage(message);
@@ -377,7 +417,9 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
   @Override
   protected Future<Void> sendTransportFrame(TransportFrame.Builder builder) {
     Future<Void> sent = registration.sendTransportFrame(builder, wireFormat, null);
-    sent.onFailure(this::handleRemoteEndpointDown);
+    if (sent != null) {
+      sent.onFailure(this::handleRemoteEndpointDown);
+    }
     return sent;
   }
 
@@ -402,10 +444,6 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
 
   private void failPending(Throwable cause) {
     failPendingWrites(cause);
-    MessageWrite write;
-    while ((write = pending.poll()) != null) {
-      write.fail(cause);
-    }
   }
 
   private void terminate() {

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientImpl.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientImpl.java
@@ -10,6 +10,7 @@ import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
 import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
+import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -19,7 +20,8 @@ public class EventBusGrpcClientImpl extends EventBusGrpcEndpoint implements Even
   private final AtomicInteger sequence = new AtomicInteger();
 
   private EventBusGrpcClientImpl(ContextInternal producerContext, EventBusGrpcClientOptions options) {
-    super(producerContext, "grpc.eb.client.", options.getWireFormat(), options.getPingInterval().toMillis(), pingTimeout(options));
+    super(producerContext, "grpc.eb.client.", options.getWireFormat(), options.getPingInterval().toMillis(),
+      pingTimeout(options), options.getInitialWindowSize());
     this.wireFormat = options.getWireFormat();
   }
 
@@ -54,7 +56,8 @@ public class EventBusGrpcClientImpl extends EventBusGrpcEndpoint implements Even
   @Override
   public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(ServiceMethod<Resp, Req> method) {
     ContextInternal consumerContext = vertx.getOrCreateContext();
-    EventBusGrpcClientInvoker invoker = new EventBusGrpcClientInvoker(consumerContext, this, !method.clientStreaming(), !method.serverStreaming());
+    EventBusGrpcClientInvoker invoker = new EventBusGrpcClientInvoker(consumerContext, this,
+      !method.clientStreaming(), !method.serverStreaming(), initialWindowSize, EventBusGrpcServerOptions.DEFAULT_INITIAL_WINDOW_SIZE);
     GrpcClientRequestImpl<Req, Resp> request = new GrpcClientRequestImpl<>(
       consumerContext,
       invoker,

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientInvoker.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientInvoker.java
@@ -11,17 +11,23 @@ public class EventBusGrpcClientInvoker implements GrpcClientInvoker {
   private final boolean remoteUnary;
   private final EventBusGrpcClientImpl client;
   private final boolean localUnary;
+  private final int initialInboundWindowSize;
+  private final int initialOutboundWindowSize;
 
-  public EventBusGrpcClientInvoker(ContextInternal context, EventBusGrpcClientImpl client, boolean localUnary, boolean remoteUnary) {
+  public EventBusGrpcClientInvoker(ContextInternal context, EventBusGrpcClientImpl client, boolean localUnary,
+                                   boolean remoteUnary, int initialInboundWindowSize, int initialOutboundWindowSize) {
     this.client = client;
     this.context = context;
     this.localUnary = localUnary;
     this.remoteUnary = remoteUnary;
+    this.initialInboundWindowSize = initialInboundWindowSize;
+    this.initialOutboundWindowSize = initialOutboundWindowSize;
   }
 
   @Override
   public GrpcStream invoke(ServiceName serviceName, String methodName) {
     EventBusGrpcEndpoint.StreamRegistration registration = client.createStream();
-    return new EventBusGrpcClientCall(context, localUnary, remoteUnary, registration, client, serviceName, methodName);
+    return new EventBusGrpcClientCall(context, localUnary, remoteUnary, registration, client, serviceName, methodName,
+      initialInboundWindowSize, initialOutboundWindowSize);
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -34,12 +34,14 @@ abstract class EventBusGrpcEndpoint {
   private final ConcurrentMap<Long, EventBusGrpcStreamBase> streams = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, RemoteEndpoint> remoteEndpoints = new ConcurrentHashMap<>();
   private final AtomicLong pingData = new AtomicLong();
+  protected final int initialWindowSize;
 
   private MessageConsumer<Object> consumer;
   private long livenessTimerId = -1L;
   private boolean stopped;
 
-  EventBusGrpcEndpoint(ContextInternal producerContext, String prefix, WireFormat pingWireFormat, long pingInterval, long pingTimeout) {
+  EventBusGrpcEndpoint(ContextInternal producerContext, String prefix, WireFormat pingWireFormat, long pingInterval,
+                       long pingTimeout, int initialWindowSize) {
 
     UUID uuid = UUID.randomUUID();
 
@@ -51,6 +53,7 @@ abstract class EventBusGrpcEndpoint {
     this.pingWireFormat = pingWireFormat;
     this.pingInterval = pingInterval;
     this.pingTimeout = pingTimeout;
+    this.initialWindowSize = initialWindowSize;
   }
 
   int id() {
@@ -274,6 +277,9 @@ abstract class EventBusGrpcEndpoint {
       Object payload = EventBusGrpcCodec.encodeFrame(builder, wireFormat);
       if (options == null) {
         options = new DeliveryOptions().addHeader(EventBusHeaders.WIRE_FORMAT, wireFormat.name());
+      }
+      if (remoteEndpoint == null) {
+        return null;
       }
       MessageProducer<Object> producer = remoteEndpoint.producer;
       return producer.write(payload, options);

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
@@ -35,8 +35,9 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
     EventBusGrpcEndpoint.StreamRegistration registration,
     WireFormat wireFormat,
     String encoding,
-    int window) {
-    super(context, localUnary, remoteUnary, registration, window);
+    int initialInboundWindowSize,
+    int initialOutboundWindowSize) {
+    super(context, localUnary, remoteUnary, registration, initialInboundWindowSize, initialOutboundWindowSize);
     this.wireFormat = wireFormat;
     this.encoding = encoding;
     this.inbound = remoteUnary ? new UnaryInbound() : new StreamingInbound();
@@ -138,7 +139,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
     public void init(String address, Message<Object> msg) {
       DeliveryOptions replyOptions = new DeliveryOptions()
         .addHeader(EventBusHeaders.SERVER_ADDRESS, address)
-        .addHeader(EventBusHeaders.INITIAL_WINDOW, Integer.toString(DEFAULT_WINDOW));
+        .addHeader(EventBusHeaders.INITIAL_WINDOW, Integer.toString(registration.localEndpoint().initialWindowSize));
 
       msg.reply(Buffer.buffer(), replyOptions);
     }
@@ -264,7 +265,9 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
 
   private Future<Void> sendTransportFrame(TransportFrame.Builder builder, DeliveryOptions options) {
     Future<Void> sent = registration.sendTransportFrame(builder, wireFormat, options);
-    sent.onFailure(this::handleRemoteEndpointDown);
+    if (sent != null) {
+      sent.onFailure(this::handleRemoteEndpointDown);
+    }
     return sent;
   }
 
@@ -302,10 +305,13 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
     }
 
     @Override
-    public void write() {
+    public boolean write() {
       Future<Void> sent = sendTrailers(frame);
-      terminate();
-      sent.onComplete(promise);
+      if (sent != null) {
+        terminate();
+        sent.onComplete(promise);
+      }
+      return sent != null;
     }
 
     @Override

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerImpl.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerImpl.java
@@ -8,6 +8,7 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.grpc.common.*;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
+import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
 import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
 import io.vertx.grpc.server.GrpcServerRequest;
@@ -26,7 +27,8 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
   protected final ContextInternal consumerContext;
 
   private EventBusGrpcServerImpl(ContextInternal consumerContext, EventBusGrpcServerOptions options) {
-    super(Utils.eventLoopCtx(consumerContext),  "grpc.eb.server.", WireFormat.PROTOBUF, 0L, 0L);
+    super(Utils.eventLoopCtx(consumerContext),  "grpc.eb.server.", WireFormat.PROTOBUF, 0L,
+      0L, options.getInitialWindowSize());
     this.consumerContext = consumerContext;
     this.supportedWireFormats = new LinkedHashSet<>(options.getSupportedWireFormats());
     this.maxPingTimeout = options.getMaxPingTimeout().toMillis();
@@ -274,6 +276,24 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
         return;
       }
 
+      int initialOutboundWindowSize;
+      if (serviceMethod.serverStreaming()) {
+        String initialWindowHeader = message.headers().get(EventBusHeaders.INITIAL_WINDOW);
+        if (initialWindowHeader == null) {
+          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Missing '" + EventBusHeaders.INITIAL_WINDOW + "' header");
+          return;
+        }
+        try {
+          initialOutboundWindowSize = Integer.parseInt(initialWindowHeader);
+        } catch (NumberFormatException e) {
+          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Invalid '" + EventBusHeaders.INITIAL_WINDOW + "' header");
+          return;
+        }
+      } else {
+        initialOutboundWindowSize = EventBusGrpcClientOptions.DEFAULT_INITIAL_WINDOW_SIZE;
+      }
+
+
       String clientStreamIdHeader = message.headers().get(EventBusHeaders.STREAM_ID);
       long streamId;
       if (clientStreamIdHeader == null) {
@@ -291,7 +311,6 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
         }
       }
 
-      int window = EventBusGrpcStreamBase.DEFAULT_WINDOW;
       long remoteTimeout = remoteTimeout(message.headers().get(EventBusHeaders.PING_TIMEOUT));
 
       EventBusGrpcEndpoint.StreamRegistration registration = createStream(streamId);
@@ -302,7 +321,8 @@ public class EventBusGrpcServerImpl extends EventBusGrpcEndpoint implements Even
         registration,
         wireFormat,
         "identity",
-        window
+        initialWindowSize,
+        initialOutboundWindowSize
       );
 
       if (stream.registration.id() != 0) {

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -16,7 +16,6 @@ import io.vertx.grpc.eventbus.transport.v1alpha.WindowUpdate;
 
 abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
 
-  static final int DEFAULT_WINDOW = 64;
   static final Object END_MARKER = new Object();
 
   protected final EventBusGrpcEndpoint.StreamRegistration registration;
@@ -35,14 +34,16 @@ abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
 
   private long sequence;
 
-  EventBusGrpcStreamBase(ContextInternal context, boolean localUnary, boolean remoteUnary, EventBusGrpcEndpoint.StreamRegistration registration, int window) {
+  EventBusGrpcStreamBase(ContextInternal context, boolean localUnary, boolean remoteUnary,
+                         EventBusGrpcEndpoint.StreamRegistration registration, int initialInboundWindowSize,
+                         int initialOutboundWindowSize) {
     this.registration = registration;
     this.consumerContext = context;
     this.producerContext = registration.localEndpoint().producerContext;
-    this.inboundQueue = new IMQ(registration, context);
+    this.inboundQueue = new IMQ(registration, context, initialInboundWindowSize);
     this.localUnary = localUnary;
     this.remoteUnary = remoteUnary;
-    this.outboundQueue = new OMQ(context, window);
+    this.outboundQueue = new OMQ(context, initialOutboundWindowSize);
   }
 
   abstract void handle(TransportFrame frame, io.vertx.core.eventbus.Message<Object> message);
@@ -188,8 +189,12 @@ abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
     }
 
     @Override
-    public void write() {
-      stream.doSendMessage(message).onComplete(promise);
+    public boolean write() {
+      Future<Void> sent = stream.doSendMessage(message);
+      if (sent != null) {
+        sent.onComplete(promise);
+      }
+      return sent != null;
     }
 
     @Override
@@ -204,18 +209,21 @@ abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
 
   private class IMQ extends InboundMessageQueue<Object> {
 
-    private int window;
+    private final int initialWindowSize;
+    private int windowSize;
 
-    public IMQ(EventBusGrpcEndpoint.StreamRegistration registration, ContextInternal context) {
+    public IMQ(EventBusGrpcEndpoint.StreamRegistration registration, ContextInternal context, int initialWindowSize) {
       super(registration.localEndpoint().producerContext.executor(), context.executor());
-      window = DEFAULT_WINDOW;
+      this.initialWindowSize = initialWindowSize;
+      this.windowSize = initialWindowSize;
     }
 
     @Override
     protected void handleMessage(Object msg) {
-      if (--window == 0) {
-        window = DEFAULT_WINDOW;
-        sendTransportFrame(TransportFrame.newBuilder().setWindowUpdate(WindowUpdate.newBuilder().setDelta(DEFAULT_WINDOW)));
+      if (--windowSize < initialWindowSize / 2) {
+        // Replenish window
+        int windowSizeUpdate = initialWindowSize - windowSize;
+        sendTransportFrame(TransportFrame.newBuilder().setWindowUpdate(WindowUpdate.newBuilder().setDelta(windowSizeUpdate)));
       }
       dispatchInbound(msg);
     }
@@ -223,20 +231,22 @@ abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
 
   private class OMQ extends OutboundMessageQueue<MessageWrite> {
 
-    private long outboundInflight;
+    private long window;
 
-    public OMQ(ContextInternal context, int window) {
+    public OMQ(ContextInternal context, int initialWindowSize) {
       super(context.eventLoop());
 
-      this.outboundInflight = window;
+      this.window = initialWindowSize;
     }
 
     @Override
     public boolean test(MessageWrite msg) {
-      if (outboundInflight > 0) {
-        outboundInflight--;
-        msg.write();
-        return true;
+      if (window > 0) {
+        boolean written = msg.write();
+        if (written) {
+          window--;
+        }
+        return written;
       } else {
         return false;
       }
@@ -258,8 +268,9 @@ abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
       }
     }
 
+    // Todo : check thread
     private void updateWindow(int delta) {
-      outboundInflight += delta;
+      window += delta;
       outboundQueue.tryDrain();
     }
   }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/MessageWrite.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/MessageWrite.java
@@ -15,8 +15,10 @@ interface MessageWrite {
    * configuration or state of the containing class or its dependencies.
    *
    * Implementing classes should ensure the write logic aligns with the expected operation of the system components where this method is employed.
+   *
+   * @return whether the write occured
    */
-  void write();
+  boolean write();
 
   /**
    * Handles a failure scenario by reporting the provided cause.

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcStreamingTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcStreamingTest.java
@@ -1012,14 +1012,13 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
 
   @Test
   public void testMalformedHandshakeReplyFailsFast() throws Exception {
-    String fqn = SOURCE_SERVER.serviceName().fullyQualifiedName();
+    String fqn = PIPE_SERVER.serviceName().fullyQualifiedName();
     vertx.eventBus().<Buffer>consumer(fqn, msg -> msg.reply(Buffer.buffer(), new DeliveryOptions()
       .addHeader(EventBusHeaders.SERVER_ADDRESS, "s.addr"))).completion().await(5, TimeUnit.SECONDS);
-
     try {
-      client.request(SOURCE_CLIENT)
+      client.request(PIPE_CLIENT)
         .compose(request -> {
-          request.end(Empty.getDefaultInstance());
+          request.write(Request.getDefaultInstance());
           return request.response();
         })
         .compose(GrpcReadStream::last)

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcWindowSizeTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/tests/eventbus/EventBusGrpcWindowSizeTest.java
@@ -1,0 +1,174 @@
+package io.vertx.tests.eventbus;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.client.GrpcClientRequest;
+import io.vertx.grpc.eventbus.EventBusGrpcClient;
+import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
+import io.vertx.grpc.server.GrpcServerRequest;
+import io.vertx.grpc.server.GrpcServerResponse;
+import io.vertx.tests.common.grpc.Reply;
+import io.vertx.tests.common.grpc.Request;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class EventBusGrpcWindowSizeTest extends EventBusGrpcTestBase {
+
+  EventBusGrpcServer server;
+  EventBusGrpcClient client;
+
+  @Override
+  public void setUp(TestContext should) {
+    super.setUp(should);
+    client = EventBusGrpcClient.client(vertx).await();
+    server = EventBusGrpcServer.server(vertx, new EventBusGrpcServerOptions().setInitialWindowSize(8)).await();
+  }
+
+  @Test
+  public void testFlowControl(TestContext should) {
+
+    Async async1 = should.async();
+
+    Promise<Void> signal = Promise.promise();
+
+    server.callHandler(PIPE_SERVER, new Handler<>() {
+
+      int submitted = 0;
+      int written = 0;
+
+      @Override
+      public void handle(GrpcServerRequest<Request, Reply> request) {
+        GrpcServerResponse<Request, Reply> response = request.response();
+        request.handler(item -> {
+          response.writeHead();
+        });
+        request.endHandler(v -> {
+          Future<Void> last;
+          do {
+            int val = ++submitted;
+            Future<Void> write = response.write(Reply.newBuilder().setMessage("msg-" + val).build());
+            last = write;
+            write.onComplete(should.asyncAssertSuccess(v2 -> {
+              written++;
+              // Default window size
+              if (val == 64) {
+                vertx.setTimer(100, id -> {
+                  // Check we haven't written extra messages to the wire
+                  should.assertEquals(64, written);
+                  // Signal client to consume messages
+                  signal.succeed();
+                });
+              }
+            }));
+          }
+          while (!response.writeQueueFull());
+          AtomicInteger drains = new AtomicInteger();
+          response.drainHandler(v2 -> {
+            drains.incrementAndGet();
+          });
+          last.onComplete(ar -> {
+            should.assertEquals(1, drains.incrementAndGet());
+            async1.complete();
+          });
+        });
+      }
+    });
+
+    Async async2 = should.async();
+
+    Future<GrpcClientRequest<Request, Reply>> fut = client.request(PIPE_CLIENT);
+    fut.onComplete(should.asyncAssertSuccess(request -> {
+      request.write(Request.getDefaultInstance());
+      request
+        .response()
+        .onComplete(should.asyncAssertSuccess(response -> {
+          response.handler(msg -> {
+            should.fail();
+          });
+          response.endHandler(msg -> {
+            should.fail();
+          });
+          AtomicInteger consumed = new AtomicInteger();
+          signal.future().onComplete(should.asyncAssertSuccess(pending -> {
+            // Consume 1/2 of the window size to trigger a window update frame
+            response.handler(msg -> {
+              if (consumed.incrementAndGet() == 32) {
+                vertx.setTimer(100, id -> {
+                  should.assertEquals(32, consumed.get());
+                  async2.complete();
+                });
+              }
+            });
+            response.fetch(32);
+          }));
+          response.pause();
+          request.end();
+      }));
+    }));
+  }
+
+  @Test
+  public void testServerWindowSizeClientInitialValue(TestContext should) {
+
+    Async async = should.async();
+
+    server.callHandler(PIPE_SERVER, request -> {
+      request.pause();
+      request
+        .response()
+        .writeHead();
+    });
+
+    Future<GrpcClientRequest<Request, Reply>> fut = client.request(PIPE_CLIENT);
+    fut.onComplete(should.asyncAssertSuccess(request -> {
+      should.assertFalse(request.writeQueueFull());
+      request.drainHandler(v -> {
+        int written = 0;
+        while (!request.writeQueueFull()) {
+          request.write(Request.getDefaultInstance());
+          written++;
+        }
+        // No message can be really written, so we consume the outbound message queue count
+        should.assertEquals(16, written);
+        async.complete();
+      });
+      request.writeHead();
+    }));
+  }
+
+  @Test
+  public void testServerWindowSizeClientAdjustment(TestContext should) {
+
+    Async async2 = should.async();
+
+    server.callHandler(PIPE_SERVER, request -> {
+      request.pause();
+      request
+        .response()
+        .writeHead();
+    });
+
+    Future<GrpcClientRequest<Request, Reply>> fut = client.request(PIPE_CLIENT);
+    fut.onComplete(should.asyncAssertSuccess(request -> {
+      request.write(Request.getDefaultInstance());
+      request
+        .response()
+        .onComplete(should.asyncAssertSuccess(response -> {
+          int written = 1;
+          while (!request.writeQueueFull()) {
+            request.write(Request.getDefaultInstance());
+            written++;
+          }
+          // 8: server window size
+          // 16: outbound queue high watermark
+          should.assertEquals(written, 8 + 16);
+          async2.complete();
+        }));
+    }));
+  }
+}


### PR DESCRIPTION
Motivation:

gRPC event-bus flow control window size should be configurable.

Changes:

Make gRPC event-bus flow control configurable.

Handle client flow control temporatily with an arbitrary size in absence of server configuration, adjust the window size when the server initial window size is received.

Add testing.
