### PR TITLE
gRPC event-bus json wireformat should encode message payload in plain text.

### DIFF
--- a/vertx-grpc-eventbus/README.md
+++ b/vertx-grpc-eventbus/README.md
@@ -80,7 +80,7 @@ these items:
 Depending on the client method type, the request body will differ, when the client
 
 - sends a unique message, the request body is this unique message
-- sends a stream of messages, the request body is empty
+- sends a stream of messages, the request body is null
 
 #### The reply of the server
 
@@ -96,6 +96,8 @@ operates. Therefore, the reply contains no response metadata.
 
 When the client sends a unique message as part of the event-bus request, this message is delivered to the
 service.
+
+The response body is null.
 
 Otherwise, the call is full duplex: all subsequent data are carried as `TransportFrame` on the  private addresses.
 
@@ -210,81 +212,6 @@ gRPC `status` value, because a response stream must end with a status.
 
 The full schema is in
 [`eventbus_transport.proto`](src/main/proto/io/vertx/grpc/eventbus/transport/v1alpha/eventbus_transport.proto):
-
-```proto
-syntax = "proto3";
-
-package io.vertx.grpc.eventbus.transport.v1alpha;
-
-option java_package = "io.vertx.grpc.eventbus.transport.v1alpha";
-option java_multiple_files = true;
-
-// A frame exchanged over the event bus during a streaming gRPC call, on the private
-// address only. Unary calls do not use these frames; they map to a plain request/reply.
-// The opening handshake is an upgrade-style request/reply too: the request carries the
-// client's address and stream id as delivery headers and the reply answers with the
-// server's address, stream id and initial window, both with empty bodies. Once open,
-// each endpoint multiplexes all of its streams over a single private address, and
-// stream_id demuxes the call on that address. Frames are serialized in the call's wire
-// format - protobuf binary, or JSON when the call runs in JSON mode, named in the
-// frame's grpc-wire-format header. The handshake and flow control are described in the
-// module README.
-message TransportFrame {
-  uint64 stream_id = 1; // the destination endpoint's id for this call, demuxes it on the shared private address, 0 for an endpoint level frame
-  uint64 stream_sequence = 2; // per-stream, monotonic, advances on Message frames only
-
-  oneof frame {
-    Message message = 3; // a message payload, either direction
-    WindowUpdate window_update = 4; // flow-control credit, either direction
-    HalfClose half_close = 5; // client to server, end of the request stream
-    Trailers trailers = 6; // server to client, terminates the call
-    Cancel cancel = 7; // either direction, abnormal termination
-    Headers headers = 8; // server to client, response metadata, before the first message
-    Ping ping = 9; // either direction, peer liveness probe, on stream_id 0
-  }
-}
-
-// Server to client, response initial metadata, ordered ahead of the first response
-// message. The metadata itself rides as __header__. prefixed delivery headers.
-message Headers {
-}
-
-// A message payload, either direction. The serialized message in the call's wire
-// format, carried verbatim.
-message Message {
-  bytes payload = 1;
-}
-
-// Flow-control credit, either direction: grants the peer delta more messages to
-// send. Counted in messages, after HTTP/2's WINDOW_UPDATE.
-message WindowUpdate {
-  uint32 delta = 1;
-}
-
-// Client to server, end of the request stream (half close).
-message HalfClose {
-}
-
-// Server to client, terminates the call. Trailing metadata rides as __trailer__.
-// prefixed delivery headers.
-message Trailers {
-  uint32 status = 1; // gRPC status code
-  string status_message = 2;
-}
-
-// Either direction, abnormal termination.
-message Cancel {
-  uint32 status = 1; // typically CANCELLED or DEADLINE_EXCEEDED
-  string reason = 2;
-}
-
-// A peer liveness probe, carried on stream_id 0 because it belongs to the peer endpoint
-// rather than to any single call.
-message Ping {
-  uint64 data = 1; // opaque, echoed verbatim in the ack
-  bool ack = 2; // set on the echo, clear on the probe
-}
-```
 
 The transport does not encode the messages again. The gRPC encoder makes the bytes. The
 `Message.payload` field contains these bytes without a change. The receiver sends the

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
@@ -197,7 +197,7 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase {
       }
 
       Promise<Void> promise = consumerContext.promise();
-      endpoint.request(consumerContext, serviceName.fullyQualifiedName(), Buffer.buffer(), options).onComplete(ar -> {
+      endpoint.request(consumerContext, serviceName.fullyQualifiedName(), null, options).onComplete(ar -> {
         if (ar.failed()) {
           handleFailure(ar.cause(), encoding, wireFormat);
           promise.fail(ar.cause());

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCodec.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCodec.java
@@ -52,7 +52,18 @@ final class EventBusGrpcCodec {
   }
 
   static GrpcMessage message(TransportFrame frame, String encoding, WireFormat wireFormat) {
-    return GrpcMessage.message(encoding, wireFormat, Buffer.buffer(frame.getMessage().getPayload().toByteArray()));
+    Buffer buffer;
+    switch (wireFormat.name()) {
+      case "proto":
+        buffer = Buffer.buffer(frame.getMessage().getBytes().toByteArray());
+        break;
+      case "json":
+        buffer = Buffer.buffer(frame.getMessage().getString());
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
+    return GrpcMessage.message(encoding, wireFormat, buffer);
   }
 
   static GrpcStatus mapFailure(Throwable cause) {

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
@@ -141,7 +141,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase {
         .addHeader(EventBusHeaders.SERVER_ADDRESS, address)
         .addHeader(EventBusHeaders.INITIAL_WINDOW, Integer.toString(registration.localEndpoint().initialWindowSize));
 
-      msg.reply(Buffer.buffer(), replyOptions);
+      msg.reply(null, replyOptions);
     }
 
     @Override

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -146,9 +146,20 @@ abstract class EventBusGrpcStreamBase implements GrpcStream, Closeable {
   }
 
   private Future<Void> doSendMessage(GrpcMessage message) {
+    Message.Builder msg;
+    switch (message.format().name()) {
+      case "proto":
+        msg = Message.newBuilder().setBytes(ByteString.copyFrom(message.payload().getBytes()));
+        break;
+      case "json":
+        msg = Message.newBuilder().setStringBytes(ByteString.copyFrom(message.payload().getBytes()));
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
     return sendTransportFrame(TransportFrame.newBuilder()
       .setStreamSequence(++sequence)
-      .setMessage(Message.newBuilder().setPayload(ByteString.copyFrom(message.payload().getBytes()))));
+      .setMessage(msg));
   }
 
   protected void enqueue(MessageWrite write) {

--- a/vertx-grpc-eventbus/src/main/proto/io/vertx/grpc/eventbus/transport/v1alpha/eventbus_transport.proto
+++ b/vertx-grpc-eventbus/src/main/proto/io/vertx/grpc/eventbus/transport/v1alpha/eventbus_transport.proto
@@ -38,7 +38,10 @@ message Headers {
 // A message payload, either direction. The serialized message in the call's wire
 // format, carried verbatim.
 message Message {
-  bytes payload = 1;
+  oneof payload {
+    bytes bytes = 1;
+    string string = 2;
+  }
 }
 
 // Flow-control credit, either direction: grants the peer delta more messages to

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusWireFormatTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusWireFormatTest.java
@@ -1,0 +1,113 @@
+package io.vertx.grpc.eventbus.tests;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.common.GrpcReadStream;
+import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.common.tests.Reply;
+import io.vertx.grpc.common.tests.Request;
+import io.vertx.grpc.eventbus.EventBusGrpcClient;
+import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import io.vertx.grpc.eventbus.impl.EventBusHeaders;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.function.BiConsumer;
+
+public class EventBusWireFormatTest extends EventBusGrpcTestBase {
+
+  private EventBusGrpcServer server;
+  private EventBusGrpcClient client;
+  private volatile BiConsumer<String, Buffer> payloadHandler;
+
+  @Before
+  public void setUp(TestContext should) {
+    super.setUp(should);
+    server = EventBusGrpcServer.server(vertx).await();
+    client = EventBusGrpcClient.client(vertx).await();
+  }
+
+  private void addPayloadInterceptor(TestContext should, BiConsumer<String, Object> payloadHandler) {
+    vertx.eventBus().addOutboundInterceptor(ctx -> {
+      MultiMap headers = ctx
+        .message()
+        .headers();
+      String wireFormat = headers.get(EventBusHeaders.WIRE_FORMAT);
+      if (wireFormat != null) {
+        try {
+          payloadHandler.accept(wireFormat, ctx.message().body());
+        } catch (Throwable failure) {
+          should.fail(failure);
+        }
+      }
+      ctx.next();
+    });
+  }
+
+  @Test
+  public void testUnary(TestContext should) {
+
+    addPayloadInterceptor(should, (format, body) -> {
+      should.assertEquals("json", format);
+      should.assertEquals(JsonObject.class, body.getClass());
+    });
+
+    server.callHandler(UNARY_SERVER, request -> request
+      .endHandler(v -> request
+        .response()
+        .end(Reply.getDefaultInstance())));
+
+    client.request(UNARY_CLIENT)
+      .compose(request -> {
+        request.format(WireFormat.JSON);
+        request.end(Request.getDefaultInstance());
+        return request
+          .response()
+          .compose(GrpcReadStream::last);
+      }).await();
+  }
+
+  @Test
+  public void testStreaming(TestContext should) {
+
+    addPayloadInterceptor(should, (format, body) -> {
+      should.assertEquals("json", format);
+      if (body == null) {
+        // OK
+      } else {
+        Buffer buffer = (Buffer) body;
+        JsonObject json = new JsonObject(buffer);
+        JsonObject message = json.getJsonObject("message");
+        if (message != null) {
+          Object str = message.getValue("string");
+          should.assertEquals(String.class, str.getClass());
+          JsonObject payload = new JsonObject((String)str);
+        }
+      }
+    });
+
+    server.callHandler(PIPE_SERVER, request -> request
+      .handler(msg -> {
+        request.response().write(Reply.newBuilder().setMessage("reply-to-" + msg.getName()).build());
+      })
+      .endHandler(v -> request
+        .response()
+        .end(Reply.getDefaultInstance())));
+
+    int num = 8;
+
+    client.request(PIPE_CLIENT)
+      .compose(request -> {
+        request.format(WireFormat.JSON);
+        for (int i = 0;i < num;i++) {
+          request.write(Request.newBuilder().setName("msg-" + i).build());
+        }
+        request.end();
+        return request
+          .response()
+          .compose(GrpcReadStream::last);
+      }).await();
+  }
+}


### PR DESCRIPTION
Motivation:

gRPC event-bus proto definition for a message defines bytes which are encoded as an opaque string with the json wire format.

When using wire format, we would like this to appear in clear text.

Changes:

Update the message definition to be a one-of string|bytes, string should contain the json encoded payload and bytes should contain the proto encoded payload.

Stream request/reply use a null body instead of an empty body, since the format of the body can be ready by interceptors, they would assume an incorrect value for either proto or json.
