### PR TITLE
Improve handling of client reset frames sent by the server.

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
@@ -334,7 +334,7 @@ public class GrpcClientRequestImpl<Req, Resp> extends GrpcWriteStreamBase<GrpcCl
   }
 
   private void handleCancelFrame(GrpcCancelFrame frame) {
-    cancel();
+    handleCancel();
   }
 
   private void handleEnd(Void v) {

--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientRequestTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientRequestTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.vertx.grpc.common.GrpcError.CANCELLED;
 import static org.junit.Assert.assertFalse;
 
 /**
@@ -663,7 +664,7 @@ public class ClientRequestTest extends ClientTest {
         callRequest.response().onComplete(should.asyncAssertFailure(err -> {
           should.assertEquals(GrpcErrorException.class, err.getClass());
           GrpcErrorException gee = (GrpcErrorException) err;
-          should.assertEquals(GrpcError.CANCELLED, gee.error());
+          should.assertEquals(CANCELLED, gee.error());
           done.complete();
         }));
       }));
@@ -931,5 +932,23 @@ public class ClientRequestTest extends ClientTest {
 
     request.end(Request.newBuilder().setName("Julien").build()).await();
     requestReceived.future().await();
+  }
+
+  @Override
+  public void testServerCancellationReset(TestContext should) {
+    super.testServerCancellationReset(should);
+    Async test = should.async();
+    client = GrpcClient.client(vertx);
+    client.request(SocketAddress.inetSocketAddress(port, "localhost"), SINK)
+      .onComplete(should.asyncAssertSuccess(callRequest -> {
+        callRequest.exceptionHandler(err -> {
+          if (err instanceof GrpcErrorException && ((GrpcErrorException)err).error() == CANCELLED) {
+            callRequest.exceptionHandler(null);
+            should.assertTrue(callRequest.isCancelled());
+            test.complete();
+          }
+        });
+        callRequest.write(Request.newBuilder().setName("Julien").build());
+      }));
   }
 }

--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientTest.java
@@ -462,4 +462,16 @@ public abstract class ClientTest extends ClientTestBase {
       .listen(port, "localhost")
       .await();
   }
+
+  @Test
+  public void testServerCancellationReset(TestContext should) {
+    vertx.createHttpServer().requestHandler(req -> {
+        req.handler(msg -> {
+          // Cancel via reset
+          req.response().reset(0x08);
+        });
+      })
+      .listen(8080, "localhost")
+      .await();
+  }
 }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
@@ -79,7 +79,7 @@ public interface GrpcWriteStream<T> extends WriteStream<T> {
   void cancel();
 
   /**
-   * @return whether the stream is cancelled
+   * @return whether the stream is canceled
    */
   boolean isCancelled();
 

--- a/vertx-grpcio-client/src/test/java/io/vertx/grpcio/client/tests/ClientBridgeTest.java
+++ b/vertx-grpcio-client/src/test/java/io/vertx/grpcio/client/tests/ClientBridgeTest.java
@@ -664,4 +664,31 @@ public class ClientBridgeTest extends ClientTest {
       Assert.assertEquals(Status.UNAUTHENTICATED, expected.getStatus());
     }
   }
+
+  @Override
+  public void testServerCancellationReset(TestContext should) {
+    super.testServerCancellationReset(should);
+    Async test = should.async();
+
+    client = GrpcIoClient.client(vertx);
+    GrpcIoClientChannel channel = new GrpcIoClientChannel(client, SocketAddress.inetSocketAddress(port, "localhost"));
+
+    TestServiceGrpc.TestServiceStub stub = TestServiceGrpc.newStub(channel);
+     StreamObserver<Request> sink = stub.pipe(new StreamObserver<Reply>() {
+      @Override
+      public void onNext(Reply value) {
+      }
+      @Override
+      public void onError(Throwable t) {
+        should.assertEquals(StatusRuntimeException.class, t.getClass());
+        StatusRuntimeException sre = (StatusRuntimeException)t;
+        should.assertEquals(Status.Code.CANCELLED, sre.getStatus().getCode());
+        test.complete();
+      }
+      @Override
+      public void onCompleted() {
+      }
+    });
+    sink.onNext(Request.newBuilder().setName("item").build());
+  }
 }


### PR DESCRIPTION
Motivation:

Although the server should cancel using a status frame, it can send reset frames as well under some circumstances.

The client should properly handle them.

Changes:

Change client handling of server cancelation reset frame that was actually trying to reset the stream instead of merely reflecting the state and notifying.
