### PR TITLE
Improve client side cancellation.

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/GrpcClientRequestImpl.java
@@ -221,11 +221,14 @@ public class GrpcClientRequestImpl<Req, Resp> extends GrpcWriteStreamBase<GrpcCl
   }
 
   @Override
-  protected boolean sendCancel() {
-    stream
-      .write(DefaultGrpcCancelFrame.INSTANCE)
-      .onSuccess(v -> handleError(GrpcError.CANCELLED));
-    return true;
+  protected Future<Void> sendCancel() {
+    GrpcStream s = stream;
+    if (s != null) {
+      return s.write(DefaultGrpcCancelFrame.INSTANCE);
+    } else {
+      internalHandleException(new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED));
+      return Future.succeededFuture();
+    }
   }
 
   @Override

--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientRequestTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientRequestTest.java
@@ -951,4 +951,35 @@ public class ClientRequestTest extends ClientTest {
         callRequest.write(Request.newBuilder().setName("Julien").build());
       }));
   }
+
+  @Test
+  public void testClientEarlyCancel(TestContext should) throws Exception {
+
+    TestServiceGrpc.TestServiceImplBase called = new TestServiceGrpc.TestServiceImplBase() {
+      @Override
+      public void unary(Request request, StreamObserver<Reply> responseObserver) {
+      }
+    };
+    startServer(called);
+
+    Async test = should.async(2);
+    client = GrpcClient.client(vertx);
+    client.request(SocketAddress.inetSocketAddress(port, "localhost"), UNARY)
+      .onComplete(should.asyncAssertSuccess(callRequest -> {
+        callRequest.exceptionHandler(err -> {
+          test.complete();
+          callRequest.exceptionHandler(null);
+        });
+        callRequest
+          .write(Request.newBuilder().setName("Julien").build())
+          .onComplete(should.asyncAssertSuccess(v -> {
+            callRequest.cancel();
+        }));
+        callRequest
+          .response()
+          .onComplete(should.asyncAssertFailure(err -> {
+            test.countDown();
+        }));
+      }));
+  }
 }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcWriteStream.java
@@ -74,12 +74,19 @@ public interface GrpcWriteStream<T> extends WriteStream<T> {
   Future<Void> endMessage(GrpcMessage message);
 
   /**
-   * Cancel the stream.
+   * Attempt to cancel the stream.
    */
   void cancel();
 
   /**
-   * @return whether the stream is canceled
+   * @return the current attempt of cancelling the stream when not null.
+   */
+  @Nullable
+  Future<Void> cancellation();
+
+  /**
+   * @return whether the stream is canceled, this might not reflect the status of the cancellation
+   * accurately on the client side.
    */
   boolean isCancelled();
 

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcWriteStreamBase.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/GrpcWriteStreamBase.java
@@ -18,7 +18,7 @@ public abstract class GrpcWriteStreamBase<S extends GrpcWriteStreamBase<S, T>, T
   private boolean headersWritten;
   private boolean endWritten;
   private GrpcError error;
-  private boolean cancelled;
+  private Future<Void> cancellation;
   private MultiMap headers;
   private Handler<Throwable> exceptionHandler;
 
@@ -35,7 +35,7 @@ public abstract class GrpcWriteStreamBase<S extends GrpcWriteStreamBase<S, T>, T
   }
 
   public void handleCancel() {
-    cancelled = true;
+    cancellation = context.succeededFuture();
   }
 
   public void handleException(Throwable err) {
@@ -50,19 +50,28 @@ public abstract class GrpcWriteStreamBase<S extends GrpcWriteStreamBase<S, T>, T
   }
 
   public void handleStatus(GrpcStatus status) {
-    cancelled |= status == GrpcStatus.CANCELLED;
+    if (cancellation == null && status == GrpcStatus.CANCELLED) {
+      cancellation = context.succeededFuture();
+    }
   }
 
   @Override
   public boolean isCancelled() {
-    return cancelled;
+    Future<Void> c = cancellation;
+    // Compute an optimistic view of cancellation
+    return c != null && (c.succeeded() || !c.isComplete());
   }
 
   @Override
   public void cancel() {
-    if (!cancelled) {
-      cancelled = sendCancel();
+    if (cancellation == null) {
+      cancellation = sendCancel();
     }
+  }
+
+  @Override
+  public Future<Void> cancellation() {
+    return cancellation;
   }
 
   @Override
@@ -155,7 +164,7 @@ public abstract class GrpcWriteStreamBase<S extends GrpcWriteStreamBase<S, T>, T
   protected abstract Future<Void> sendHead();
   protected abstract Future<Void> sendMessage(GrpcMessage message);
   protected abstract Future<Void> sendEnd();
-  protected abstract boolean sendCancel();
+  protected abstract Future<Void> sendCancel();
 
   protected Future<Void> sendEnd(GrpcMessage message) {
     sendMessage(message);

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
@@ -5,10 +5,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.grpc.common.GrpcMessage;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.common.*;
 import io.vertx.grpc.common.impl.*;
 import io.vertx.grpc.eventbus.transport.v1alpha.*;
 
@@ -24,6 +21,7 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase<EventBusGrpcClientEn
   private MultiMap requestHeaders;
   private Duration timeout;
   private Future<Void> halfCloseWritten;
+  private Promise<Void> cancellation;
   private State state;
   private final Outbound outbound;
 
@@ -136,13 +134,29 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase<EventBusGrpcClientEn
   }
 
   @Override
-  public Future<Void> write(GrpcFrame frame) {
-    if (state == State.CLOSED) {
-      return consumerContext.failedFuture("Stream closed");
+  protected void dispatchInbound(GrpcFrame frame) {
+    if (frame.type() == GrpcFrameType.HEADERS) {
+      Promise<Void> c = cancellation;
+      if (c != null) {
+        if (localUnary && remoteUnary) {
+          c.fail("Cannot cancel a unary/unary stream");
+        } else {
+          Future<Void> fut = sendTransportFrame(TransportFrame.newBuilder().setCancel(Cancel.newBuilder().setStatus(GrpcStatus.CANCELLED.code)), null);
+          fut.onComplete(c);
+        }
+      }
     }
+    super.dispatchInbound(frame);
+  }
+
+  @Override
+  public Future<Void> write(GrpcFrame frame) {
     if (frame.type() == GrpcFrameType.CANCEL) {
       return writeCancel();
     } else {
+      if (state == State.CLOSED) {
+        return consumerContext.failedFuture("Stream closed");
+      }
       return outbound.write(frame);
     }
   }
@@ -186,10 +200,21 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase<EventBusGrpcClientEn
   }
 
   private Future<Void> writeCancel() {
-    if (state == State.STREAMING) {
-      return sendTransportFrame(TransportFrame.newBuilder().setCancel(Cancel.newBuilder().setStatus(GrpcStatus.CANCELLED.code)), null);
-    } else {
-      return consumerContext.failedFuture("Not supported");
+    switch (state) {
+      case CLOSED:
+        return consumerContext.failedFuture("Stream closed");
+      case IDLE:
+        state = State.CLOSED;
+        handleException(new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED));
+        return consumerContext.succeededFuture();
+      case CONNECTING:
+        Promise<Void> promise = consumerContext.promise();
+        cancellation = promise;
+        return promise.future();
+      case STREAMING:
+        return sendTransportFrame(TransportFrame.newBuilder().setCancel(Cancel.newBuilder().setStatus(GrpcStatus.CANCELLED.code)), null);
+      default:
+        return consumerContext.failedFuture("Not supported");
     }
   }
 

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -66,7 +66,7 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     });
   }
 
-  private void handleException(Throwable t) {
+  protected void handleException(Throwable t) {
     Handler<Throwable> handler = exceptionHandler;
     if (handler != null) {
       consumerContext.dispatch(t, handler);
@@ -157,7 +157,7 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     inboundQueue.write(frames);
   }
 
-  private void dispatchInbound(GrpcFrame frame) {
+  protected void dispatchInbound(GrpcFrame frame) {
     Handler<GrpcFrame> handler = frameHandler;
     if (handler != null) {
       handler.handle(frame);

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClientCancellationTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClientCancellationTest.java
@@ -1,0 +1,204 @@
+package io.vertx.grpc.eventbus.tests;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.client.GrpcClientRequest;
+import io.vertx.grpc.common.GrpcError;
+import io.vertx.grpc.common.GrpcErrorException;
+import io.vertx.grpc.common.tests.Empty;
+import io.vertx.grpc.common.tests.Reply;
+import io.vertx.grpc.common.tests.Request;
+import io.vertx.grpc.eventbus.EventBusGrpcClient;
+import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
+import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
+import io.vertx.grpc.server.GrpcServerRequest;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class EventBusGrpcClientCancellationTest extends EventBusGrpcTestBase {
+
+  EventBusGrpcServer server;
+  EventBusGrpcClient client;
+
+  @Override
+  public void setUp(TestContext should) {
+    super.setUp(should);
+    client = EventBusGrpcClient.client(vertx, new EventBusGrpcClientOptions()).await();
+    server = EventBusGrpcServer.server(vertx, new EventBusGrpcServerOptions().setInitialWindowSize(8)).await();
+  }
+
+  @Test
+  public void testClientUnaryCancelEarly(TestContext should) {
+    server.callHandler(UNARY_SERVER, request -> {
+    });
+    GrpcClientRequest<Request, Reply> request = client.request(UNARY_CLIENT).await();
+    request.cancel();
+    try {
+      request.response().await();
+      should.fail();
+    } catch (GrpcErrorException e) {
+      should.assertEquals(GrpcError.CANCELLED, e.error());
+    }
+    should.assertTrue(request.isCancelled());
+  }
+
+  @Test
+  public void testClientUnaryCancelBeforeEnd(TestContext should) {
+    server.callHandler(UNARY_SERVER, request -> {
+    });
+    GrpcClientRequest<Request, Reply> request = client.request(UNARY_CLIENT).await();
+    request.write(Request.getDefaultInstance()).await();
+    request.cancel();
+    try {
+      request.response().await();
+      should.fail();
+    } catch (GrpcErrorException e) {
+      should.assertEquals(GrpcError.CANCELLED, e.error());
+    }
+    should.assertTrue(request.isCancelled());
+  }
+
+  @Test
+  public void testClientUnaryCancelBeforeAfterEnd(TestContext should) {
+    AtomicReference<GrpcServerRequest<Request, Reply>> serverRequestRef = new AtomicReference<>();
+    Async async = should.async();
+    server.callHandler(UNARY_SERVER, request -> {
+      serverRequestRef.set(request);
+      async.complete();
+    });
+    GrpcClientRequest<Request, Reply> request = client.request(UNARY_CLIENT).await();
+    request.end(Request.getDefaultInstance());
+    async.awaitSuccess(20_000);
+    request.cancel();
+    serverRequestRef
+      .get()
+      .response()
+      .end(Reply.getDefaultInstance());
+    request.cancellation().onComplete(should.asyncAssertFailure(err -> {
+      should.assertFalse(request.isCancelled());
+    }));
+  }
+
+  @Test
+  public void testClientSinkCancelEarly(TestContext should) {
+    server.callHandler(SINK_SERVER, request -> {
+    });
+    GrpcClientRequest<Request, Empty> request = client.request(SINK_CLIENT).await();
+    request.cancel();
+    try {
+      request.response().await();
+      should.fail();
+    } catch (GrpcErrorException e) {
+      should.assertEquals(GrpcError.CANCELLED, e.error());
+    }
+    should.assertTrue(request.isCancelled());
+  }
+
+  @Test
+  public void testClientSinkCancelBeforeEnd(TestContext should) {
+    AtomicReference<GrpcServerRequest<Request, Empty>> serverRequestRef = new AtomicReference<>();
+    Async latch = should.async();
+    server.callHandler(SINK_SERVER, request -> {
+      serverRequestRef.set(request);
+      latch.complete();
+    });
+    GrpcClientRequest<Request, Empty> request = client.request(SINK_CLIENT).await();
+    request.write(Request.getDefaultInstance()).await();
+    request.cancel();
+    latch.awaitSuccess(20_000);
+    serverRequestRef
+      .get()
+      .response()
+      .writeHead();
+    try {
+      request.response().await();
+      should.fail();
+    } catch (GrpcErrorException e) {
+      should.assertEquals(GrpcError.CANCELLED, e.error());
+    }
+    should.assertTrue(request.isCancelled());
+  }
+
+  @Test
+  public void testClientSinkCancelBeforeAfterEnd(TestContext should) {
+    AtomicReference<GrpcServerRequest<Request, Empty>> serverRequestRef = new AtomicReference<>();
+    Async async = should.async();
+    server.callHandler(SINK_SERVER, request -> {
+      serverRequestRef.set(request);
+      async.complete();
+    });
+    GrpcClientRequest<Request, Empty> request = client.request(SINK_CLIENT).await();
+    request.end(Request.getDefaultInstance());
+    async.awaitSuccess(20_000);
+    request.cancel();
+    serverRequestRef
+      .get()
+      .response()
+      .end(Empty.getDefaultInstance());
+    try {
+      request.response().await();
+      should.fail();
+    } catch (GrpcErrorException e) {
+      should.assertEquals(GrpcError.CANCELLED, e.error());
+    }
+    should.assertTrue(request.isCancelled());
+  }
+
+  @Test
+  public void testClientSourceCancelEarly(TestContext should) {
+    server.callHandler(SOURCE_SERVER, request -> {
+    });
+    GrpcClientRequest<Empty, Reply> request = client.request(SOURCE_CLIENT).await();
+    request.cancel();
+    try {
+      request.response().await();
+      should.fail();
+    } catch (GrpcErrorException e) {
+      should.assertEquals(GrpcError.CANCELLED, e.error());
+    }
+    should.assertTrue(request.isCancelled());
+  }
+
+  @Test
+  public void testClientSourceCancelBeforeEnd(TestContext should) {
+    server.callHandler(SOURCE_SERVER, request -> {
+    });
+    GrpcClientRequest<Empty, Reply> request = client.request(SOURCE_CLIENT).await();
+    request.write(Empty.getDefaultInstance()).await();
+    request.cancel();
+    try {
+      request.response().await();
+      should.fail();
+    } catch (GrpcErrorException e) {
+      should.assertEquals(GrpcError.CANCELLED, e.error());
+    }
+    should.assertTrue(request.isCancelled());
+  }
+
+  @Test
+  public void testClientSourceCancelBeforeAfterEnd(TestContext should) {
+    AtomicReference<GrpcServerRequest<Empty, Reply>> serverRequestRef = new AtomicReference<>();
+    Async async = should.async();
+    server.callHandler(SOURCE_SERVER, request -> {
+      serverRequestRef.set(request);
+      async.complete();
+    });
+    GrpcClientRequest<Empty, Reply> request = client.request(SOURCE_CLIENT).await();
+    request.end(Empty.getDefaultInstance());
+    async.awaitSuccess(20_000);
+    request.cancel();
+    serverRequestRef
+      .get()
+      .response()
+      .end(Reply.getDefaultInstance());
+    try {
+      request.response().await();
+      should.fail();
+    } catch (GrpcErrorException e) {
+      should.assertEquals(GrpcError.CANCELLED, e.error());
+    }
+    should.assertTrue(request.isCancelled());
+  }
+}

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -147,14 +147,13 @@ public final class GrpcServerResponseImpl<Req, Resp> extends GrpcWriteStreamBase
     return acceptedEncodings;
   }
 
-  protected boolean sendCancel() {
+  protected Future<Void> sendCancel() {
     if (!isEndWritten()) {
       status(GrpcStatus.CANCELLED);
-      end();
-      return true;
+      return end();
     } else {
       // Can this happen ?
-      return false;
+      throw new UnsupportedOperationException();
     }
   }
 


### PR DESCRIPTION
Motivation:

With event-bus grpc transport, cancellation is not possible for the unary/unary pattern.

The API and interaction should reflect that.

The implementation should handle all possible cases.

Changes:

Update the API to provide a cancellation future that provides an async failable view of cancellation.

Implement best effort cancellation on grpc event bus client side.
