### PR TITLE
Fix incorrect cancellation frame write failure handling.

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -124,7 +124,7 @@ abstract class EventBusGrpcEndpoint {
         remoteEndpoint.lastPingTimestamp = now;
         remoteEndpoint.producer
           .write(EventBusGrpcCodec.encodeFrame(TransportFrame.newBuilder().setPing(ping).build(), remoteEndpoint.format), options)
-          .onFailure(cause -> remoteEndpointDown(remoteEndpoint));
+          .onFailure(cause -> remoteEndpointDown(remoteEndpoint, false));
       }
     }
   }
@@ -134,16 +134,16 @@ abstract class EventBusGrpcEndpoint {
       if (remoteEndpoint.timeout > 0 && now - remoteEndpoint.lastSeenTimestamp > remoteEndpoint.timeout) {
         GrpcErrorException err = new GrpcErrorException(GrpcError.UNAVAILABLE, GrpcStatus.UNAVAILABLE);
         err.initCause(new TimeoutException("No ping from remote endpoint " + remoteEndpoint.address + " within " + remoteEndpoint.timeout + " ms"));
-        remoteEndpointDown(remoteEndpoint);
+        remoteEndpointDown(remoteEndpoint, true);
       }
     }
   }
 
-  private void remoteEndpointDown(RemoteEndpoint remoteEndpoint) {
+  private void remoteEndpointDown(RemoteEndpoint remoteEndpoint, boolean notify) {
     if (remoteEndpoints.get(remoteEndpoint.address) == remoteEndpoint) {
       ArrayList<StreamRegistration> copy = new ArrayList<>(remoteEndpoint.streams.values());
       for (StreamRegistration registration : copy) {
-        registration.close(new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED), true);
+        registration.close(new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED), notify);
       }
       // Check endpoint is down
       assert !remoteEndpoints.containsKey(remoteEndpoint.address);
@@ -309,7 +309,7 @@ abstract class EventBusGrpcEndpoint {
         Future<Void> res = producer.write(payload, options);
         return res.andThen(ar -> {
           if (ar.failed()) {
-            localEndpoint.remoteEndpointDown(remoteEndpoint);
+            localEndpoint.remoteEndpointDown(remote, false);
           }
         });
       }

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcEndpointTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcEndpointTest.java
@@ -1,0 +1,77 @@
+package io.vertx.grpc.eventbus.tests;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.client.GrpcClientRequest;
+import io.vertx.grpc.common.tests.Reply;
+import io.vertx.grpc.common.tests.Request;
+import io.vertx.grpc.eventbus.EventBusGrpcClient;
+import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
+import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class EventBusGrpcEndpointTest extends EventBusGrpcTestBase {
+
+  EventBusGrpcServer server;
+  EventBusGrpcClient client;
+
+  @Override
+  public void setUp(TestContext should) {
+    super.setUp(should);
+    client = EventBusGrpcClient.client(vertx, new EventBusGrpcClientOptions()
+      .setPingInterval(Duration.ofMillis(1))
+    ).await();
+    server = EventBusGrpcServer.server(vertx, new EventBusGrpcServerOptions()).await();
+  }
+
+  @Test
+  public void testCancellationWriteFailureShouldDisposeTheEndpoint(TestContext should) throws Exception {
+
+    Async test = should.async(2);
+
+    AtomicInteger numberOfPingFrames = new AtomicInteger();
+    vertx.eventBus().addOutboundInterceptor(new TransportInterceptor() {
+      @Override
+      protected Result onClientCancel(String serverAddress, String streamId) {
+        return Result.failure(new Exception("could not cancel"));
+      }
+      @Override
+      protected Result onPing(String srcAddress, String dstAddress, long data, boolean ack) {
+        numberOfPingFrames.incrementAndGet();
+        return super.onPing(srcAddress, dstAddress, data, ack);
+      }
+    });
+
+    server.callHandler(PIPE_SERVER, request -> {
+      request.handler(msg -> {
+        request.response().write(Reply.getDefaultInstance());
+      });
+    });
+
+    GrpcClientRequest<Request, Reply> request1 = client.request(PIPE_CLIENT).await();
+    request1.write(Request.getDefaultInstance()).await();
+    request1.exceptionHandler(err -> {
+      request1.exceptionHandler(null);
+      test.countDown();
+    });
+    request1.response().await();
+
+    GrpcClientRequest<Request, Reply> request2 = client.request(PIPE_CLIENT).await();
+    request2.exceptionHandler(err -> {
+      request2.exceptionHandler(null);
+      test.countDown();
+    });
+    request2.write(Request.getDefaultInstance()).await();
+    request1.response().await();
+
+    request2.cancel();
+    numberOfPingFrames.set(0);
+    test.awaitSuccess(20_000);
+    Thread.sleep(10);
+    should.assertEquals(0, numberOfPingFrames.get());
+  }
+}


### PR DESCRIPTION
Motivation:

The failure write of a cancellation frame triggers the endpoint to be taken down.

The implementation rely the stream remote endpoint field and this can be set to null when the stream is closed, resulting in not disposing the endpoint.

Changes:

Let the write failure uses the capture endpoint reference to attempt to dispose the endpoint.
