### PR TITLE
Register streams before the initial event bus interaction.

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -333,7 +333,7 @@ abstract class EventBusGrpcEndpoint {
       }
     }
 
-    private void close(Throwable cause, boolean notify) {
+    void close(Throwable cause, boolean notify) {
       assert localEndpoint.producerContext.inThread();
       if (!inboundClosed || !outboundClosed) {
         closeReason = cause;

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -5,6 +5,7 @@ import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.concurrent.InboundMessageQueue;
 import io.vertx.core.internal.concurrent.OutboundMessageQueue;
@@ -14,7 +15,6 @@ import io.vertx.grpc.common.impl.*;
 import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
 import io.vertx.grpc.eventbus.transport.v1alpha.*;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,6 +22,8 @@ import static io.vertx.grpc.eventbus.impl.EventBusHeaders.HEADER_PREFIX;
 import static io.vertx.grpc.eventbus.impl.EventBusHeaders.TRAILER_PREFIX;
 
 abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends EventBusGrpcEndpoint.StreamRegistration implements GrpcStream {
+
+  private static final Throwable CLOSED = new InvalidStatusException(GrpcStatus.OK, GrpcStatus.CANCELLED);
 
   protected final E localEndpoint;
   protected final ContextInternal consumerContext;
@@ -39,11 +41,11 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
 
   private long sequence;
 
-  private Throwable cause;
+  private Throwable closed;
+  private Throwable pendingWriteFailureCause;
 
   EventBusGrpcStreamBase(E localEndpoint, long id, ContextInternal context, boolean localUnary, boolean remoteUnary,
-                         int initialInboundWindowSize,
-                         int initialOutboundWindowSize) {
+                         int initialInboundWindowSize, int initialOutboundWindowSize) {
     super(localEndpoint, id);
     this.localEndpoint = localEndpoint;
     this.consumerContext = context;
@@ -51,12 +53,13 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     this.inboundQueue = new IMQ(context, initialInboundWindowSize);
     this.localUnary = localUnary;
     this.remoteUnary = remoteUnary;
-    this.outboundQueue = new OMQ(context, initialOutboundWindowSize);
+    this.outboundQueue = new OMQ(localEndpoint.producerContext().executor(), initialOutboundWindowSize);
     this.sequence = 1;
   }
 
   @Override
   protected final void handleClose(Throwable cause) {
+    closed = cause != null ? cause : CLOSED;
     consumerContext.execute(cause, err -> {
       if (cause != null) {
         failPendingWrites(cause);
@@ -214,29 +217,33 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     return new OutboundWrite(promise) {
       @Override
       void write() {
+        registerStream();
         localEndpoint.request(serviceName.fullyQualifiedName(), body, options)
           .onComplete(ar -> {
-            if (ar.succeeded()) {
-              Throwable malformed = handleReply(ar.result());
-              if (malformed == null) {
-                // Something specific to do ?
-              } else {
-                handleFailure(malformed, encoding, wireFormat);
-              }
-              promise.succeed();
+            Throwable c = closed;
+            if (c != null) {
+              promise.fail(c);
             } else {
-              InvalidStatusException err = handleFailure(ar.cause(), encoding, wireFormat);
-              promise.fail(err);
+              if (ar.succeeded()) {
+                Throwable malformed = handleReply(ar.result());
+                if (malformed == null) {
+                  promise.succeed();
+                } else {
+                  InvalidStatusException err = invalidStatusException(malformed);
+                  close(err, true);
+                  promise.fail(err);
+                }
+              } else {
+                InvalidStatusException err = invalidStatusException(ar.cause());
+                close(err, false);
+                promise.fail(err);
+              }
             }
           });
       }
 
-      private InvalidStatusException handleFailure(Throwable cause, String encoding, WireFormat wireFormat) {
+      private InvalidStatusException invalidStatusException(Throwable cause) {
         GrpcStatus status = EventBusGrpcCodec.mapFailure(cause);
-        emitInbound(Arrays.asList(
-          new DefaultGrpcHeadersFrame(wireFormat, encoding, MultiMap.caseInsensitiveMultiMap()),
-          new DefaultGrpcTrailersFrame(status, cause.getMessage(), MultiMap.caseInsensitiveMultiMap())
-        ));
         return new InvalidStatusException(GrpcStatus.OK, status);
       }
 
@@ -286,8 +293,6 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
             return new IllegalStateException("Malformed handshake reply: invalid grpc-initial-window header");
           }
         }
-
-        registerStream();
 
         if (serverAddress != null) {
           registerRemoteEndpoint(serverAddress, pingTimeout, serverFormat);
@@ -386,7 +391,7 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
   }
 
   protected void failPendingWrites(Throwable cause) {
-    this.cause = cause;
+    this.pendingWriteFailureCause = cause;
     outboundQueue.close();
   }
 
@@ -443,13 +448,11 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
 
   private class OMQ extends OutboundMessageQueue<OutboundWrite> {
 
-    private final ContextInternal context;
     private long window;
 
-    public OMQ(ContextInternal context, int initialWindowSize) {
-      super(context.executor());
+    public OMQ(EventExecutor eventExecutor, int initialWindowSize) {
+      super(eventExecutor);
 
-      this.context = context;
       this.window = initialWindowSize;
     }
 
@@ -466,26 +469,28 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
 
     @Override
     protected void handleDrained() {
-      Handler<Void> handler = drainHandler;
-      if (handler != null) {
-        handler.handle(null);
-      }
+      consumerContext.emit(v -> {
+        Handler<Void> handler = drainHandler;
+        if (handler != null) {
+          consumerContext.dispatch(null, handler);
+        }
+      });
     }
 
     @Override
     protected void handleDispose(OutboundWrite msg) {
-      Throwable c = cause;
+      Throwable c = pendingWriteFailureCause;
       if (c != null) {
         msg.cancel(c);
       }
     }
 
     private void updateWindow(int delta) {
-      if (context.inThread()) {
+      if (producerContext.inThread()) {
         window += delta;
         outboundQueue.tryDrain();
       } else {
-        context.execute(delta, this::updateWindow);
+        producerContext.execute(delta, this::updateWindow);
       }
     }
   }

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcEndpointTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcEndpointTest.java
@@ -1,18 +1,23 @@
 package io.vertx.grpc.eventbus.tests;
 
+import io.vertx.core.Future;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.client.GrpcClientRequest;
+import io.vertx.grpc.common.GrpcErrorException;
+import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.tests.Reply;
 import io.vertx.grpc.common.tests.Request;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
 import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
 import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
+import io.vertx.grpc.server.GrpcServerRequest;
 import org.junit.Test;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class EventBusGrpcEndpointTest extends EventBusGrpcTestBase {
 
@@ -73,5 +78,28 @@ public class EventBusGrpcEndpointTest extends EventBusGrpcTestBase {
     test.awaitSuccess(20_000);
     Thread.sleep(10);
     should.assertEquals(0, numberOfPingFrames.get());
+  }
+
+  @Test
+  public void testCloseClientStreamsAfterEndpointClose(TestContext should) {
+    Async latch = should.async();
+    AtomicReference<GrpcServerRequest<Request, Reply>> serverRequestRef = new AtomicReference<>();
+    server.callHandler(UNARY_SERVER, request -> {
+      serverRequestRef.set(request);
+      latch.complete();
+    });
+    GrpcClientRequest<Request, Reply> request = client.request(UNARY_CLIENT).await();
+    Future<Void> end = request.end(Request.getDefaultInstance());
+    latch.awaitSuccess(20_000);
+    client.close().await();
+    should.assertTrue(request.response().failed());
+    should.assertFalse(end.isComplete());
+    serverRequestRef.get().response().end(Reply.getDefaultInstance());
+    try {
+      end.await();
+      should.fail();
+    } catch (GrpcErrorException e) {
+      should.assertEquals(GrpcStatus.CANCELLED, e.error().status);
+    }
   }
 }

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
@@ -7,6 +7,7 @@ import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.*;
 import io.vertx.grpc.client.GrpcClientRequest;
@@ -278,11 +279,12 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
   }
 
   @Test
-  public void testQueuedWriteCompletesOnDrain() throws Exception {
+  public void testQueuedWriteCompletesOnDrain(TestContext should) throws Exception {
     AtomicBoolean stalled = new AtomicBoolean();
     AtomicInteger written = new AtomicInteger();
     AtomicInteger drains = new AtomicInteger();
     Promise<Void> queued = Promise.promise();
+    Async drainLatch = should.async();
 
     server.callHandler(SOURCE_SERVER, request -> request.handler(empty -> {
       GrpcServerResponse<Empty, Reply> response = request.response();
@@ -290,7 +292,11 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
       while (!response.writeQueueFull()) {
         response.write(Reply.newBuilder().setMessage("m-" + cnt++).build());
       }
-      response.drainHandler(v -> drains.incrementAndGet());
+      response.drainHandler(v -> {
+        if (drains.incrementAndGet() == 1) {
+          drainLatch.complete();
+        }
+      });
       Future<Void> write = response.write(Reply.newBuilder().setMessage("queued").build());
       stalled.set(!write.isComplete());
       written.set(1 + cnt);
@@ -314,7 +320,7 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
     assertTrue("the write must not complete while the message sits behind a closed window", stalled.get());
     queued.future().await(20, TimeUnit.SECONDS);
     assertEquals("queued", replies.get(replies.size() - 1).getMessage());
-    assertEquals(1, drains.get());
+    drainLatch.awaitSuccess(20_000);
   }
 
   @Test
@@ -480,8 +486,8 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
     // message is on the wire, so the following writes have no consumer to deliver to.
     vertx.eventBus().addOutboundInterceptor(new TransportInterceptor() {
       @Override
-      public Result onServerConnect(String serverAddress, String streamId) {
-        return Result.of(server.close());
+      protected Result onClientConnect(String clientAddress, String streamId) {
+        return Result.failure(new ReplyException(ReplyFailure.NO_HANDLERS));
       }
     });
 
@@ -491,8 +497,7 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
     try {
       request.write(Request.newBuilder().setName("a").build()).await(10, TimeUnit.SECONDS);
       fail("the write must fail once the server address has no consumer");
-    } catch (ReplyException e) {
-      assertEquals(ReplyFailure.NO_HANDLERS, e.failureType());
+    } catch (InvalidStatusException expected) {
     }
 
     // The stream is given up on rather than left hanging: the response is failed too.

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
@@ -170,7 +170,12 @@ public class TransportInterceptor implements Handler<DeliveryContext<Object>> {
         if (err == null) {
           apply(context, actions);
         } else {
-          context.fail(ReplyFailure.ERROR, 0, err.getMessage());
+          if (err instanceof ReplyException) {
+            ReplyException replyException = (ReplyException)err;
+            context.fail(replyException.failureType(), replyException.failureCode(), replyException.getMessage());
+          } else {
+            context.fail(ReplyFailure.ERROR, 0, err.getMessage());
+          }
         }
       });
     }


### PR DESCRIPTION
Motivation:

Streams are registered by the endpoint after the reply of the request interaction.

On an endpoint close, those streams are not disposed, and they should be.

Changes:

Register streams before the event bus request.

When we event bus response is obtained, we need to check the stream has not been closed in the mean time and fail accordingly the promise and simply give up on any other signal since the stream has been closed.

In addition better handle reply failures and close the stream accordingly instead of trying provide a regular response.

Finally fix a few context issues found with the outboud message queue of the stream.
