### PR TITLE
Upon a grpc event-bus stream close, the pending cancellation promise should be handled.

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
@@ -138,6 +138,7 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase<EventBusGrpcClientEn
     if (frame.type() == GrpcFrameType.HEADERS) {
       Promise<Void> c = cancellation;
       if (c != null) {
+        cancellation = null;
         if (localUnary && remoteUnary) {
           c.fail("Cannot cancel a unary/unary stream");
         } else {
@@ -230,9 +231,14 @@ class EventBusGrpcClientCall extends EventBusGrpcStreamBase<EventBusGrpcClientEn
   }
 
   @Override
-  void handleClosed() {
+  void handleConsumerClosed() {
     assert state != State.CLOSED;
     state = State.CLOSED;
+    Promise<Void> c = cancellation;
+    if (c != null) {
+      cancellation = null;
+      c.succeed();
+    }
   }
 
   private enum State {

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -268,7 +268,7 @@ abstract class EventBusGrpcEndpoint {
 
     abstract WireFormat format();
 
-    abstract void handleClose(Throwable cause);
+    abstract void handleProducerClosed(Throwable cause);
 
     final long id() {
       return id;
@@ -320,7 +320,7 @@ abstract class EventBusGrpcEndpoint {
       inboundClosed = true;
       if (outboundClosed) {
         remove();
-        handleClose(null);
+        handleProducerClosed(null);
       }
     }
 
@@ -329,7 +329,7 @@ abstract class EventBusGrpcEndpoint {
       outboundClosed = true;
       if (inboundClosed) {
         remove();
-        handleClose(null);
+        handleProducerClosed(null);
       }
     }
 
@@ -352,7 +352,7 @@ abstract class EventBusGrpcEndpoint {
           remoteEndpoint.producer.write(payload, options);
         }
         remove();
-        handleClose(cause);
+        handleProducerClosed(cause);
       }
     }
 

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
@@ -56,7 +56,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase<EventBusGrpcServerEn
   }
 
   @Override
-  void handleClosed() {
+  void handleConsumerClosed() {
     closed = true;
   }
 

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -23,8 +23,6 @@ import static io.vertx.grpc.eventbus.impl.EventBusHeaders.TRAILER_PREFIX;
 
 abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends EventBusGrpcEndpoint.StreamRegistration implements GrpcStream {
 
-  private static final Throwable CLOSED = new InvalidStatusException(GrpcStatus.OK, GrpcStatus.CANCELLED);
-
   protected final E localEndpoint;
   protected final ContextInternal consumerContext;
   protected final ContextInternal producerContext;
@@ -41,7 +39,8 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
 
   private long sequence;
 
-  private Throwable closed;
+  private boolean closed;
+  private Throwable closeCause;
   private Throwable pendingWriteFailureCause;
 
   EventBusGrpcStreamBase(E localEndpoint, long id, ContextInternal context, boolean localUnary, boolean remoteUnary,
@@ -58,14 +57,15 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
   }
 
   @Override
-  protected final void handleClose(Throwable cause) {
-    closed = cause != null ? cause : CLOSED;
+  protected final void handleProducerClosed(Throwable cause) {
+    closeCause = cause;
+    closed = true;
     consumerContext.execute(cause, err -> {
       if (cause != null) {
         failPendingWrites(cause);
         handleException(cause);
-        handleClosed();
       }
+      handleConsumerClosed();
     });
   }
 
@@ -106,7 +106,7 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     }
   }
 
-  abstract void handleClosed();
+  abstract void handleConsumerClosed();
 
   abstract WireFormat format();
 
@@ -220,9 +220,12 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
         registerStream();
         localEndpoint.request(serviceName.fullyQualifiedName(), body, options)
           .onComplete(ar -> {
-            Throwable c = closed;
-            if (c != null) {
-              promise.fail(c);
+            if (closed) {
+              Throwable cause = closeCause;
+              if (cause == null) {
+                cause = new VertxException("Stream closed");
+              }
+              promise.fail(cause);
             } else {
               if (ar.succeeded()) {
                 Throwable malformed = handleReply(ar.result());

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClientCancellationTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClientCancellationTest.java
@@ -1,5 +1,6 @@
 package io.vertx.grpc.eventbus.tests;
 
+import io.vertx.core.Future;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.client.GrpcClientRequest;
@@ -26,7 +27,7 @@ public class EventBusGrpcClientCancellationTest extends EventBusGrpcTestBase {
   public void setUp(TestContext should) {
     super.setUp(should);
     client = EventBusGrpcClient.client(vertx, new EventBusGrpcClientOptions()).await();
-    server = EventBusGrpcServer.server(vertx, new EventBusGrpcServerOptions().setInitialWindowSize(8)).await();
+    server = EventBusGrpcServer.server(vertx, new EventBusGrpcServerOptions()).await();
   }
 
   @Test
@@ -76,9 +77,28 @@ public class EventBusGrpcClientCancellationTest extends EventBusGrpcTestBase {
       .get()
       .response()
       .end(Reply.getDefaultInstance());
-    request.cancellation().onComplete(should.asyncAssertFailure(err -> {
+    Future<Void> cancellation = request.cancellation();
+    should.assertFalse(cancellation.isComplete());
+    should.assertTrue(request.isCancelled()); // Optimistic
+    cancellation.onComplete(should.asyncAssertFailure(err -> {
       should.assertFalse(request.isCancelled());
     }));
+  }
+
+  @Test
+  public void testClientUnaryCancelCompletesAfterClose(TestContext should) {
+    Async async = should.async();
+    server.callHandler(UNARY_SERVER, request -> {
+      async.complete();
+    });
+    GrpcClientRequest<Request, Reply> request = client.request(UNARY_CLIENT).await();
+    request.end(Request.getDefaultInstance());
+    async.awaitSuccess(20_000);
+    request.cancel();
+    Future<Void> cancellation = request.cancellation();
+    should.assertFalse(cancellation.isComplete());
+    client.close().await();
+    should.assertTrue(cancellation.isComplete());
   }
 
   @Test


### PR DESCRIPTION
Motivation:

When an event-bus stream closes, there might be a pending cancellation promise that has been set because the stream was connecting at cancellation time.

When that promise is still there, it should be completed.

Changes:

Complete the cancellation promise when a stream closes.
