### PR TITLE
Service proxy compatibility.

### DIFF
--- a/vertx-grpc-eventbus/README.md
+++ b/vertx-grpc-eventbus/README.md
@@ -37,15 +37,17 @@ of the event bus.
 
 ## Types of call
 
-The type of the method selects the part.
+Every call uses one event bus `request()` to the service address. The type of the method
+determines what follows.
 
-### Client Unary calls: a request and a reply
+### Unary calls: a request and a reply
 
 A unary call is one event bus `request()` call and its reply. The request contains these
 items:
 
-- The `action` header, which contains the name of the method.
-- The `grpc-wire-format` header, which contains the wire format.
+- `grpc-stream-method-name`, the name of the method.
+- `grpc-stream-wire-format`, the wire format.
+- `grpc-stream-id`, the stream identifier.
 - The headers with the `__header__.` prefix, which contain the request metadata.
 - The body, which contains the encoded message.
 
@@ -54,31 +56,29 @@ The reply contains the response message. The headers with the `__header__.` and
 not `OK` gives no reply. The server fails the event bus message with the gRPC status as
 the failure code and the status message as the failure message.
 
-A Vert.x service proxy uses the same format. This is intentional. A unary call and a
-service proxy call stay interchangeable on the bus. Therefore unary calls do not change,
-and only streams add new items.
-
 ### Streams: an upgrade handshake
 
-The event bus does not natively support streaming, instead any kind of streaming requires more than one request and one reply.
+The event bus does not natively support streaming, instead any kind of streaming requires
+more than one request and one reply.
 
-To open a stream, the client sends a request and receives a reply, this procedure is very much like an HTTP upgrade.
+To open a stream, the client sends a request and receives a reply, this procedure is very
+much like an HTTP upgrade.
 
 #### The request of the client
 
 The client sends the first `request()` call to the service address. The headers contain
 these items:
 
-- `action`, the name of the method.
-- `grpc-wire-format`, the wire format.
+- `grpc-stream-method-name`, the name of the method.
+- `grpc-stream-wire-format`, the wire format.
+- `grpc-stream-id`, the identifier that the client gives to this call.
 - `grpc-endpoint-address`, the private address of the client. Present when any side streams.
 - `grpc-endpoint-wire-format`, the wire format of the client endpoint. Present when any
   side streams.
-- `grpc-stream-id`, the identifier that the client gives to this call.
-- `grpc-initial-window`, the number of messages the client can receive. Present when the
-  server streams. The server uses this value as its send credit.
-- `grpc-ping-timeout`, the time in milliseconds that the client waits before it declares a
-  peer down. Present when the client streams. Refer to [Liveness](#liveness).
+- `grpc-stream-initial-window`, the number of messages the client can receive. Present when
+  the server streams. The server uses this value as its send credit.
+- `grpc-endpoint-ping-timeout`, the time in milliseconds that the client waits before it
+  declares a peer down. Present when the client streams. Refer to [Liveness](#liveness).
 - The request metadata, with the `__header__.` prefix.
 
 Depending on the client method type, the request body will differ, when the client
@@ -93,7 +93,7 @@ The server does these steps:
 1. Find the method.
 2. Prepare the call.
 3. Register the call.
-4. Reply with `grpc-endpoint-address`, `grpc-endpoint-wire-format`, and `grpc-initial-window`.
+4. Reply with `grpc-endpoint-address`, `grpc-endpoint-wire-format`, and `grpc-stream-initial-window`.
 
 The reply is only the signal to start. The server sends the reply before the handler
 operates. Therefore, the reply contains no response metadata.
@@ -154,9 +154,9 @@ sequenceDiagram
     participant S as Server
 
     Note over C,S: Open the stream. A request and a reply on the<br/>service address. The bodies are empty.
-    C->>S: request, headers action, grpc-wire-format,<br/>grpc-endpoint-address, grpc-endpoint-wire-format,<br/>grpc-stream-id, grpc-initial-window
+    C->>S: request, headers grpc-stream-method-name,<br/>grpc-stream-wire-format, grpc-stream-id,<br/>grpc-endpoint-address, grpc-endpoint-wire-format,<br/>grpc-stream-initial-window
     Note right of S: The method type is a stream.<br/>Register the call in the stream map.
-    S-->>C: reply, headers grpc-endpoint-address,<br/>grpc-endpoint-wire-format, grpc-initial-window
+    S-->>C: reply, headers grpc-endpoint-address,<br/>grpc-endpoint-wire-format, grpc-stream-initial-window
 
     Note over C,S: The call is now full duplex. Each frame contains<br/>the stream_id of the destination. Each direction<br/>counts its messages separately.
     C->>S: Message, stream_sequence 1, the first request message
@@ -176,9 +176,9 @@ server only after this registration is complete. Therefore the private address o
 endpoint always has a consumer when the handshake begins.
 
 Both sides exchange their inbound window in the handshake itself. The client sends
-`grpc-initial-window` in the request when the server streams, and the server sends
-`grpc-initial-window` in the reply when the client streams. Each side uses the window of
-the peer as its send credit. Therefore neither side starts at zero and no initial
+`grpc-stream-initial-window` in the request when the server streams, and the server sends
+`grpc-stream-initial-window` in the reply when the client streams. Each side uses the
+window of the peer as its send credit. Therefore neither side starts at zero and no initial
 `WindowUpdate` frame is necessary.
 
 ## Frames
@@ -186,8 +186,8 @@ the peer as its send credit. Therefore neither side starts at zero and no initia
 Each item of data after the handshake is a `TransportFrame` object. The wire format of the
 call gives the format of the frame. The default format is protobuf binary. In JSON mode,
 the format is JSON. The frame is the body of the event bus message. The
-`grpc-wire-format` header of the frame gives the format. Therefore the receiver knows how
-to read the frame.
+`grpc-stream-wire-format` header of the frame gives the format. Therefore the receiver
+knows how to read the frame.
 
 A frame contains a small header and one variant. The header contains the `stream_id` and
 `stream_sequence` values. The variant is one of these items:
@@ -225,11 +225,11 @@ The payload in a JSON frame stays as the message bytes. The frame contains these
 base64 data. The transport does not encode them again.
 
 The encoder and the decoder do not control all of the gRPC data. The delivery headers of
-the event bus contain this data. The map is the same for unary calls and for streams:
+the event bus contain this data. The map is as follows:
 
-- `action` contains the method.
+- `grpc-stream-method-name` contains the method.
+- `grpc-stream-wire-format` contains the wire format.
 - The headers with the `__header__.` and `__trailer__.` prefixes contain the metadata.
-- `grpc-wire-format` contains the wire format.
 
 The frame protobuf contains only the data that streams add.
 
@@ -287,10 +287,10 @@ bytes.
 
 The window is equivalent to the HTTP/2 `WINDOW_UPDATE` mechanism (RFC 7540, section 6.9),
 but at message level. Both sides exchange their inbound window in the handshake. The client
-sends `grpc-initial-window` in the request when the server streams, and the server sends
-`grpc-initial-window` in the reply when the client streams. Each side uses the window of
-the peer as its send credit. The endpoint uses one credit for each `Message` frame that it
-sends. At zero credits, the endpoint stops.
+sends `grpc-stream-initial-window` in the request when the server streams, and the server
+sends `grpc-stream-initial-window` in the reply when the client streams. Each side uses the
+window of the peer as its send credit. The endpoint uses one credit for each `Message`
+frame that it sends. At zero credits, the endpoint stops.
 
 The application of the receiver reads the messages. Then the receiver sends a
 `WindowUpdate` frame with a delta value. The sender adds this delta to its window.
@@ -411,6 +411,24 @@ streams behind one slow stream. This condition is head-of-line blocking.
 
 A slow reader keeps the `WindowUpdate` credit of its own stream. At the same time, the
 shared consumer continues to read the data of the other streams.
+
+## Service proxy compatibility
+
+The server also accepts Vert.x service proxy requests. A service proxy sends a request
+with the `action` header and a JSON body, but without `grpc-stream-method-name`. The
+server distinguishes the two forms by the presence of that header.
+
+When `grpc-stream-method-name` is absent, the server falls back to the service proxy
+form:
+
+- The method name comes from the `action` header.
+- The wire format is JSON.
+- The server generates the stream identifier.
+- Only unary methods are allowed. A streaming method is rejected with `INVALID_ARGUMENT`.
+
+The gRPC client also sends the `action` header on every request, so that the same service
+address can accept both forms. A service proxy consumer on the same address receives the
+`action` header and can process the call.
 
 ## Open questions and future work
 

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientEndpoint.java
@@ -12,13 +12,11 @@ import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
 import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
 
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class EventBusGrpcClientEndpoint extends EventBusGrpcEndpoint implements EventBusGrpcClient {
 
   private final VertxInternal vertx;
   private final WireFormat wireFormat;
-  private final AtomicInteger sequence = new AtomicInteger();
   final long pingTimeout;
 
   private EventBusGrpcClientEndpoint(ContextInternal producerContext, EventBusGrpcClientOptions options) {
@@ -34,10 +32,6 @@ public class EventBusGrpcClientEndpoint extends EventBusGrpcEndpoint implements 
       throw new IllegalArgumentException("pingTimeout (" + options.getPingTimeout() + ") must be greater than pingInterval (" + options.getPingInterval() + ")");
     }
     return options.getPingTimeout().toMillis();
-  }
-
-  long nextStreamId() {
-    return ((long)id()) << 32 | sequence.getAndIncrement();
   }
 
   public static Future<EventBusGrpcClient> create(Vertx vertx, EventBusGrpcClientOptions options) {

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCodec.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCodec.java
@@ -46,7 +46,7 @@ public final class EventBusGrpcCodec {
   }
 
   public static TransportFrame decodeFrame(Message<?> message) {
-    String header = message.headers().get(EventBusHeaders.WIRE_FORMAT);
+    String header = message.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT);
     WireFormat format = JsonWireFormat.NAME.equals(header) ? WireFormat.JSON : WireFormat.PROTOBUF;
     return FRAME_DECODER.decode(GrpcMessage.message("identity", format, decodeBody(message.body())));
   }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -17,6 +17,7 @@ import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
 
 import java.util.*;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 abstract class EventBusGrpcEndpoint {
@@ -26,6 +27,7 @@ abstract class EventBusGrpcEndpoint {
   private final EventBusInternal eventBus;
   private final String address;
   private final int id;
+  private final AtomicInteger sequence = new AtomicInteger();
   private final long pingInterval;
   private final LongObjectMap<EventBusGrpcStreamBase<?>> streams = new LongObjectHashMap<>();
   private final Map<String, RemoteEndpoint> remoteEndpoints = new HashMap<>();
@@ -63,6 +65,10 @@ abstract class EventBusGrpcEndpoint {
 
   public String address() {
     return address;
+  }
+
+  long nextStreamId() {
+    return ((long)id()) << 32 | sequence.getAndIncrement();
   }
 
   long pingInterval() {
@@ -119,7 +125,7 @@ abstract class EventBusGrpcEndpoint {
       for (RemoteEndpoint remoteEndpoint : toPing) {
         Ping.Builder ping = Ping.newBuilder().setData(data);
         DeliveryOptions options = new DeliveryOptions()
-          .addHeader(EventBusHeaders.WIRE_FORMAT, remoteEndpoint.format.name())
+          .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, remoteEndpoint.format.name())
           .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, address);
         remoteEndpoint.lastPingTimestamp = now;
         remoteEndpoint.producer
@@ -173,10 +179,10 @@ abstract class EventBusGrpcEndpoint {
       remoteEndpoint.lastSeenTimestamp = System.currentTimeMillis();
     }
     if (!ping.getAck()) {
-      String wireFormatName = message.headers().get(EventBusHeaders.WIRE_FORMAT);
+      String wireFormatName = message.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT);
       WireFormat wireFormat = JsonWireFormat.NAME.equals(wireFormatName) ? WireFormat.JSON : WireFormat.PROTOBUF;
       DeliveryOptions options = new DeliveryOptions()
-        .addHeader(EventBusHeaders.WIRE_FORMAT, wireFormat.name())
+        .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name())
         .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, address);
       Ping.Builder ack = Ping.newBuilder().setData(ping.getData()).setAck(true);
       eventBus.send(remoteAddress, EventBusGrpcCodec.encodeFrame(TransportFrame.newBuilder().setPing(ack).build(), wireFormat), options);
@@ -261,7 +267,7 @@ abstract class EventBusGrpcEndpoint {
     private Throwable closeReason;
 
     StreamRegistration(EventBusGrpcEndpoint localEndpoint, long id) {
-      assert id > 0;
+      assert id >= 0;
       this.localEndpoint = localEndpoint;
       this.id = id;
     }
@@ -276,6 +282,7 @@ abstract class EventBusGrpcEndpoint {
 
     final void registerStream() {
       assert localEndpoint.producerContext.inThread();
+      assert id > 0;
       localEndpoint.streams.put(id, (EventBusGrpcStreamBase<?>) this);
     }
 
@@ -304,7 +311,7 @@ abstract class EventBusGrpcEndpoint {
         if (options == null) {
           options = new DeliveryOptions();
         }
-        options.addHeader(EventBusHeaders.WIRE_FORMAT, wireFormat.name());
+        options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name());
         MessageProducer<Object> producer = remote.producer;
         Future<Void> res = producer.write(payload, options);
         return res.andThen(ar -> {
@@ -347,7 +354,7 @@ abstract class EventBusGrpcEndpoint {
             .build();
           WireFormat format = format();
           DeliveryOptions options = new DeliveryOptions();
-          options.addHeader(EventBusHeaders.WIRE_FORMAT, format.name());
+          options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, format.name());
           Object payload = EventBusGrpcCodec.encodeFrame(frame, format);
           remoteEndpoint.producer.write(payload, options);
         }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
@@ -171,7 +171,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase<EventBusGrpcServerEn
       DeliveryOptions replyOptions = new DeliveryOptions()
         .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address())
         .addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, format().name())
-        .addHeader(EventBusHeaders.INITIAL_WINDOW, Integer.toString(localEndpoint.initialWindowSize));
+        .addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, Integer.toString(localEndpoint.initialWindowSize));
 
       msg.reply(null, replyOptions);
     }
@@ -210,7 +210,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase<EventBusGrpcServerEn
         EventBusHeaders.encodeMultiMap(HEADER_PREFIX, headers, delivery);
         options.setHeaders(delivery);
       }
-      options.addHeader(EventBusHeaders.WIRE_FORMAT, wireFormat.name());
+      options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name());
       return sendTransportFrame(TransportFrame.newBuilder().setHeaders(Headers.newBuilder()), options);
     }
   }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
@@ -221,25 +221,43 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
 
     @Override
     public void handle(Message<Object> message) {
-      String methodName = message.headers().get(EventBusHeaders.ACTION);
-      if (methodName == null) {
-        message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Missing '" + EventBusHeaders.ACTION + "' header");
-        return;
-      }
-      String wireFormatName = message.headers().get(EventBusHeaders.WIRE_FORMAT);
-      if (wireFormatName == null) {
-        message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Missing '" + EventBusHeaders.WIRE_FORMAT + "' header");
-        return;
-      }
 
+      boolean isServiceProxy;
       WireFormat wireFormat;
-      if (ProtobufWireFormat.NAME.equals(wireFormatName)) {
-        wireFormat = WireFormat.PROTOBUF;
-      } else if (JsonWireFormat.NAME.equals(wireFormatName)) {
+      long streamId;
+      String methodName = message.headers().get(EventBusHeaders.STREAM_METHOD_NAME);
+      if (methodName == null) {
+        methodName = message.headers().get(EventBusHeaders.SERVICE_PROXY_ACTION);
+        if (methodName == null) {
+          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Missing '" + EventBusHeaders.SERVICE_PROXY_ACTION + "' header");
+          return;
+        }
+        isServiceProxy = true;
         wireFormat = WireFormat.JSON;
+        streamId = nextStreamId();
       } else {
-        message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Unknown wire format: " + wireFormatName);
-        return;
+        isServiceProxy = false;
+        String wireFormatName = message.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT);
+        if (ProtobufWireFormat.NAME.equals(wireFormatName)) {
+          wireFormat = WireFormat.PROTOBUF;
+        } else if (JsonWireFormat.NAME.equals(wireFormatName)) {
+          wireFormat = WireFormat.JSON;
+        } else {
+          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Unknown wire format: " + wireFormatName);
+          return;
+        }
+        String clientStreamIdHeader = message.headers().get(EventBusHeaders.STREAM_ID);
+        if (clientStreamIdHeader == null) {
+          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Missing '" + EventBusHeaders.STREAM_ID + "' header");
+          return;
+        } else {
+          try {
+            streamId = Long.parseLong(clientStreamIdHeader);
+          } catch (NumberFormatException e) {
+            message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Invalid '" + EventBusHeaders.STREAM_ID + "' header: " + clientStreamIdHeader);
+            return;
+          }
+        }
       }
 
       if (!supportedWireFormats.contains(wireFormat)) {
@@ -257,12 +275,17 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
 
       if (serviceMethod == null) {
         message.fail(GrpcStatus.UNIMPLEMENTED.code, "Method not found: " + methodName);
-        return;
+      } else if (isServiceProxy && (serviceMethod.clientStreaming() || serviceMethod.serverStreaming())) {
+        message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Unsupported service proxy action");
+      } else {
+        dispatchStreaming(message, serviceMethod, streamId, wireFormat);
       }
-      dispatchStreaming(message, serviceMethod, wireFormat);
     }
 
-    private <Req, Resp> void dispatchStreaming(Message<Object> message, ServiceMethod<Req, Resp> serviceMethod, WireFormat wireFormat) {
+    private <Req, Resp> void dispatchStreaming(Message<Object> message,
+                                               ServiceMethod<Req, Resp> serviceMethod,
+                                               long streamId,
+                                               WireFormat wireFormat) {
       boolean needClientAddress = serviceMethod.serverStreaming() || serviceMethod.clientStreaming();
       String clientAddress = message.headers().get(EventBusHeaders.ENDPOINT_ADDRESS);
       String s = message.headers().get(EventBusHeaders.ENDPOINT_WIRE_FORMAT);
@@ -302,36 +325,22 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
 
       int initialOutboundWindowSize;
       if (serviceMethod.serverStreaming()) {
-        String initialWindowHeader = message.headers().get(EventBusHeaders.INITIAL_WINDOW);
+        String initialWindowHeader = message.headers().get(EventBusHeaders.STREAM_INITIAL_WINDOW);
         if (initialWindowHeader == null) {
-          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Missing '" + EventBusHeaders.INITIAL_WINDOW + "' header");
+          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Missing '" + EventBusHeaders.STREAM_INITIAL_WINDOW + "' header");
           return;
         }
         try {
           initialOutboundWindowSize = Integer.parseInt(initialWindowHeader);
         } catch (NumberFormatException e) {
-          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Invalid '" + EventBusHeaders.INITIAL_WINDOW + "' header");
+          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Invalid '" + EventBusHeaders.STREAM_INITIAL_WINDOW + "' header");
           return;
         }
       } else {
         initialOutboundWindowSize = EventBusGrpcClientOptions.DEFAULT_INITIAL_WINDOW_SIZE;
       }
 
-      String clientStreamIdHeader = message.headers().get(EventBusHeaders.STREAM_ID);
-      long streamId;
-      if (clientStreamIdHeader == null) {
-        message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Missing '" + EventBusHeaders.STREAM_ID + "' header");
-        return;
-      } else {
-        try {
-          streamId = Long.parseLong(clientStreamIdHeader);
-        } catch (NumberFormatException e) {
-          message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Invalid '" + EventBusHeaders.STREAM_ID + "' header: " + clientStreamIdHeader);
-          return;
-        }
-      }
-
-      long remoteTimeout = remoteTimeout(message.headers().get(EventBusHeaders.PING_TIMEOUT));
+      long remoteTimeout = remoteTimeout(message.headers().get(EventBusHeaders.ENDPOINT_PING_TIMEOUT));
 
       EventBusGrpcServerCall stream = new EventBusGrpcServerCall(
         EventBusGrpcServerEndpoint.this,

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -185,7 +185,7 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
 
     if (localUnary) {
       if (!remoteUnary) {
-        options.addHeader(EventBusHeaders.INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
+        options.addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
         options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, wireFormat.name());
         options.addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address());
       }
@@ -193,10 +193,10 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
       options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, wireFormat.name());
       options.addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address());
       if (!remoteUnary) {
-        options.addHeader(EventBusHeaders.INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
+        options.addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
       }
       if (pingTimeout > 0) {
-        options.addHeader(EventBusHeaders.PING_TIMEOUT, Long.toString(pingTimeout));
+        options.addHeader(EventBusHeaders.ENDPOINT_PING_TIMEOUT, Long.toString(pingTimeout));
       }
     }
 
@@ -204,8 +204,9 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
       options.setSendTimeout(timeout.toMillis());
     }
 
-    options.addHeader(EventBusHeaders.ACTION, methodName);;
-    options.addHeader(EventBusHeaders.WIRE_FORMAT, wireFormat.name());
+    options.addHeader(EventBusHeaders.SERVICE_PROXY_ACTION, methodName);;
+    options.addHeader(EventBusHeaders.STREAM_METHOD_NAME, methodName);;
+    options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name());
     options.addHeader(EventBusHeaders.STREAM_ID, Long.toString(id()));
 
     if (requestHeaders != null) {
@@ -283,7 +284,7 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
         if (remoteUnary) {
           initialOutboundWindowSize = EventBusGrpcServerOptions.DEFAULT_INITIAL_WINDOW_SIZE;
         } else {
-          String initialWindowHeader = reply.headers().get(EventBusHeaders.INITIAL_WINDOW);
+          String initialWindowHeader = reply.headers().get(EventBusHeaders.STREAM_INITIAL_WINDOW);
           if (initialWindowHeader == null) {
             return new IllegalStateException("Malformed handshake reply: missing grpc-initial-window header");
           }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusHeaders.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusHeaders.java
@@ -10,14 +10,9 @@ import java.util.Map;
 public final class EventBusHeaders {
 
   /**
-   * The gRPC method name, e.g. {@code "SayHello"}.
+   * The service proxy action, e.g. {@code "SayHello"}.
    */
-  public static final String ACTION = "action";
-
-  /**
-   * The wire format, carrying the {@link io.vertx.grpc.common.WireFormat#name()} value, e.g. {@code "proto"} or {@code "json"}.
-   */
-  public static final String WIRE_FORMAT = "grpc-wire-format";
+  public static final String SERVICE_PROXY_ACTION = "action";
 
   /**
    * The endpoint wire format, carrying the {@link io.vertx.grpc.common.WireFormat#name()} value, e.g. {@code "proto"} or {@code "json"}, used
@@ -31,6 +26,22 @@ public final class EventBusHeaders {
   public static final String ENDPOINT_ADDRESS = "grpc-endpoint-address";
 
   /**
+   * Streaming handshake, client to server: how long in milliseconds the client may go unheard before it is considered gone, the same deadline the client applies to this server, so
+   * both sides give the stream up at the same time. Absent when the client does not ping.
+   */
+  public static final String ENDPOINT_PING_TIMEOUT = "grpc-endpoint-ping-timeout";
+
+  /**
+   * The gRPC method name , e.g. {@code "SayHello"}.
+   */
+  public static final String STREAM_METHOD_NAME = "grpc-stream-method-name";
+
+  /**
+   * The wire format, carrying the {@link io.vertx.grpc.common.WireFormat#name()} value, e.g. {@code "proto"} or {@code "json"}.
+   */
+  public static final String STREAM_WIRE_FORMAT = "grpc-stream-wire-format";
+
+  /**
    * Streaming handshake, client to server: the stream's id for this call, used to demux server to identify frames.
    */
   public static final String STREAM_ID = "grpc-stream-id";
@@ -38,13 +49,7 @@ public final class EventBusHeaders {
   /**
    * Streaming handshake, server to client: the number of messages the server grants the client to send.
    */
-  public static final String INITIAL_WINDOW = "grpc-initial-window";
-
-  /**
-   * Streaming handshake, client to server: how long in milliseconds the client may go unheard before it is considered gone, the same deadline the client applies to this server, so
-   * both sides give the stream up at the same time. Absent when the client does not ping.
-   */
-  public static final String PING_TIMEOUT = "grpc-ping-timeout";
+  public static final String STREAM_INITIAL_WINDOW = "grpc-stream-initial-window";
 
   /**
    * The prefix for grpc headers among delivery options.

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClientTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClientTest.java
@@ -35,8 +35,9 @@ public class EventBusGrpcClientTest extends EventBusGrpcTestBase {
   @Test
   public void testRequestReplyProtobuf(TestContext testContext) throws Exception {
     vertx.eventBus().<Buffer> consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> {
-      testContext.assertEquals("Unary", msg.headers().get("action"));
-      testContext.assertEquals(WireFormat.PROTOBUF.name(), msg.headers().get("grpc-wire-format"));
+      testContext.assertEquals("Unary", msg.headers().get(EventBusHeaders.SERVICE_PROXY_ACTION));
+      testContext.assertEquals("Unary", msg.headers().get(EventBusHeaders.STREAM_METHOD_NAME));
+      testContext.assertEquals(WireFormat.PROTOBUF.name(), msg.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT));
       try {
         Request request = Request.parseFrom(msg.body().getBytes());
         Reply reply = Reply.newBuilder().setMessage("Hello " + request.getName()).build();
@@ -62,8 +63,9 @@ public class EventBusGrpcClientTest extends EventBusGrpcTestBase {
   @Test
   public void testRequestReplyJson(TestContext testContext) throws TimeoutException {
     vertx.eventBus().<JsonObject> consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> {
-      testContext.assertEquals("Unary", msg.headers().get("action"));
-      testContext.assertEquals(WireFormat.JSON.name(), msg.headers().get("grpc-wire-format"));
+      testContext.assertEquals("Unary", msg.headers().get(EventBusHeaders.SERVICE_PROXY_ACTION));
+      testContext.assertEquals("Unary", msg.headers().get(EventBusHeaders.STREAM_METHOD_NAME));
+      testContext.assertEquals(WireFormat.JSON.name(), msg.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT));
       String name = msg.body().getString("name");
       msg.reply(new JsonObject().put("message", "Hello " + name));
     });

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcServerTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcServerTest.java
@@ -47,9 +47,9 @@ public class EventBusGrpcServerTest extends EventBusGrpcTestBase {
 
     Buffer payload = Buffer.buffer(Request.newBuilder().setName("Julien").build().toByteArray());
     DeliveryOptions opts = new DeliveryOptions()
-      .addHeader(EventBusHeaders.ACTION, "Unary")
+      .addHeader(EventBusHeaders.STREAM_METHOD_NAME, "Unary")
       .addHeader(EventBusHeaders.STREAM_ID, "1")
-      .addHeader(EventBusHeaders.WIRE_FORMAT, WireFormat.PROTOBUF.name());
+      .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, WireFormat.PROTOBUF.name());
 
     Buffer body = vertx.eventBus().<Buffer> request(ADDRESS, payload, opts).map(Message::body).await(10, TimeUnit.SECONDS);
 
@@ -65,9 +65,9 @@ public class EventBusGrpcServerTest extends EventBusGrpcTestBase {
     }));
 
     DeliveryOptions opts = new DeliveryOptions()
-      .addHeader(EventBusHeaders.ACTION, "Unary")
+      .addHeader(EventBusHeaders.STREAM_METHOD_NAME, "Unary")
       .addHeader(EventBusHeaders.STREAM_ID, "1")
-      .addHeader(EventBusHeaders.WIRE_FORMAT, WireFormat.JSON.name());
+      .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, WireFormat.JSON.name());
 
     JsonObject payload = new JsonObject().put("name", "Julien");
     JsonObject body = vertx.eventBus().<JsonObject> request(ADDRESS, payload, opts).map(Message::body).await(10, TimeUnit.SECONDS);
@@ -81,9 +81,9 @@ public class EventBusGrpcServerTest extends EventBusGrpcTestBase {
 
     Buffer payload = Buffer.buffer(Request.newBuilder().setName("Julien").build().toByteArray());
     DeliveryOptions opts = new DeliveryOptions()
-      .addHeader(EventBusHeaders.ACTION, "Unary")
+      .addHeader(EventBusHeaders.STREAM_METHOD_NAME, "Unary")
       .addHeader(EventBusHeaders.STREAM_ID, "1")
-      .addHeader(EventBusHeaders.WIRE_FORMAT, WireFormat.PROTOBUF.name());
+      .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, WireFormat.PROTOBUF.name());
 
     try {
       vertx.eventBus().<Buffer> request(ADDRESS, payload, opts).await(10, TimeUnit.SECONDS);
@@ -102,9 +102,9 @@ public class EventBusGrpcServerTest extends EventBusGrpcTestBase {
 
     Buffer payload = Buffer.buffer(Request.newBuilder().setName("Julien").build().toByteArray());
     DeliveryOptions opts = new DeliveryOptions()
-      .addHeader(EventBusHeaders.ACTION, "Unary")
+      .addHeader(EventBusHeaders.STREAM_METHOD_NAME, "Unary")
       .addHeader(EventBusHeaders.STREAM_ID, "1")
-      .addHeader(EventBusHeaders.WIRE_FORMAT, WireFormat.PROTOBUF.name());
+      .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, WireFormat.PROTOBUF.name());
 
     try {
       vertx.eventBus().<Buffer> request(ADDRESS, payload, opts).await(10, TimeUnit.SECONDS);
@@ -122,8 +122,9 @@ public class EventBusGrpcServerTest extends EventBusGrpcTestBase {
 
     Buffer payload = Buffer.buffer(Request.newBuilder().setName("Julien").build().toByteArray());
     DeliveryOptions opts = new DeliveryOptions()
-      .addHeader(EventBusHeaders.ACTION, "Unary")
-      .addHeader(EventBusHeaders.WIRE_FORMAT, WireFormat.PROTOBUF.name());
+      .addHeader(EventBusHeaders.STREAM_METHOD_NAME, "Unary")
+      .addHeader(EventBusHeaders.STREAM_ID, "1")
+      .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, WireFormat.PROTOBUF.name());
 
     try {
       vertx.eventBus().<Buffer> request(ADDRESS, payload, opts).await(10, TimeUnit.SECONDS);
@@ -143,9 +144,9 @@ public class EventBusGrpcServerTest extends EventBusGrpcTestBase {
 
     Buffer payload = Buffer.buffer(Request.newBuilder().setName("Julien").build().toByteArray());
     DeliveryOptions opts = new DeliveryOptions()
-      .addHeader(EventBusHeaders.ACTION, "Unary")
+      .addHeader(EventBusHeaders.STREAM_METHOD_NAME, "Unary")
       .addHeader(EventBusHeaders.STREAM_ID, "1")
-      .addHeader(EventBusHeaders.WIRE_FORMAT, WireFormat.PROTOBUF.name());
+      .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, WireFormat.PROTOBUF.name());
 
     Buffer body = vertx.eventBus().<Buffer> request(ADDRESS, payload, opts).map(Message::body).await(10, TimeUnit.SECONDS);
 
@@ -173,9 +174,9 @@ public class EventBusGrpcServerTest extends EventBusGrpcTestBase {
     }));
 
     DeliveryOptions opts = new DeliveryOptions()
-      .addHeader(EventBusHeaders.ACTION, "Unary")
+      .addHeader(EventBusHeaders.STREAM_METHOD_NAME, "Unary")
       .addHeader(EventBusHeaders.STREAM_ID, "1")
-      .addHeader(EventBusHeaders.WIRE_FORMAT, WireFormat.PROTOBUF.name())
+      .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, WireFormat.PROTOBUF.name())
       .addHeader(EventBusHeaders.HEADER_PREFIX + "x-custom", "request_header_value");
 
     Buffer payload = Buffer.buffer(Request.newBuilder().setName("Julien").build().toByteArray());
@@ -186,5 +187,21 @@ public class EventBusGrpcServerTest extends EventBusGrpcTestBase {
     assertEquals("Header: request_header_value", reply.getMessage());
     assertEquals("response_header_value", replyMsg.headers().get(EventBusHeaders.HEADER_PREFIX + "x-custom"));
     assertEquals("response_trailer_value", replyMsg.headers().get(EventBusHeaders.TRAILER_PREFIX + "x-custom"));
+  }
+
+  @Test
+  public void testServiceProxyInterrop() throws Exception {
+    server.callHandler(UNARY_SERVER, request -> request.handler(msg -> {
+      Reply reply = Reply.newBuilder().setMessage("Hello " + msg.getName()).build();
+      request.response().end(reply);
+    }));
+
+    DeliveryOptions opts = new DeliveryOptions()
+      .addHeader(EventBusHeaders.SERVICE_PROXY_ACTION, "Unary");
+
+    JsonObject payload = new JsonObject().put("name", "Julien");
+    JsonObject body = vertx.eventBus().<JsonObject> request(ADDRESS, payload, opts).map(Message::body).await(10, TimeUnit.SECONDS);
+
+    assertEquals("Hello Julien", body.getString("message"));
   }
 }

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
@@ -636,8 +636,8 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
 
     // Open the stream by hand, omitting the advertisement a real client would send.
     DeliveryOptions handshake = new DeliveryOptions()
-      .addHeader(EventBusHeaders.ACTION, "Sink")
-      .addHeader(EventBusHeaders.WIRE_FORMAT, WireFormat.PROTOBUF.name())
+      .addHeader(EventBusHeaders.STREAM_METHOD_NAME, "Sink")
+      .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, WireFormat.PROTOBUF.name())
       .addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, WireFormat.PROTOBUF.name())
       .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, "grpc.eb.client.silent")
       .addHeader(EventBusHeaders.STREAM_ID, "1");
@@ -1026,8 +1026,8 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
     server.callHandler(SOURCE_SERVER, request -> request.handler(empty -> request.response().end()));
 
     DeliveryOptions options = new DeliveryOptions()
-      .addHeader(EventBusHeaders.ACTION, "Source")
-      .addHeader(EventBusHeaders.WIRE_FORMAT, "NOT_A_FORMAT")
+      .addHeader(EventBusHeaders.SERVICE_PROXY_ACTION, "Source")
+      .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, "NOT_A_FORMAT")
       .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, "c.addr")
       .addHeader(EventBusHeaders.STREAM_ID, "1")
       .setSendTimeout(3000);

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusWireFormatTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusWireFormatTest.java
@@ -34,7 +34,7 @@ public class EventBusWireFormatTest extends EventBusGrpcTestBase {
       MultiMap headers = ctx
         .message()
         .headers();
-      String wireFormat = headers.get(EventBusHeaders.WIRE_FORMAT);
+      String wireFormat = headers.get(EventBusHeaders.STREAM_WIRE_FORMAT);
       if (wireFormat != null) {
         try {
           payloadHandler.accept(wireFormat, ctx.message().body());

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
@@ -40,8 +40,8 @@ public class TransportInterceptor implements Handler<DeliveryContext<Object>> {
     Deque<Supplier<Result>> actions = new ArrayDeque<>();
     Message<?> msg = ctx.message();
     MultiMap headers = msg.headers();
-    String actionHeader = headers.get(EventBusHeaders.ACTION);
-    String formatHeader = headers.get(EventBusHeaders.WIRE_FORMAT);
+    String actionHeader = headers.get(EventBusHeaders.SERVICE_PROXY_ACTION);
+    String formatHeader = headers.get(EventBusHeaders.STREAM_WIRE_FORMAT);
     WireFormat wireFormat;
     if (formatHeader != null) {
       switch (formatHeader) {


### PR DESCRIPTION
Motivation:

Currently the implementation of unary streams is a mix between gRPC and service proxy.

Instead we should have gRPC streams have their own headers and service proxy should be compatible with the endpoint format.

Changes:

Use grpc-stream-method-name to carry the service method name.

The service proxy action header is instead detected by the server and switch to an emulation mode that does not require a stream id to be provided nor the wire format to be specified.

The service proxy action header is send by the client along with the grpc-stream-method-name.
