### PR TITLE
gRPC over event-bus stream corruption detection.

### DIFF
--- a/vertx-grpc-eventbus/README.md
+++ b/vertx-grpc-eventbus/README.md
@@ -137,6 +137,7 @@ The endpoint removes a stream from the map when the stream ends with trailers or
 
 - The endpoint cannot deliver a frame.
 - The peer of the stream does not answer. Refer to [Liveness](#liveness).
+- A frame arrives out of order. Refer to [Frame ordering](#frame-ordering).
 
 Therefore, a peer that leaves the cluster does not cause a registration to stay in the
 map.
@@ -158,14 +159,14 @@ sequenceDiagram
     Note right of S: The method type is a stream.<br/>Register the call in the stream map.
     S-->>C: reply, headers grpc-endpoint-address,<br/>grpc-endpoint-wire-format, grpc-stream-initial-window
 
-    Note over C,S: The call is now full duplex. Each frame contains<br/>the stream_id of the destination. Each direction<br/>counts its messages separately.
-    C->>S: Message, stream_sequence 1, the first request message
-    S->>C: Headers, the response metadata
-    S->>C: Message, stream_sequence 1
-    C->>S: Message, stream_sequence 2
-    C->>S: HalfClose, the client sends no more messages
+    Note over C,S: The call is now full duplex. Each frame contains<br/>the stream_id of the destination. Content frames<br/>carry an incrementing stream_sequence per direction.<br/>Control frames (WindowUpdate) carry stream_sequence 0.
+    C->>S: Message, stream_sequence 1
+    S->>C: Headers, stream_sequence 1
     S->>C: Message, stream_sequence 2
-    S->>C: Trailers, the status
+    C->>S: Message, stream_sequence 2
+    C->>S: HalfClose, stream_sequence 3
+    S->>C: Message, stream_sequence 3
+    S->>C: Trailers, stream_sequence 4
     Note over C,S: The two endpoints remove the stream from their<br/>maps. The call is complete.
 ```
 
@@ -198,6 +199,20 @@ A frame contains a small header and one variant. The header contains the `stream
 - `Headers` or `Trailers`, from the server.
 - `Cancel`, from the client or from the server.
 - `Ping`, a liveness probe, from the client or from the server.
+
+### Frame ordering
+
+Content frames — `Message`, `Headers`, `Trailers`, and `HalfClose` — carry an
+incrementing `stream_sequence` value. Each direction counts independently, starting from
+1. Control frames (`WindowUpdate`) carry `stream_sequence` 0 and are not sequenced.
+
+The receiver tracks the expected sequence for each stream. When a content frame arrives
+with a `stream_sequence` that does not match the expected value, the receiver cancels the
+stream and sends a `Cancel` frame to the peer. This condition indicates that a frame was
+lost or reordered in transit, which can happen on a clustered event bus.
+
+The `Ping` and `Cancel` frames bypass the sequence check. A `Ping` frame is not related
+to a stream. A `Cancel` frame stops the stream immediately, regardless of order.
 
 A `Ping` frame is not related to a call. Therefore, it has the `stream_id` value 0. The
 endpoint processes this frame and does not send it to a stream. The `grpc-endpoint-address`
@@ -447,10 +462,10 @@ direction for each function.
   in addition to the window of each stream. Therefore a connection can limit the total
   quantity of data in its buffers. The equivalent function is a window for all the streams
   that use one private address. This function needs the `session_id` value above.
-- **Resumption.** Each `Message` frame contains a `stream_sequence` value. This value
-  permits a future function. A client that loses its connection can connect again. The
-  client can then ask the server to send again all the messages after the last sequence
-  value that it received. The MCP `Last-Event-ID` function has the same purpose. Two items
+- **Resumption.** Each content frame contains a `stream_sequence` value. The sequence
+  currently detects out-of-order delivery. It also permits a future resumption function. A
+  client that loses its connection can connect again. The client can then ask the server to
+  send again all the messages after the last sequence value that it received. The MCP `Last-Event-ID` function has the same purpose. Two items
   are necessary: a handshake for the new connection, and a replay buffer with a limit. To
   continue after a node failure, and not only after a lost connection, the session data
   must be in a shared or permanent store. This store can be an SPI with a local default

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -165,7 +165,7 @@ abstract class EventBusGrpcEndpoint {
     EventBusGrpcStreamBase<?> stream = streams.get(frame.getStreamId());
     if (stream != null) {
       if (frame.getFrameCase() == TransportFrame.FrameCase.CANCEL) {
-        ((StreamRegistration)stream).close(new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED), false);
+        stream.close(new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED), false);
       } else {
         stream.handle(frame, message);
       }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -37,7 +37,8 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
   private final OMQ outboundQueue;
   private final IMQ inboundQueue;
 
-  private long sequence;
+  private long outboundSequence;
+  private long inboundSequence;
 
   private boolean closed;
   private Throwable closeCause;
@@ -53,7 +54,8 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     this.localUnary = localUnary;
     this.remoteUnary = remoteUnary;
     this.outboundQueue = new OMQ(localEndpoint.producerContext().executor(), initialOutboundWindowSize);
-    this.sequence = 1;
+    this.outboundSequence = 1;
+    this.inboundSequence = 1;
   }
 
   @Override
@@ -77,32 +79,37 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
   }
 
   void handle(TransportFrame frame, io.vertx.core.eventbus.Message<Object> message) {
-    switch (frame.getFrameCase()) {
-      case WINDOW_UPDATE:
-        updateOutboundWindow(frame.getWindowUpdate().getDelta());
-        break;
-      case HEADERS:
-        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
-        EventBusHeaders.decodeMultimap(HEADER_PREFIX, message.headers(), headers);
-        emitInbound(new DefaultGrpcHeadersFrame(format(), encoding(), headers));
-        break;
-      case MESSAGE:
-        emitInbound(new DefaultGrpcMessageFrame(EventBusGrpcCodec.message(frame, encoding(), format())));
-        break;
-      case HALF_CLOSE:
-        emitInbound(DefaultGrpcHalfCloseFrame.INSTANCE);
-        closeInbound();
-        break;
-      case TRAILERS:
-        Trailers t = frame.getTrailers();
-        MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
-        EventBusHeaders.decodeMultimap(TRAILER_PREFIX, message.headers(), trailers);
-        GrpcStatus status = Optional.ofNullable(GrpcStatus.valueOf(t.getStatus())).orElse(GrpcStatus.UNKNOWN);
-        emitInbound(new DefaultGrpcTrailersFrame(status, t.getStatusMessage().isEmpty() ? null : t.getStatusMessage(), trailers));
-        closeInbound();
-        break;
-      default:
-        break;
+    long sequence;
+    if ((sequence = frame.getStreamSequence()) > 0 && sequence != inboundSequence++) {
+      close(new GrpcErrorException(GrpcError.CANCELLED, GrpcStatus.CANCELLED), true);
+    } else {
+      switch (frame.getFrameCase()) {
+        case WINDOW_UPDATE:
+          updateOutboundWindow(frame.getWindowUpdate().getDelta());
+          break;
+        case HEADERS:
+          MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+          EventBusHeaders.decodeMultimap(HEADER_PREFIX, message.headers(), headers);
+          emitInbound(new DefaultGrpcHeadersFrame(format(), encoding(), headers));
+          break;
+        case MESSAGE:
+          emitInbound(new DefaultGrpcMessageFrame(EventBusGrpcCodec.message(frame, encoding(), format())));
+          break;
+        case HALF_CLOSE:
+          emitInbound(DefaultGrpcHalfCloseFrame.INSTANCE);
+          closeInbound();
+          break;
+        case TRAILERS:
+          Trailers t = frame.getTrailers();
+          MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
+          EventBusHeaders.decodeMultimap(TRAILER_PREFIX, message.headers(), trailers);
+          GrpcStatus status = Optional.ofNullable(GrpcStatus.valueOf(t.getStatus())).orElse(GrpcStatus.UNKNOWN);
+          emitInbound(new DefaultGrpcTrailersFrame(status, t.getStatusMessage().isEmpty() ? null : t.getStatusMessage(), trailers));
+          closeInbound();
+          break;
+        default:
+          break;
+      }
     }
   }
 
@@ -216,6 +223,10 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     Promise<Void> promise = consumerContext.promise();
 
     return new OutboundWrite(promise) {
+      @Override
+      long sequence() {
+        return 0L;
+      }
       @Override
       void write() {
         registerStream();
@@ -337,7 +348,7 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     }
   }
 
-  private OutboundFrameMessage messageFrameWrite(GrpcMessage message) {
+  private OutboundFrameWrite messageFrameWrite(GrpcMessage message) {
     Promise<Void> completion = consumerContext.promise();
 
     Message.Builder messageBuilder;
@@ -355,10 +366,10 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
       .newBuilder()
       .setMessage(messageBuilder);
 
-    return new OutboundFrameMessage(completion, builder, null);
+    return new OutboundFrameWrite(completion, builder, outboundSequence++, null);
   }
 
-  private OutboundFrameMessage trailersFrameWrite(GrpcTrailersFrame frame) {
+  private OutboundFrameWrite trailersFrameWrite(GrpcTrailersFrame frame) {
     Promise<Void> completion = consumerContext.promise();
     DeliveryOptions deliveryOptions = new DeliveryOptions();
     MultiMap headers = frame.trailers();
@@ -374,18 +385,18 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     TransportFrame.Builder builder = TransportFrame
       .newBuilder()
       .setTrailers(trailersBuilder);
-    return new OutboundFrameMessage(completion, builder, deliveryOptions);
+    return new OutboundFrameWrite(completion, builder, outboundSequence++, deliveryOptions);
   }
 
-  private OutboundFrameMessage halfCloseFrameWrite() {
-    return new OutboundFrameMessage(
+  private OutboundFrameWrite halfCloseFrameWrite() {
+    return new OutboundFrameWrite(
       consumerContext.promise(),
       TransportFrame.newBuilder().setHalfClose(HalfClose.newBuilder()),
+      outboundSequence++,
       null);
   }
 
   Future<Void> enqueue(OutboundWrite write) {
-    write.serial = sequence++;
     outboundQueue.write(write);
     return write.completion.future();
   }
@@ -501,12 +512,13 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
 
   static abstract class OutboundWrite {
 
-    long serial;
     final Promise<Void> completion;
 
     public OutboundWrite(Promise<Void> completion) {
       this.completion = completion;
     }
+
+    abstract long sequence();
 
     abstract void write();
 
@@ -515,20 +527,28 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     }
   }
 
-  private class OutboundFrameMessage extends OutboundWrite {
+  private class OutboundFrameWrite extends OutboundWrite {
 
+
+    final long sequence;
     final TransportFrame.Builder frame;
     final DeliveryOptions deliveryOptions;
 
-    public OutboundFrameMessage(Promise<Void> completion, TransportFrame.Builder frame, DeliveryOptions deliveryOptions) {
+    public OutboundFrameWrite(Promise<Void> completion, TransportFrame.Builder frame, long sequence, DeliveryOptions deliveryOptions) {
       super(completion);
       this.frame = frame;
       this.deliveryOptions = deliveryOptions;
+      this.sequence = sequence;
+    }
+
+    @Override
+    long sequence() {
+      return sequence;
     }
 
     @Override
     public void write() {
-      frame.setStreamSequence(serial);
+      frame.setStreamSequence(sequence);
       Future<Void> sent = sendTransportFrame(frame, deliveryOptions);
       sent.onComplete(completion);
     }

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -666,7 +667,7 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
       @Override
       public Result onPing(String srcAddress, String dstAddress, long data, boolean ack) {
         if (dstAddress.startsWith("grpc.eb.client.")) {
-          return Result.stop();
+          return Result.never();
         } else {
           return Result.cont();
         }
@@ -1125,5 +1126,55 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
     } catch (InvalidStatusException e) {
       assertEquals(GrpcStatus.UNIMPLEMENTED, e.actualStatus());
     }
+  }
+
+  @Test
+  public void testMessageReordering() {
+
+    int num = 8;
+    int limit = 4;
+
+    vertx.eventBus().addOutboundInterceptor(new TransportInterceptor() {
+      int count = 0;
+      @Override
+      protected Result onClientMessage(String clientAddress, WireFormat wireFormat, String streamId, Buffer msg) {
+        if (count++ == limit) {
+          return Result.of(vertx.timer(5));
+        } else if (count > limit) {
+          return Result.never();
+        }
+        return Result.cont();
+      }
+    });
+
+    List<String> received = Collections.synchronizedList(new ArrayList<>());
+    server.callHandler(SINK_SERVER, request -> {
+      request.handler(msg -> {
+        received.add(msg.getName());
+      });
+      request.endHandler(v -> {
+        request.response().end();
+      });
+    });
+
+    try {
+      client.request(SINK_CLIENT)
+        .compose(request -> {
+          for (int i = 0;i < num;i++) {
+            request.write(Request.newBuilder().setName("msg-" + i).build());
+          }
+          request.end();
+          return request.response();
+        }).await();
+      fail();
+    } catch (GrpcErrorException expected) {
+    }
+
+    List<String> expected = IntStream
+      .range(0, limit)
+      .mapToObj(val -> "msg-" + val)
+      .collect(Collectors.toList());
+
+    assertEquals(expected, received);
   }
 }

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
@@ -241,7 +241,7 @@ public class TransportInterceptor implements Handler<DeliveryContext<Object>> {
       }
     };
 
-    private static final Result STOP = new Result() {
+    private static final Result NEVER = new Result() {
       @Override
       void apply(Completable<?> completion) {
       }
@@ -251,8 +251,8 @@ public class TransportInterceptor implements Handler<DeliveryContext<Object>> {
       return NEXT;
     }
 
-    public static Result stop() {
-      return STOP;
+    public static Result never() {
+      return NEVER;
     }
 
     public static Result of(Future<?> result) {


### PR DESCRIPTION
Motivation:

In normal circumstances, event bus messages are received in order they are sent and thus message order is not an issue.

However, event-bus interceptors can change that, we should be able to detect reordering and fail the stream accordingly.

Changes:

Use the sequence for stream frames that requires and and implement out of order detection and handling.
