### PR TITLE
Simply GrpcDispatcher that does not need to know about the wire format or grpc protocol in advanced.

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
@@ -371,8 +371,6 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
       GrpcDispatcher<Req, Resp> dispatcher = new GrpcDispatcher<>(
         stream,
         consumerContext,
-        null,
-        wireFormat,
         serviceMethod.decoder(),
         serviceMethod.encoder(),
         methodCall,

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcProtocol.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/GrpcProtocol.java
@@ -1,6 +1,8 @@
 package io.vertx.grpc.server;
 
 import io.vertx.core.http.HttpVersion;
+import io.vertx.grpc.common.GrpcMediaType;
+import io.vertx.grpc.common.WireFormat;
 
 import java.util.EnumSet;
 
@@ -12,22 +14,42 @@ public enum GrpcProtocol {
   /**
    * gRPC over HTTP/2
    */
-  HTTP_2("application/grpc", EnumSet.of(HttpVersion.HTTP_2)),
+  HTTP_2("application/grpc", EnumSet.of(HttpVersion.HTTP_2)) {
+    @Override
+    public WireFormat wireFormat(String mediaType) {
+      return GrpcMediaType.parseContentType(mediaType, mediaType());
+    }
+  },
 
   /**
    * gRPC transcoding HTTP/1
    */
-  TRANSCODING("application/json", EnumSet.allOf(HttpVersion.class)),
+  TRANSCODING("application/json", EnumSet.allOf(HttpVersion.class)) {
+    @Override
+    public WireFormat wireFormat(String mediaType) {
+      return mediaType().equals(mediaType) ? WireFormat.JSON : null;
+    }
+  },
 
   /**
    * gRPC Web
    */
-  WEB("application/grpc-web", EnumSet.allOf(HttpVersion.class)),
+  WEB("application/grpc-web", EnumSet.allOf(HttpVersion.class)) {
+    @Override
+    public WireFormat wireFormat(String mediaType) {
+      return GrpcMediaType.parseContentType(mediaType, mediaType());
+    }
+  },
 
   /**
    * gRPC Web text
    */
-  WEB_TEXT("application/grpc-web-text", EnumSet.allOf(HttpVersion.class));
+  WEB_TEXT("application/grpc-web-text", EnumSet.allOf(HttpVersion.class)) {
+    @Override
+    public WireFormat wireFormat(String mediaType) {
+      return GrpcMediaType.parseContentType(mediaType, mediaType());
+    }
+  };
 
   private final String mediaType;
   private final EnumSet<HttpVersion> acceptedVersions;
@@ -50,4 +72,12 @@ public enum GrpcProtocol {
   public String mediaType() {
     return mediaType;
   }
+
+  /**
+   * The wire format adapted for the
+   * @param mediaType
+   * @return
+   */
+  public abstract WireFormat wireFormat(String mediaType);
+
 }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcDispatcher.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcDispatcher.java
@@ -10,15 +10,12 @@ import io.vertx.grpc.common.impl.GrpcHeadersFrame;
 import io.vertx.grpc.common.impl.GrpcStream;
 import io.vertx.grpc.common.impl.GrpcMessageFrame;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
-import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServerRequest;
 
 public class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
 
   private final GrpcStream stream;
   private final ContextInternal context;
-  private final GrpcProtocol protocol;
-  private final WireFormat format;
   private final GrpcMessageDecoder<Req> messageDecoder;
   private final GrpcMessageEncoder<Resp> messageEncoder;
   private final GrpcMethodCall methodCall;
@@ -31,8 +28,6 @@ public class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
 
   public GrpcDispatcher(GrpcStream stream,
                         ContextInternal context,
-                        GrpcProtocol protocol,
-                        WireFormat format,
                         GrpcMessageDecoder<Req> messageDecoder,
                         GrpcMessageEncoder<Resp> messageEncoder,
                         GrpcMethodCall methodCall,
@@ -42,8 +37,6 @@ public class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
                         boolean scheduleDeadline) {
     this.stream = stream;
     this.context = context;
-    this.protocol = protocol;
-    this.format = format;
     this.messageDecoder = messageDecoder;
     this.messageEncoder = messageEncoder;
     this.methodCall = methodCall;
@@ -76,10 +69,10 @@ public class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
   }
 
   private void handleHeadersFrame(GrpcHeadersFrame frame) {
+    WireFormat format = frame.format();
     grpcRequest = new GrpcServerRequestImpl<>(
       context,
       frame.headers(),
-      protocol,
       format,
       stream,
       frame.timeout(),
@@ -95,7 +88,6 @@ public class GrpcDispatcher<Req, Resp> implements Handler<GrpcFrame> {
       context,
       grpcRequest,
       stream,
-      protocol,
       messageEncoder);
     grpcResponse.format(format);
     long timeout = grpcRequest.timeout();

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerImpl.java
@@ -30,7 +30,6 @@ import io.vertx.grpc.common.impl.Http2GrpcMessageDeframer;
 import io.vertx.grpc.server.*;
 
 import java.util.*;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
@@ -39,8 +38,6 @@ import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class GrpcServerImpl implements GrpcServer, Closeable {
-
-  private static final Pattern CONTENT_TYPE_PATTERN = Pattern.compile("application/grpc(-web(-text)?)?(\\+(json|proto))?");
 
   private static final Logger log = LoggerFactory.getLogger(GrpcServer.class);
 
@@ -217,8 +214,6 @@ public class GrpcServerImpl implements GrpcServer, Closeable {
     GrpcDispatcher<Req, Resp> dispatcher = new GrpcDispatcher<>(
       outboundInvoker,
       context,
-      protocol,
-      format,
       messageDecoder,
       method.messageEncoder,
       methodCall,

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerRequestImpl.java
@@ -19,7 +19,6 @@ import io.vertx.grpc.common.*;
 import io.vertx.grpc.common.impl.GrpcInboundStream;
 import io.vertx.grpc.common.impl.GrpcMethodCall;
 import io.vertx.grpc.common.impl.GrpcReadStreamBase;
-import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServerRequest;
 
 import java.time.Duration;
@@ -33,14 +32,12 @@ public class GrpcServerRequestImpl<Req, Resp> extends GrpcReadStreamBase<GrpcSer
   private final GrpcInboundStream inbound;
   private final MultiMap headers;
   final Duration timeout;
-  final GrpcProtocol protocol;
   private GrpcServerResponseImpl<Req, Resp> response;
   private final GrpcMethodCall methodCall;
   private Timer deadline;
 
   public GrpcServerRequestImpl(ContextInternal context,
                                MultiMap headers,
-                               GrpcProtocol protocol,
                                WireFormat format,
                                GrpcInboundStream inbound,
                                Duration timeout,
@@ -51,7 +48,6 @@ public class GrpcServerRequestImpl<Req, Resp> extends GrpcReadStreamBase<GrpcSer
 
     this.inbound = inbound;
     this.headers = headers;
-    this.protocol = protocol;
     this.timeout = timeout;
     this.methodCall = methodCall;
   }

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/GrpcServerResponseImpl.java
@@ -23,7 +23,6 @@ import io.vertx.grpc.common.impl.DefaultGrpcMessageFrame;
 import io.vertx.grpc.common.impl.DefaultGrpcTrailersFrame;
 import io.vertx.grpc.common.impl.GrpcOutboundStream;
 import io.vertx.grpc.common.impl.GrpcWriteStreamBase;
-import io.vertx.grpc.server.GrpcProtocol;
 import io.vertx.grpc.server.GrpcServerResponse;
 import io.vertx.grpc.server.StatusException;
 
@@ -49,7 +48,6 @@ public final class GrpcServerResponseImpl<Req, Resp> extends GrpcWriteStreamBase
   public GrpcServerResponseImpl(ContextInternal context,
                                 GrpcServerRequestImpl<Req, Resp> request,
                                 GrpcOutboundStream outbound,
-                                GrpcProtocol protocol,
                                 GrpcMessageEncoder<Resp> encoder) {
     super(context, encoder);
     this.outbound = outbound;

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/HttpGrpcInboundStream.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/HttpGrpcInboundStream.java
@@ -10,7 +10,6 @@ import io.vertx.grpc.common.GrpcCancelFrame;
 import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcErrorException;
 import io.vertx.grpc.common.GrpcHeaderNames;
-import io.vertx.grpc.common.GrpcMediaType;
 import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.server.GrpcProtocol;
 
@@ -121,7 +120,7 @@ public class HttpGrpcInboundStream implements GrpcInboundStream {
     String encoding = httpRequest.headers().get(GrpcHeaderNames.GRPC_ENCODING);
     String contentType = httpRequest.headers().get(HttpHeaders.CONTENT_TYPE);
 
-    WireFormat wireFormat = GrpcMediaType.parseContentType(contentType, protocol.mediaType());
+    WireFormat wireFormat = protocol.wireFormat(contentType);
 
     GrpcHeadersFrame headersFrame = new DefaultGrpcHeadersFrame(wireFormat, encoding, httpRequest.headers(), timeout);
 

--- a/vertx-grpc-transcoding/src/test/java/io/vertx/grpc/transcoding/tests/ServerTranscodingJsonFormatTest.java
+++ b/vertx-grpc-transcoding/src/test/java/io/vertx/grpc/transcoding/tests/ServerTranscodingJsonFormatTest.java
@@ -104,6 +104,7 @@ public class ServerTranscodingJsonFormatTest extends GrpcTestBase {
     httpClient.request(HttpMethod.POST, "/hello").compose(req -> {
       req.headers().addAll(HEADERS);
       req.headers().set(HttpHeaders.CONTENT_LENGTH, String.valueOf(body.length()));
+      req.putHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE);
       return req.send(body).compose(response -> response.body().map(response));
     }).onComplete(should.asyncAssertSuccess(response -> should.verify(v -> {
       assertEquals(200, response.statusCode());


### PR DESCRIPTION
Fixes a parsing bug in HttpGrpcInboundStream that reports incorrectly the request wire format since application/json indicates protobuf instead of json at the grpc stream level.
