### PR TITLE
Add DEADLINE_EXCEEDED support

### DIFF
--- a/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
+++ b/vertx-grpcio-client/src/main/java/io/vertx/grpcio/client/VertxClientCall.java
@@ -127,27 +127,35 @@ class VertxClientCall<RequestT, ResponseT> extends ClientCall<RequestT, Response
             }
             readAdapter.init(grpcResponse, decoder);
             grpcResponse.end().onComplete(ar -> {
-              Status status;
-              Metadata trailers;
-              if (grpcResponse.status() != null) {
-                status = Status.fromCodeValue(grpcResponse.status().code);
-                if (grpcResponse.statusMessage() != null) {
-                  status = status.withDescription(grpcResponse.statusMessage());
-                }
-                trailers = io.vertx.grpcio.common.impl.Utils.readMetadata(trailersOnly ? grpcResponse.headers() : grpcResponse.trailers());
+              if (deadline != null && deadline.isExpired()) {
+                doClose(Status.DEADLINE_EXCEEDED.withDescription("Deadline exceeded"), new Metadata());
               } else {
-                status = Status.fromThrowable(ar.cause());
-                trailers = new Metadata();
+                Status status;
+                Metadata trailers;
+                if (grpcResponse.status() != null) {
+                  status = Status.fromCodeValue(grpcResponse.status().code);
+                  if (grpcResponse.statusMessage() != null) {
+                    status = status.withDescription(grpcResponse.statusMessage());
+                  }
+                  trailers = io.vertx.grpcio.common.impl.Utils.readMetadata(trailersOnly ? grpcResponse.headers() : grpcResponse.trailers());
+                } else {
+                  status = Status.fromThrowable(ar.cause());
+                  trailers = new Metadata();
+                }
+                doClose(status, trailers);
               }
-              doClose(status, trailers);
             });
           } else {
-            Throwable err = ar2.cause();
-            if (err instanceof GrpcErrorException) {
-              GrpcErrorException reset = (GrpcErrorException) err;
-              doClose(Status.fromCodeValue(reset.status().code), new Metadata());
+            if (deadline != null && deadline.isExpired()) {
+              doClose(Status.DEADLINE_EXCEEDED.withDescription("Deadline exceeded"), new Metadata());
             } else {
-              doClose(Status.fromThrowable(err), new Metadata());
+              Throwable err = ar2.cause();
+              if (err instanceof GrpcErrorException) {
+                GrpcErrorException reset = (GrpcErrorException) err;
+                doClose(Status.fromCodeValue(reset.status().code), new Metadata());
+              } else {
+                doClose(Status.fromThrowable(err), new Metadata());
+              }
             }
           }
         });

--- a/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
+++ b/vertx-grpcio-client/src/test/java/io/vertx/tests/client/ClientBridgeTest.java
@@ -602,7 +602,7 @@ public class ClientBridgeTest extends ClientTest {
     try {
       c.accept(stub);
     } catch (StatusRuntimeException e) {
-      should.assertEquals(Status.Code.CANCELLED, e.getStatus().getCode());
+      should.assertEquals(Status.Code.DEADLINE_EXCEEDED, e.getStatus().getCode());
     }
   }
 


### PR DESCRIPTION
backport of #322 

Add support for `DEADLINE_EXCEEDED` status when a deadline expires

**Motivation**:
When a gRPC call's deadline expires, the client should report a `DEADLINE_EXCEEDED` status to the caller.
Previously, the `VertxClientCall` did not check the deadline on stream completion, so a timed-out call could end up being reported with a misleading status (e.g. `CANCELLED` or whatever the underlying transport error mapped to).

**Modifications**:
In `VertxClientCall`, on the grpcResponse.end() callback, we now check if the deadline has expired before processing the normal response status.
This check is applied in both the success path (response ended cleanly but after the deadline) and the failure path (response ended with an error).
In both cases, if the deadline is expired, `DEADLINE_EXCEEDED` is returned immediately instead of propagating the underlying transport error.

`ClientBridgeTest` now asserts `DEADLINE_EXCEEDED` instead of `CANCELLED`

**Result**:
gRPC calls that time out now correctly throw Status.`DEADLINE_EXCEEDED` instead of `CANCELLED`