### PR TITLE
Let the event bus endpoint deduce the client/server streaming from the request message sent by the initial event bus client request.

### DIFF
--- a/vertx-grpc-eventbus/README.md
+++ b/vertx-grpc-eventbus/README.md
@@ -86,14 +86,21 @@ Depending on the client method type, the request body will differ, when the clie
 - sends a unique message, the request body is this unique message
 - sends a stream of messages, the request body is null
 
+The server deduces the communication pattern from the request. It does not use the method
+definition. A null body means the client streams. When the client streams, the presence of
+`grpc-stream-initial-window` means the server streams. When the client does not stream,
+the presence of `grpc-endpoint-address` means the server streams. Therefore a client can
+use any streaming pattern, regardless of the method type in the service definition.
+
 #### The reply of the server
 
 The server does these steps:
 
 1. Find the method.
-2. Prepare the call.
-3. Register the call.
-4. Reply with `grpc-endpoint-address`, `grpc-endpoint-wire-format`, and `grpc-stream-initial-window`.
+2. Deduce the communication pattern from the request.
+3. Prepare the call.
+4. Register the call.
+5. Reply with `grpc-endpoint-address`, `grpc-endpoint-wire-format`, and `grpc-stream-initial-window`.
 
 The reply is only the signal to start. The server sends the reply before the handler
 operates. Therefore, the reply contains no response metadata.

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientCall.java
@@ -11,7 +11,7 @@ import io.vertx.grpc.eventbus.transport.v1alpha.*;
 
 import java.time.Duration;
 
-class EventBusGrpcClientCall extends EventBusGrpcStreamBase<EventBusGrpcClientEndpoint> {
+class EventBusGrpcClientCall extends EventBusGrpcStreamBase.Client {
 
   private final ServiceName serviceName;
   private final String methodName;

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
@@ -31,9 +31,10 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase<EventBusGrpcServerEn
     String encoding,
     int initialInboundWindowSize,
     int initialOutboundWindowSize) {
-    super(localEndpoint, id, context, localUnary, remoteUnary, initialInboundWindowSize, initialOutboundWindowSize);
+    super(localEndpoint, id, context, initialInboundWindowSize, initialOutboundWindowSize);
     this.wireFormat = wireFormat;
     this.encoding = encoding;
+
     this.inbound = remoteUnary ? new UnaryInbound() : new StreamingInbound();
     this.outbound = localUnary && remoteUnary ? new UnaryOutbound() : new StreamingOutbound();
   }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
@@ -273,20 +273,31 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
         }
       }
 
+      boolean clientStreaming = message.body() == null;
+      boolean serverStreaming;
+      if (clientStreaming) {
+        serverStreaming = message.headers().get(EventBusHeaders.STREAM_INITIAL_WINDOW) != null;
+      } else {
+        serverStreaming = message.headers().get(EventBusHeaders.ENDPOINT_ADDRESS) != null;
+      }
+
       if (serviceMethod == null) {
         message.fail(GrpcStatus.UNIMPLEMENTED.code, "Method not found: " + methodName);
-      } else if (isServiceProxy && (serviceMethod.clientStreaming() || serviceMethod.serverStreaming())) {
+      } else if (isServiceProxy && (clientStreaming || serverStreaming)) {
         message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Unsupported service proxy action");
       } else {
-        dispatchStreaming(message, serviceMethod, streamId, wireFormat);
+        dispatchStreaming(message, serviceMethod, clientStreaming, serverStreaming, streamId, wireFormat);
       }
     }
 
     private <Req, Resp> void dispatchStreaming(Message<Object> message,
                                                ServiceMethod<Req, Resp> serviceMethod,
+                                               boolean clientStreaming,
+                                               boolean serverStreaming,
                                                long streamId,
                                                WireFormat wireFormat) {
-      boolean needClientAddress = serviceMethod.serverStreaming() || serviceMethod.clientStreaming();
+
+      boolean needClientAddress = serverStreaming || clientStreaming;
       String clientAddress = message.headers().get(EventBusHeaders.ENDPOINT_ADDRESS);
       String s = message.headers().get(EventBusHeaders.ENDPOINT_WIRE_FORMAT);
 
@@ -324,7 +335,7 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
       }
 
       int initialOutboundWindowSize;
-      if (serviceMethod.serverStreaming()) {
+      if (serverStreaming) {
         String initialWindowHeader = message.headers().get(EventBusHeaders.STREAM_INITIAL_WINDOW);
         if (initialWindowHeader == null) {
           message.fail(GrpcStatus.INVALID_ARGUMENT.code, "Missing '" + EventBusHeaders.STREAM_INITIAL_WINDOW + "' header");
@@ -346,8 +357,8 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
         EventBusGrpcServerEndpoint.this,
         streamId,
         consumerContext,
-        !serviceMethod.serverStreaming(),
-        !serviceMethod.clientStreaming(),
+        !serverStreaming,
+        !clientStreaming,
         wireFormat,
         "identity",
         initialWindowSize,

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -26,8 +26,6 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
   protected final E localEndpoint;
   protected final ContextInternal consumerContext;
   protected final ContextInternal producerContext;
-  protected final boolean localUnary;
-  protected final boolean remoteUnary;
 
   private Handler<GrpcFrame> frameHandler;
   private Handler<Void> endHandler;
@@ -40,22 +38,185 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
   private long outboundSequence;
   private long inboundSequence;
 
-  private boolean closed;
-  private Throwable closeCause;
+  boolean closed;
+  Throwable closeCause;
   private Throwable pendingWriteFailureCause;
 
-  EventBusGrpcStreamBase(E localEndpoint, long id, ContextInternal context, boolean localUnary, boolean remoteUnary,
-                         int initialInboundWindowSize, int initialOutboundWindowSize) {
+  EventBusGrpcStreamBase(E localEndpoint, long id, ContextInternal context, int initialInboundWindowSize, int initialOutboundWindowSize) {
     super(localEndpoint, id);
     this.localEndpoint = localEndpoint;
     this.consumerContext = context;
     this.producerContext = localEndpoint.producerContext();
     this.inboundQueue = new IMQ(context, initialInboundWindowSize);
-    this.localUnary = localUnary;
-    this.remoteUnary = remoteUnary;
     this.outboundQueue = new OMQ(localEndpoint.producerContext().executor(), initialOutboundWindowSize);
     this.outboundSequence = 1;
     this.inboundSequence = 1;
+  }
+
+  abstract static class Client extends EventBusGrpcStreamBase<EventBusGrpcClientEndpoint> {
+
+    protected final boolean localUnary;
+    protected final boolean remoteUnary;
+
+    public Client(EventBusGrpcClientEndpoint localEndpoint, long id, ContextInternal context, boolean localUnary, boolean remoteUnary, int initialInboundWindowSize, int initialOutboundWindowSize) {
+      super(localEndpoint, id, context, initialInboundWindowSize, initialOutboundWindowSize);
+
+      this.localUnary = localUnary;
+      this.remoteUnary = remoteUnary;
+    }
+
+    Future<Void> connect(Object body, MultiMap requestHeaders, ServiceName serviceName, String methodName,
+                         long pingTimeout, String encoding, WireFormat wireFormat, java.time.Duration timeout) {
+      return enqueue(createConnectWrite(body, requestHeaders, serviceName, methodName, pingTimeout, encoding, wireFormat, timeout));
+    }
+
+    private OutboundWrite createConnectWrite(Object body, MultiMap requestHeaders, ServiceName serviceName,
+                                             String methodName, long pingTimeout, String encoding, WireFormat wireFormat,
+                                             java.time.Duration timeout) {
+      DeliveryOptions options = new DeliveryOptions();
+
+      if (localUnary) {
+        if (!remoteUnary) {
+          options.addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
+          options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, wireFormat.name());
+          options.addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address());
+        }
+      } else {
+        options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, wireFormat.name());
+        options.addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address());
+        if (!remoteUnary) {
+          options.addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
+        }
+        if (pingTimeout > 0) {
+          options.addHeader(EventBusHeaders.ENDPOINT_PING_TIMEOUT, Long.toString(pingTimeout));
+        }
+      }
+
+      if (timeout != null) {
+        options.setSendTimeout(timeout.toMillis());
+      }
+
+      options.addHeader(EventBusHeaders.SERVICE_PROXY_ACTION, methodName);;
+      options.addHeader(EventBusHeaders.STREAM_METHOD_NAME, methodName);;
+      options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name());
+      options.addHeader(EventBusHeaders.STREAM_ID, Long.toString(id()));
+
+      if (requestHeaders != null) {
+        EventBusHeaders.encodeMultiMap(HEADER_PREFIX, requestHeaders, options.getHeaders());
+      }
+
+      Promise<Void> promise = consumerContext.promise();
+
+      return new OutboundWrite(promise) {
+        @Override
+        long sequence() {
+          return 0L;
+        }
+        @Override
+        void write() {
+          registerStream();
+          localEndpoint.request(serviceName.fullyQualifiedName(), body, options)
+            .onComplete(ar -> {
+              if (closed) {
+                Throwable cause = closeCause;
+                if (cause == null) {
+                  cause = new VertxException("Stream closed");
+                }
+                promise.fail(cause);
+              } else {
+                if (ar.succeeded()) {
+                  Throwable malformed = handleReply(ar.result());
+                  if (malformed == null) {
+                    promise.succeed();
+                  } else {
+                    InvalidStatusException err = invalidStatusException(malformed);
+                    close(err, true);
+                    promise.fail(err);
+                  }
+                } else {
+                  InvalidStatusException err = invalidStatusException(ar.cause());
+                  close(err, false);
+                  promise.fail(err);
+                }
+              }
+            });
+        }
+
+        private InvalidStatusException invalidStatusException(Throwable cause) {
+          GrpcStatus status = EventBusGrpcCodec.mapFailure(cause);
+          return new InvalidStatusException(GrpcStatus.OK, status);
+        }
+
+        private Throwable handleReply(io.vertx.core.eventbus.Message<Object> reply) {
+
+          WireFormat serverFormat;
+          String serverAddress;
+          if (!localUnary || !remoteUnary) {
+            MultiMap replyHeaders = reply.headers();
+            serverAddress = replyHeaders.get(EventBusHeaders.ENDPOINT_ADDRESS);
+            String s = replyHeaders.get(EventBusHeaders.ENDPOINT_WIRE_FORMAT);
+            if (s == null) {
+              return new IllegalStateException("Malformed handshake reply: missing endpoint-wire-format header");
+            }
+            if (serverAddress == null) {
+              return new IllegalStateException("Malformed handshake reply: missing grpc-endpoint-address header");
+            }
+            switch (s) {
+              case "json":
+                serverFormat = WireFormat.JSON;
+                break;
+              case "proto":
+                serverFormat = WireFormat.PROTOBUF;
+                break;
+              default:
+                return new IllegalStateException("Malformed handshake reply: invalid endpoint-wire-format header");
+            }
+          } else {
+            serverAddress = null;
+            serverFormat = null;
+          }
+
+          int initialOutboundWindowSize;
+          if (remoteUnary) {
+            initialOutboundWindowSize = EventBusGrpcServerOptions.DEFAULT_INITIAL_WINDOW_SIZE;
+          } else {
+            String initialWindowHeader = reply.headers().get(EventBusHeaders.STREAM_INITIAL_WINDOW);
+            if (initialWindowHeader == null) {
+              return new IllegalStateException("Malformed handshake reply: missing grpc-initial-window header");
+            }
+            try {
+              initialOutboundWindowSize = Integer.parseInt(initialWindowHeader);
+            } catch (NumberFormatException e) {
+              return new IllegalStateException("Malformed handshake reply: non-numeric grpc-initial-window header");
+            }
+            if (initialOutboundWindowSize <= 0) {
+              return new IllegalStateException("Malformed handshake reply: invalid grpc-initial-window header");
+            }
+          }
+
+          if (serverAddress != null) {
+            registerRemoteEndpoint(serverAddress, pingTimeout, serverFormat);
+          }
+
+          updateOutboundWindow(initialOutboundWindowSize);
+
+          if (remoteUnary && localUnary) {
+            MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+            MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
+            EventBusHeaders.decodeMultimap(HEADER_PREFIX, reply.headers(), headers);
+            EventBusHeaders.decodeMultimap(TRAILER_PREFIX, reply.headers(), trailers);
+            Buffer payload = EventBusGrpcCodec.decodeBody(reply.body());
+            emitInbound(List.of(
+              new DefaultGrpcHeadersFrame(wireFormat, encoding, headers),
+              new DefaultGrpcMessageFrame(GrpcMessage.message(encoding, wireFormat, payload)),
+              new DefaultGrpcTrailersFrame(GrpcStatus.OK, null, trailers)
+            ));
+          }
+
+          return null;
+        }
+      };
+    }
   }
 
   @Override
@@ -180,159 +341,6 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     }
   }
 
-  Future<Void> connect(Object body, MultiMap requestHeaders, ServiceName serviceName, String methodName,
-                       long pingTimeout, String encoding, WireFormat wireFormat, java.time.Duration timeout) {
-    return enqueue(createConnectWrite(body, requestHeaders, serviceName, methodName, pingTimeout, encoding, wireFormat, timeout));
-  }
-
-  private OutboundWrite createConnectWrite(Object body, MultiMap requestHeaders, ServiceName serviceName,
-                                           String methodName, long pingTimeout, String encoding, WireFormat wireFormat,
-                                           java.time.Duration timeout) {
-    DeliveryOptions options = new DeliveryOptions();
-
-    if (localUnary) {
-      if (!remoteUnary) {
-        options.addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
-        options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, wireFormat.name());
-        options.addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address());
-      }
-    } else {
-      options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, wireFormat.name());
-      options.addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address());
-      if (!remoteUnary) {
-        options.addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
-      }
-      if (pingTimeout > 0) {
-        options.addHeader(EventBusHeaders.ENDPOINT_PING_TIMEOUT, Long.toString(pingTimeout));
-      }
-    }
-
-    if (timeout != null) {
-      options.setSendTimeout(timeout.toMillis());
-    }
-
-    options.addHeader(EventBusHeaders.SERVICE_PROXY_ACTION, methodName);;
-    options.addHeader(EventBusHeaders.STREAM_METHOD_NAME, methodName);;
-    options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name());
-    options.addHeader(EventBusHeaders.STREAM_ID, Long.toString(id()));
-
-    if (requestHeaders != null) {
-      EventBusHeaders.encodeMultiMap(HEADER_PREFIX, requestHeaders, options.getHeaders());
-    }
-
-    Promise<Void> promise = consumerContext.promise();
-
-    return new OutboundWrite(promise) {
-      @Override
-      long sequence() {
-        return 0L;
-      }
-      @Override
-      void write() {
-        registerStream();
-        localEndpoint.request(serviceName.fullyQualifiedName(), body, options)
-          .onComplete(ar -> {
-            if (closed) {
-              Throwable cause = closeCause;
-              if (cause == null) {
-                cause = new VertxException("Stream closed");
-              }
-              promise.fail(cause);
-            } else {
-              if (ar.succeeded()) {
-                Throwable malformed = handleReply(ar.result());
-                if (malformed == null) {
-                  promise.succeed();
-                } else {
-                  InvalidStatusException err = invalidStatusException(malformed);
-                  close(err, true);
-                  promise.fail(err);
-                }
-              } else {
-                InvalidStatusException err = invalidStatusException(ar.cause());
-                close(err, false);
-                promise.fail(err);
-              }
-            }
-          });
-      }
-
-      private InvalidStatusException invalidStatusException(Throwable cause) {
-        GrpcStatus status = EventBusGrpcCodec.mapFailure(cause);
-        return new InvalidStatusException(GrpcStatus.OK, status);
-      }
-
-      private Throwable handleReply(io.vertx.core.eventbus.Message<Object> reply) {
-
-        WireFormat serverFormat;
-        String serverAddress;
-        if (!localUnary || !remoteUnary) {
-          MultiMap replyHeaders = reply.headers();
-          serverAddress = replyHeaders.get(EventBusHeaders.ENDPOINT_ADDRESS);
-          String s = replyHeaders.get(EventBusHeaders.ENDPOINT_WIRE_FORMAT);
-          if (s == null) {
-            return new IllegalStateException("Malformed handshake reply: missing endpoint-wire-format header");
-          }
-          if (serverAddress == null) {
-            return new IllegalStateException("Malformed handshake reply: missing grpc-endpoint-address header");
-          }
-          switch (s) {
-            case "json":
-              serverFormat = WireFormat.JSON;
-              break;
-            case "proto":
-              serverFormat = WireFormat.PROTOBUF;
-              break;
-            default:
-              return new IllegalStateException("Malformed handshake reply: invalid endpoint-wire-format header");
-          }
-        } else {
-          serverAddress = null;
-          serverFormat = null;
-        }
-
-        int initialOutboundWindowSize;
-        if (remoteUnary) {
-          initialOutboundWindowSize = EventBusGrpcServerOptions.DEFAULT_INITIAL_WINDOW_SIZE;
-        } else {
-          String initialWindowHeader = reply.headers().get(EventBusHeaders.STREAM_INITIAL_WINDOW);
-          if (initialWindowHeader == null) {
-            return new IllegalStateException("Malformed handshake reply: missing grpc-initial-window header");
-          }
-          try {
-            initialOutboundWindowSize = Integer.parseInt(initialWindowHeader);
-          } catch (NumberFormatException e) {
-            return new IllegalStateException("Malformed handshake reply: non-numeric grpc-initial-window header");
-          }
-          if (initialOutboundWindowSize <= 0) {
-            return new IllegalStateException("Malformed handshake reply: invalid grpc-initial-window header");
-          }
-        }
-
-        if (serverAddress != null) {
-          registerRemoteEndpoint(serverAddress, pingTimeout, serverFormat);
-        }
-
-        updateOutboundWindow(initialOutboundWindowSize);
-
-        if (remoteUnary && localUnary) {
-          MultiMap headers = MultiMap.caseInsensitiveMultiMap();
-          MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
-          EventBusHeaders.decodeMultimap(HEADER_PREFIX, reply.headers(), headers);
-          EventBusHeaders.decodeMultimap(TRAILER_PREFIX, reply.headers(), trailers);
-          Buffer payload = EventBusGrpcCodec.decodeBody(reply.body());
-          emitInbound(List.of(
-            new DefaultGrpcHeadersFrame(wireFormat, encoding, headers),
-            new DefaultGrpcMessageFrame(GrpcMessage.message(encoding, wireFormat, payload)),
-            new DefaultGrpcTrailersFrame(GrpcStatus.OK, null, trailers)
-          ));
-        }
-
-        return null;
-      }
-    };
-  }
-
   protected OutboundWrite frameWrite(GrpcFrame frame) {
     switch (frame.type()) {
       case MESSAGE:
@@ -434,7 +442,7 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     }
   }
 
-  private void updateOutboundWindow(int delta) {
+  void updateOutboundWindow(int delta) {
     outboundQueue.updateWindow(delta);
   }
 

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcCardinalityInteropTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcCardinalityInteropTest.java
@@ -1,0 +1,69 @@
+package io.vertx.grpc.eventbus.tests;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.common.GrpcReadStream;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.common.tests.Reply;
+import io.vertx.grpc.common.tests.Request;
+import io.vertx.grpc.eventbus.EventBusGrpcClient;
+import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EventBusGrpcCardinalityInteropTest extends EventBusGrpcTestBase {
+
+  private EventBusGrpcServer server;
+  private EventBusGrpcClient client;
+
+  @Before
+  public void setUp(TestContext should) {
+    super.setUp(should);
+    server = EventBusGrpcServer.server(vertx).await();
+    client = EventBusGrpcClient.client(vertx).await();
+  }
+
+  @Test
+  public void testUnaryService() {
+    server.callHandler(UNARY_SERVER, request -> request
+      .endHandler(v -> request
+        .response()
+        .end(Reply.getDefaultInstance())));
+
+    for (int i = 0;i < 4;i++) {
+      boolean clientStreaming = (i & 0x01) != 0;
+      boolean serverStreaming = (i & 0x02) != 0;
+      ServiceMethod<Reply, Request> a = ServiceMethod.client(UNARY_CLIENT.serviceName(), UNARY_CLIENT.methodName(),
+        clientStreaming,
+        serverStreaming, UNARY_CLIENT.encoder(), UNARY_CLIENT.decoder());
+      client.request(a)
+        .compose(request -> {
+          request.end(Request.getDefaultInstance());
+          return request
+            .response()
+            .compose(GrpcReadStream::last);
+        }).await();
+    }
+  }
+
+  @Test
+  public void testBidiService() {
+    server.callHandler(PIPE_SERVER, request -> request
+      .handler(msg -> request.response().write(Reply.getDefaultInstance()))
+      .endHandler(v -> request.response().end()));
+
+    for (int i = 0;i < 4;i++) {
+      boolean clientStreaming = (i & 0x01) != 0;
+      boolean serverStreaming = (i & 0x02) != 0;
+      ServiceMethod<Reply, Request> a = ServiceMethod.client(PIPE_SERVER.serviceName(), PIPE_SERVER.methodName(),
+        clientStreaming,
+        serverStreaming, UNARY_CLIENT.encoder(), UNARY_CLIENT.decoder());
+      client.request(a)
+        .compose(request -> {
+          request.end(Request.getDefaultInstance());
+          return request
+            .response()
+            .compose(GrpcReadStream::last);
+        }).await();
+    }
+  }
+}

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
@@ -644,7 +644,7 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
       .addHeader(EventBusHeaders.STREAM_ID, "1");
     vertx.eventBus().consumer("grpc.eb.client.silent", msg -> {
     }).completion().await(10, TimeUnit.SECONDS);
-    vertx.eventBus().request(TestConstants.TEST_SERVICE.fullyQualifiedName(), Buffer.buffer(), handshake).await(10, TimeUnit.SECONDS);
+    vertx.eventBus().request(TestConstants.TEST_SERVICE.fullyQualifiedName(), null, handshake).await(10, TimeUnit.SECONDS);
 
     Throwable failure = serverFailed.future().await(10, TimeUnit.SECONDS);
     assertNotNull("a peer that never advertised must still be given up on", failure);


### PR DESCRIPTION
Motivation:

The server can deduce the client/server streaming from the request message.

Changes:

Let the server reply to the client with the pattern corresponding to its modality.

Add cardinatlity interop tests.
