### PR TITLE
Use an event bus message codec for gRPC transport frames.

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCodec.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcCodec.java
@@ -1,22 +1,15 @@
 package io.vertx.grpc.eventbus.impl;
 
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.core.json.JsonObject;
 import io.vertx.grpc.common.GrpcMessage;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.JsonWireFormat;
 import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
 
 public final class EventBusGrpcCodec {
-
-  private static final GrpcMessageEncoder<TransportFrame> FRAME_ENCODER = GrpcMessageEncoder.encoder();
-  private static final GrpcMessageDecoder<TransportFrame> FRAME_DECODER = GrpcMessageDecoder.decoder(TransportFrame.getDefaultInstance());
 
   private EventBusGrpcCodec() {
   }
@@ -39,16 +32,6 @@ public final class EventBusGrpcCodec {
       return Buffer.buffer();
     }
     throw new IllegalStateException("Unsupported event bus body type: " + body.getClass().getName());
-  }
-
-  static Buffer encodeFrame(TransportFrame frame, WireFormat format) {
-    return FRAME_ENCODER.encode(frame, format).payload();
-  }
-
-  public static TransportFrame decodeFrame(Message<?> message) {
-    String header = message.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT);
-    WireFormat format = JsonWireFormat.NAME.equals(header) ? WireFormat.JSON : WireFormat.PROTOBUF;
-    return FRAME_DECODER.decode(GrpcMessage.message("identity", format, decodeBody(message.body())));
   }
 
   static GrpcMessage message(TransportFrame frame, String encoding, WireFormat wireFormat) {

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -33,7 +33,7 @@ abstract class EventBusGrpcEndpoint {
   private final Map<String, RemoteEndpoint> remoteEndpoints = new HashMap<>();
   private final AtomicLong pingData = new AtomicLong();
   protected final int initialWindowSize;
-  private MessageConsumer<Object> consumer;
+  private MessageConsumer<TransportFrame> consumer;
   private final long cleanerPeriod;
   private long livenessTimerId = -1L;
 
@@ -44,6 +44,14 @@ abstract class EventBusGrpcEndpoint {
                        int initialWindowSize) {
 
     UUID uuid = UUID.randomUUID();
+
+    EventBusInternal eventBus = producerContext.owner().eventBus();
+    try {
+      eventBus.registerCodec(EventBusGrpcProtobufMessageCodec.INSTANCE);
+      eventBus.registerCodec(EventBusGrpcJsonMessageCodec.INSTANCE);
+    } catch (IllegalStateException e) {
+      // Already registered ...
+    }
 
     this.vertx = producerContext.owner();
     this.producerContext = producerContext;
@@ -107,8 +115,8 @@ abstract class EventBusGrpcEndpoint {
     return eventBus.request(producerContext, address, body, options);
   }
 
-  MessageConsumer<Object> consumer(String address, Handler<Message<Object>> handler) {
-    MessageConsumer<Object> consumer = eventBus.consumer(producerContext, new MessageConsumerOptions().setAddress(address));
+  <T> MessageConsumer<T> consumer(String address, Handler<Message<T>> handler) {
+    MessageConsumer<T> consumer = eventBus.consumer(producerContext, new MessageConsumerOptions().setAddress(address));
     consumer.handler(handler);
     return consumer;
   }
@@ -123,13 +131,23 @@ abstract class EventBusGrpcEndpoint {
         }
       }
       for (RemoteEndpoint remoteEndpoint : toPing) {
-        Ping.Builder ping = Ping.newBuilder().setData(data);
+        TransportFrame frame = TransportFrame.newBuilder().setPing(Ping.newBuilder().setData(data)).build();
         DeliveryOptions options = new DeliveryOptions()
           .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, remoteEndpoint.format.name())
           .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, address);
+        switch (remoteEndpoint.format.name()) {
+          case "json":
+            options.setCodecName(EventBusGrpcJsonMessageCodec.CODEC_NAME);
+            break;
+          case "proto":
+            options.setCodecName(EventBusGrpcProtobufMessageCodec.CODEC_NAME);
+            break;
+          default:
+            throw new UnsupportedOperationException();
+        }
         remoteEndpoint.lastPingTimestamp = now;
         remoteEndpoint.producer
-          .write(EventBusGrpcCodec.encodeFrame(TransportFrame.newBuilder().setPing(ping).build(), remoteEndpoint.format), options)
+          .write(frame, options)
           .onFailure(cause -> remoteEndpointDown(remoteEndpoint, false));
       }
     }
@@ -156,8 +174,8 @@ abstract class EventBusGrpcEndpoint {
     }
   }
 
-  private void dispatch(Message<Object> message) {
-    TransportFrame frame = EventBusGrpcCodec.decodeFrame(message);
+  private void dispatch(Message<TransportFrame> message) {
+    TransportFrame frame = message.body();
     if (frame.getFrameCase() == TransportFrame.FrameCase.PING) {
       handlePing(frame.getPing(), message);
       return;
@@ -172,20 +190,20 @@ abstract class EventBusGrpcEndpoint {
     }
   }
 
-  private void handlePing(Ping ping, Message<Object> message) {
+  private void handlePing(Ping ping, Message<TransportFrame> message) {
     String remoteAddress = message.headers().get(EventBusHeaders.ENDPOINT_ADDRESS);
     RemoteEndpoint remoteEndpoint = remoteEndpoints.get(remoteAddress);
     if (remoteEndpoint != null) {
       remoteEndpoint.lastSeenTimestamp = System.currentTimeMillis();
-    }
-    if (!ping.getAck()) {
-      String wireFormatName = message.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT);
-      WireFormat wireFormat = JsonWireFormat.NAME.equals(wireFormatName) ? WireFormat.JSON : WireFormat.PROTOBUF;
-      DeliveryOptions options = new DeliveryOptions()
-        .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name())
-        .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, address);
-      Ping.Builder ack = Ping.newBuilder().setData(ping.getData()).setAck(true);
-      eventBus.send(remoteAddress, EventBusGrpcCodec.encodeFrame(TransportFrame.newBuilder().setPing(ack).build(), wireFormat), options);
+      if (!ping.getAck()) {
+        String wireFormatName = message.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT);
+        WireFormat wireFormat = JsonWireFormat.NAME.equals(wireFormatName) ? WireFormat.JSON : WireFormat.PROTOBUF;
+        DeliveryOptions options = new DeliveryOptions()
+          .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name())
+          .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, address);
+        Ping.Builder ack = Ping.newBuilder().setData(ping.getData()).setAck(true);
+        remoteEndpoint.sendTransportFrame(TransportFrame.newBuilder().setPing(ack).build(), wireFormat, options);
+      }
     }
   }
 
@@ -251,6 +269,21 @@ abstract class EventBusGrpcEndpoint {
       remoteEndpoints.remove(address, this);
       return producer.close();
     }
+
+    Future<Void> sendTransportFrame(TransportFrame frame, WireFormat format, DeliveryOptions options) {
+      options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, format.name());
+      switch (format.name()) {
+        case "json":
+          options.setCodecName(EventBusGrpcJsonMessageCodec.CODEC_NAME);
+          break;
+        case "proto":
+          options.setCodecName(EventBusGrpcProtobufMessageCodec.CODEC_NAME);
+          break;
+        default:
+          throw new UnsupportedOperationException();
+      }
+      return producer.write(frame, options);
+    }
   }
 
   static abstract class StreamRegistration {
@@ -303,13 +336,22 @@ abstract class EventBusGrpcEndpoint {
           // Should use a root cause for this to get unavailable instead ?
           close(GrpcError.CANCELLED, false);
         }
-        Object payload = EventBusGrpcCodec.encodeFrame(frame, wireFormat);
         if (options == null) {
           options = new DeliveryOptions();
         }
         options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name());
-        MessageProducer<Object> producer = remote.producer;
-        Future<Void> res = producer.write(payload, options);
+        switch (wireFormat.name()) {
+          case "json":
+            options.setCodecName(EventBusGrpcJsonMessageCodec.CODEC_NAME);
+            break;
+          case "proto":
+            options.setCodecName(EventBusGrpcProtobufMessageCodec.CODEC_NAME);
+            break;
+          default:
+            throw new UnsupportedOperationException();
+        }
+
+        Future<Void> res = remote.sendTransportFrame(frame, wireFormat, options);
         return res.andThen(ar -> {
           if (ar.failed()) {
             localEndpoint.remoteEndpointDown(remote, false);
@@ -352,11 +394,7 @@ abstract class EventBusGrpcEndpoint {
             .setCancel(Cancel.newBuilder().setStatus(GrpcStatus.CANCELLED.code).setReason("Closed"))
             .setStreamId(id)
             .build();
-          WireFormat format = format();
-          DeliveryOptions options = new DeliveryOptions();
-          options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, format.name());
-          Object payload = EventBusGrpcCodec.encodeFrame(frame, format);
-          remoteEndpoint.producer.write(payload, options);
+          remoteEndpoint.sendTransportFrame(frame, remoteEndpoint.format, new DeliveryOptions());
         }
         Future<Void> res = remove();
         handleProducerClosed(cause);

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcJsonMessageCodec.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcJsonMessageCodec.java
@@ -1,0 +1,55 @@
+package io.vertx.grpc.eventbus.impl;
+
+import io.vertx.core.VertxException;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.common.impl.ProtobufJsonReader;
+import io.vertx.grpc.common.impl.ProtobufJsonWriter;
+import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
+
+public class EventBusGrpcJsonMessageCodec implements MessageCodec<TransportFrame, TransportFrame> {
+
+  public static final String CODEC_NAME = "grpc-event-bus-json-codec";
+
+  public static final EventBusGrpcJsonMessageCodec INSTANCE = new EventBusGrpcJsonMessageCodec();
+
+  private EventBusGrpcJsonMessageCodec() {
+  }
+
+  @Override
+  public void encodeToWire(Buffer buffer, TransportFrame transportFrame) {
+    Buffer data = ProtobufJsonWriter.create(WireFormat.JSON).write(transportFrame);
+    buffer.appendInt(data.length());
+    buffer.appendBuffer(data);
+  }
+
+  @Override
+  public TransportFrame decodeFromWire(int pos, Buffer buffer) {
+    int length = buffer.getInt(pos);
+    pos += 4;
+    Buffer data = buffer.getBuffer(pos, pos + length);
+    TransportFrame.Builder builder = TransportFrame.newBuilder();
+    ProtobufJsonReader.create(WireFormat.JSON).merge(data, builder);
+    try {
+      return builder.build();
+    } catch (Exception e) {
+      throw new VertxException(e);
+    }
+  }
+
+  @Override
+  public TransportFrame transform(TransportFrame transportFrame) {
+    return transportFrame;
+  }
+
+  @Override
+  public String name() {
+    return CODEC_NAME;
+  }
+
+  @Override
+  public byte systemCodecID() {
+    return -1;
+  }
+}

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcProtobufMessageCodec.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcProtobufMessageCodec.java
@@ -1,0 +1,51 @@
+package io.vertx.grpc.eventbus.impl;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.vertx.core.VertxException;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
+
+public class EventBusGrpcProtobufMessageCodec implements MessageCodec<TransportFrame, TransportFrame> {
+
+  public static final String CODEC_NAME = "grpc-event-bus-protobuf-codec";
+
+  public static final EventBusGrpcProtobufMessageCodec INSTANCE = new EventBusGrpcProtobufMessageCodec();
+
+  private EventBusGrpcProtobufMessageCodec() {
+  }
+
+  @Override
+  public void encodeToWire(Buffer buffer, TransportFrame transportFrame) {
+    Buffer data = Buffer.buffer(transportFrame.toByteArray());
+    buffer.appendInt(data.length());
+    buffer.appendBuffer(data);
+  }
+
+  @Override
+  public TransportFrame decodeFromWire(int pos, Buffer buffer) {
+    int length = buffer.getInt(pos);
+    pos += 4;
+    byte[] data = buffer.getBytes(pos, pos + length);
+    try {
+      return TransportFrame.parseFrom(data);
+    } catch (InvalidProtocolBufferException e) {
+      throw new VertxException(e);
+    }
+  }
+
+  @Override
+  public TransportFrame transform(TransportFrame transportFrame) {
+    return transportFrame;
+  }
+
+  @Override
+  public String name() {
+    return CODEC_NAME;
+  }
+
+  @Override
+  public byte systemCodecID() {
+    return -1;
+  }
+}

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -255,7 +255,7 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
     });
   }
 
-  void handle(TransportFrame frame, io.vertx.core.eventbus.Message<Object> message) {
+  void handle(TransportFrame frame, io.vertx.core.eventbus.Message<TransportFrame> message) {
     long sequence;
     if ((sequence = frame.getStreamSequence()) > 0 && sequence != inboundSequence++) {
       close(GrpcError.CANCELLED, true);

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClusteringTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClusteringTest.java
@@ -6,6 +6,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.grpc.client.GrpcClientRequest;
 import io.vertx.grpc.common.GrpcReadStream;
+import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
 import io.vertx.grpc.server.GrpcServerResponse;
@@ -56,7 +57,16 @@ public class EventBusGrpcClusteringTest {
   }
 
   @Test
-  public void testRequestReply() throws Exception {
+  public void testRequestReplyProtobuf() throws Exception {
+    testRequestReply(WireFormat.PROTOBUF);
+  }
+
+  @Test
+  public void testRequestReplyJson() throws Exception {
+    testRequestReply(WireFormat.JSON);
+  }
+
+  private void testRequestReply(WireFormat wireFormat) throws Exception {
     server.callHandler(UNARY_SERVER, request -> request.handler(msg -> {
       Reply reply = Reply.newBuilder().setMessage("Hello " + msg.getName()).build();
       request.response().end(reply);
@@ -64,6 +74,7 @@ public class EventBusGrpcClusteringTest {
 
     Reply reply = client.request(UNARY_CLIENT)
       .compose(request -> {
+        request.format(wireFormat);
         request.end(Request.newBuilder().setName("Julien").build());
         return request.response();
       })
@@ -74,7 +85,16 @@ public class EventBusGrpcClusteringTest {
   }
 
   @Test
-  public void testStreaming(TestContext should) throws Exception {
+  public void testStreamingProtobuf(TestContext should) throws Exception {
+    testStreaming(should, WireFormat.PROTOBUF);
+  }
+
+  @Test
+  public void testStreamingJson(TestContext should) throws Exception {
+    testStreaming(should, WireFormat.JSON);
+  }
+
+  private void testStreaming(TestContext should, WireFormat wireFormat) throws Exception {
     server.callHandler(PIPE_SERVER, request -> {
       GrpcServerResponse<Request, Reply> response = request.response();
       request.handler(msg -> {
@@ -94,6 +114,7 @@ public class EventBusGrpcClusteringTest {
 
     GrpcClientRequest<Request, Reply> request = client.request(PIPE_CLIENT).await();
     Async async = should.async();
+    request.format(wireFormat);
     request.response().onComplete(should.asyncAssertSuccess(response -> {
       List<String> result = new ArrayList<>();
       response.handler(reply -> {

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcCodecTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcCodecTest.java
@@ -1,0 +1,36 @@
+package io.vertx.grpc.eventbus.tests;
+
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.eventbus.impl.EventBusGrpcProtobufMessageCodec;
+import io.vertx.grpc.eventbus.transport.v1alpha.Headers;
+import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
+import org.junit.Test;
+
+public class EventBusGrpcCodecTest extends EventBusGrpcTestBase {
+
+  @Test
+  public void test(TestContext should) {
+
+    EventBus eventBus = vertx.eventBus();
+
+    eventBus.registerCodec(EventBusGrpcProtobufMessageCodec.INSTANCE);
+
+    TransportFrame frame = TransportFrame
+      .newBuilder()
+      .setStreamId(1)
+      .setStreamSequence(0)
+      .setHeaders(Headers.newBuilder())
+      .build();
+
+    Async latch = should.async();
+
+    eventBus.consumer("the-address", msg -> {
+      latch.complete();
+    });
+
+    eventBus.send("the-address", frame, new DeliveryOptions().setCodecName("grpc-event-bus-protobuf-codec"));
+  }
+}

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
@@ -19,6 +19,8 @@ import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
 import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
 import io.vertx.grpc.eventbus.impl.EventBusHeaders;
+import io.vertx.grpc.eventbus.transport.v1alpha.Message;
+import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
 import io.vertx.grpc.server.GrpcServerResponse;
 import io.vertx.grpc.common.tests.*;
 import org.junit.Before;
@@ -750,8 +752,9 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
     });
 
     vertx.eventBus().addInboundInterceptor(dc -> {
-      if (dc.message().address().startsWith("grpc.eb.server.") && dc.message().body() instanceof Buffer) {
-        if (((Buffer) dc.message().body()).toJsonObject().getJsonObject("ping") != null) {
+      if (dc.message().address().startsWith("grpc.eb.server.") && dc.message().body() instanceof TransportFrame) {
+        TransportFrame frame = (TransportFrame) dc.message().body();
+        if (frame.getFrameCase() == TransportFrame.FrameCase.PING) {
           return;
         }
       }
@@ -807,7 +810,7 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
         if (partitioned.get()) {
           return;
         }
-        if (dc.message().body() instanceof Buffer && ((Buffer) dc.message().body()).toJsonObject().getJsonObject("ping") != null) {
+        if (dc.message().body() instanceof TransportFrame && ((TransportFrame)dc.message().body()).getFrameCase() == TransportFrame.FrameCase.PING) {
           if (toServer) {
             lastPingToServer.set(System.currentTimeMillis());
           } else {
@@ -875,8 +878,8 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
         if (congested.get()) {
           return;
         }
-        if (address.startsWith("grpc.eb.client.") && dc.message().body() instanceof Buffer
-          && ((Buffer) dc.message().body()).toJsonObject().getJsonObject("ping") != null) {
+        if (address.startsWith("grpc.eb.client.") && dc.message().body() instanceof TransportFrame
+          && ((TransportFrame) dc.message().body()).getFrameCase() == TransportFrame.FrameCase.PING) {
           acked.tryComplete();
         }
       }
@@ -1048,11 +1051,14 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
       request.endHandler(v -> request.response().end());
     });
 
-    List<JsonObject> frames = new CopyOnWriteArrayList<>();
+    List<Message> messages = new CopyOnWriteArrayList<>();
     vertx.eventBus().addOutboundInterceptor(ctx -> {
       Object body = ctx.message().body();
-      if (ctx.message().address().startsWith("grpc.eb.") && body instanceof Buffer && ((Buffer) body).length() > 0) {
-        frames.add(new JsonObject((Buffer) body));
+      if (ctx.message().address().startsWith("grpc.eb.") && body instanceof TransportFrame) {
+        TransportFrame frame = (TransportFrame)body;
+        if (frame.getFrameCase() == TransportFrame.FrameCase.MESSAGE) {
+          messages.add(frame.getMessage());
+        }
       }
       ctx.next();
     });
@@ -1069,8 +1075,11 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
 
     assertEquals(2, replies.size());
     assertEquals("echo-a", replies.get(0).getMessage());
-    assertFalse("expected JSON transport frames on the bus", frames.isEmpty());
-    assertTrue("a message frame should carry a JSON message object", frames.stream().anyMatch(f -> f.containsKey("message")));
+    assertFalse("expected JSON transport frames on the bus", messages.isEmpty());
+    for (Message msg : messages) {
+      assertNotNull(msg.getString());
+      new JsonObject(msg.getString());
+    }
   }
 
   @Test
@@ -1081,11 +1090,11 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
       request.endHandler(v -> request.response().end());
     });
 
-    List<JsonObject> frames = new CopyOnWriteArrayList<>();
+    List<TransportFrame> frames = new CopyOnWriteArrayList<>();
     vertx.eventBus().addOutboundInterceptor(ctx -> {
       Object body = ctx.message().body();
-      if (ctx.message().address().startsWith("grpc.eb.") && body instanceof Buffer && ((Buffer) body).length() > 0) {
-        frames.add(new JsonObject((Buffer) body));
+      if (ctx.message().address().startsWith("grpc.eb.") && body instanceof TransportFrame) {
+        frames.add((TransportFrame) body);
       }
       ctx.next();
     });
@@ -1101,7 +1110,7 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
 
     assertEquals(2, replies.size());
     assertFalse("the client's default wire format should produce JSON frames without request.format()", frames.isEmpty());
-    assertTrue(frames.stream().anyMatch(f -> f.containsKey("message")));
+    assertTrue(frames.stream().anyMatch(f -> f.getFrameCase() == TransportFrame.FrameCase.MESSAGE));
   }
 
   @Test

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusWireFormatTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusWireFormatTest.java
@@ -11,6 +11,7 @@ import io.vertx.grpc.common.tests.Request;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
 import io.vertx.grpc.eventbus.impl.EventBusHeaders;
+import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -77,15 +78,10 @@ public class EventBusWireFormatTest extends EventBusGrpcTestBase {
       if (body == null) {
         // OK
       } else {
-        Buffer buffer = (Buffer) body;
-        JsonObject json = new JsonObject(buffer);
-        JsonObject message = json.getJsonObject("message");
-        if (message != null) {
-          Object str = message.getValue("string");
-          should.assertEquals(String.class, str.getClass());
-          JsonObject payload = new JsonObject((String)str);
-        } else if (json.containsKey("trailers") || json.containsKey("headers") || json.containsKey("halfClose")) {
-          //
+        TransportFrame frame = (TransportFrame) body;
+        if (frame.getFrameCase() == TransportFrame.FrameCase.MESSAGE) {
+          should.assertNotNull(frame.getMessage().getString());
+          JsonObject message = new JsonObject(frame.getMessage().getString());
         }
       }
     });

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
@@ -10,7 +10,6 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.grpc.common.WireFormat;
-import io.vertx.grpc.eventbus.impl.EventBusGrpcCodec;
 import io.vertx.grpc.eventbus.impl.EventBusHeaders;
 import io.vertx.grpc.eventbus.transport.v1alpha.Ping;
 import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
@@ -104,7 +103,7 @@ public class TransportInterceptor implements Handler<DeliveryContext<Object>> {
         }
       } else {
         if (wireFormat != null) {
-          TransportFrame frame = EventBusGrpcCodec.decodeFrame(msg);
+          TransportFrame frame = (TransportFrame)msg.body();
           String streamId = "" + frame.getStreamId();
           if (streamId.equals("0")) {
             if (frame.getFrameCase() == TransportFrame.FrameCase.PING) {


### PR DESCRIPTION
Motivation:

The endpoint implementation performs frame codec operations itself.

Since protobuf objects are immutable they can be used directly on the event-bus using a message codec that deals with them.

As consequence, this avoids un-necessary serialization which will happen only between nodes on a cluster.

In addition event-bus interceptors will observe grpc transport frames instead of opaque bytes.

Changes:

Replace frame serdes above event-bus by direct usage of frames and provide an event-bus message codec that takes care of this taks.
