### PR TITLE
Clearly separate transport wire frame from actual message body wire frame.

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcClientOptions.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcClientOptions.java
@@ -14,11 +14,6 @@ import java.time.Duration;
 public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
 
   /**
-   * The default wire format requests use unless overridden with {@code request.format(...)} = {@link WireFormat#PROTOBUF}
-   */
-  public static final WireFormat DEFAULT_WIRE_FORMAT = WireFormat.PROTOBUF;
-
-  /**
    * The default ping interval = {@code 30} seconds
    */
   public static final Duration DEFAULT_PING_INTERVAL = Duration.ofSeconds(30);
@@ -33,7 +28,6 @@ public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
    */
   public static final int DEFAULT_INITIAL_WINDOW_SIZE = 64;
 
-  private WireFormat wireFormat;
   private Duration pingInterval;
   private Duration pingTimeout;
   private int initialWindowSize;
@@ -42,7 +36,6 @@ public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
    * Default options.
    */
   public EventBusGrpcClientOptions() {
-    wireFormat = DEFAULT_WIRE_FORMAT;
     pingInterval = DEFAULT_PING_INTERVAL;
     pingTimeout = DEFAULT_PING_TIMEOUT;
     initialWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
@@ -53,28 +46,9 @@ public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
    */
   public EventBusGrpcClientOptions(EventBusGrpcClientOptions other) {
     super(other);
-    wireFormat = other.wireFormat;
     pingInterval = other.pingInterval;
     pingTimeout = other.pingTimeout;
     initialWindowSize = other.initialWindowSize;
-  }
-
-  /**
-   * @return the default wire format requests use
-   */
-  public WireFormat getWireFormat() {
-    return wireFormat;
-  }
-
-  /**
-   * Set the default wire format requests use. A request can still override it with {@code request.format(...)}.
-   *
-   * @param wireFormat the default wire format
-   * @return a reference to this, so the API can be used fluently
-   */
-  public EventBusGrpcClientOptions setWireFormat(WireFormat wireFormat) {
-    this.wireFormat = wireFormat;
-    return this;
   }
 
   /**
@@ -150,5 +124,10 @@ public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
   @Override
   public EventBusGrpcClientOptions setCleanerPeriod(Duration cleanerPeriod) {
     return (EventBusGrpcClientOptions)super.setCleanerPeriod(cleanerPeriod);
+  }
+
+  @Override
+  public EventBusGrpcClientOptions setWireFormat(WireFormat wireFormat) {
+    return (EventBusGrpcClientOptions)super.setWireFormat(wireFormat);
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcEndpointOptions.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcEndpointOptions.java
@@ -2,6 +2,7 @@ package io.vertx.grpc.eventbus;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.Unstable;
+import io.vertx.grpc.common.WireFormat;
 
 import java.time.Duration;
 
@@ -11,14 +12,22 @@ public abstract class EventBusGrpcEndpointOptions {
 
   public static final Duration DEFAULT_CLEANER_PERIOD = Duration.ofMillis(5);
 
+  /**
+   * The default wire format used by the endpoint to decode event-bus protobuf messages defined by {@code eventbus_transport.proto} = {@link WireFormat#PROTOBUF}
+   */
+  public static final WireFormat DEFAULT_WIRE_FORMAT = WireFormat.PROTOBUF;
+
   private Duration cleanerPeriod;
+  private WireFormat wireFormat;
 
   public EventBusGrpcEndpointOptions() {
     cleanerPeriod = DEFAULT_CLEANER_PERIOD;
+    wireFormat = DEFAULT_WIRE_FORMAT;
   }
 
   public EventBusGrpcEndpointOptions(EventBusGrpcEndpointOptions other) {
     cleanerPeriod = other.cleanerPeriod;
+    wireFormat = other.wireFormat;
   }
 
   public Duration getCleanerPeriod() {
@@ -30,6 +39,24 @@ public abstract class EventBusGrpcEndpointOptions {
       throw new IllegalArgumentException("Cleaner period must be > 0");
     }
     this.cleanerPeriod = cleanerPeriod;
+    return this;
+  }
+
+  /**
+   * @return the endpoint wire format
+   */
+  public WireFormat getWireFormat() {
+    return wireFormat;
+  }
+
+  /**
+   * Set wire format used by the endpoint to decode event-bus protobuf messages defined by {@code eventbus_transport.proto}.
+   *
+   * @param wireFormat the endpoint wire format
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EventBusGrpcEndpointOptions setWireFormat(WireFormat wireFormat) {
+    this.wireFormat = wireFormat;
     return this;
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcServerOptions.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcServerOptions.java
@@ -135,4 +135,9 @@ public class EventBusGrpcServerOptions extends EventBusGrpcEndpointOptions {
   public EventBusGrpcServerOptions setCleanerPeriod(Duration cleanerPeriod) {
     return (EventBusGrpcServerOptions)super.setCleanerPeriod(cleanerPeriod);
   }
+
+  @Override
+  public EventBusGrpcServerOptions setWireFormat(WireFormat wireFormat) {
+    return (EventBusGrpcServerOptions)super.setWireFormat(wireFormat);
+  }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientEndpoint.java
@@ -17,13 +17,11 @@ import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
 public class EventBusGrpcClientEndpoint extends EventBusGrpcEndpoint implements EventBusGrpcClient {
 
   private final VertxInternal vertx;
-  private final WireFormat wireFormat;
   final long pingTimeout;
 
   private EventBusGrpcClientEndpoint(ContextInternal producerContext, EventBusGrpcClientOptions options) {
-    super(producerContext, "grpc.eb.client.", options.getCleanerPeriod().toMillis(),
+    super(producerContext, options.getWireFormat(), "grpc.eb.client.", options.getCleanerPeriod().toMillis(),
       options.getPingInterval().toMillis(), options.getInitialWindowSize());
-    this.wireFormat = options.getWireFormat();
     this.pingTimeout = pingTimeout(options);
     this.vertx = producerContext.owner();
   }
@@ -65,7 +63,7 @@ public class EventBusGrpcClientEndpoint extends EventBusGrpcEndpoint implements 
     );
     request.serviceName(method.serviceName());
     request.methodName(method.methodName());
-    request.format(wireFormat);
+    request.format(WireFormat.PROTOBUF);
     return consumerContext.succeededFuture(request);
   }
 

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -32,12 +32,14 @@ abstract class EventBusGrpcEndpoint {
   private final LongObjectMap<EventBusGrpcStreamBase<?>> streams = new LongObjectHashMap<>();
   private final Map<String, RemoteEndpoint> remoteEndpoints = new HashMap<>();
   private final AtomicLong pingData = new AtomicLong();
+  final WireFormat wireFormat;
   protected final int initialWindowSize;
   private MessageConsumer<TransportFrame> consumer;
   private final long cleanerPeriod;
   private long livenessTimerId = -1L;
 
   EventBusGrpcEndpoint(ContextInternal producerContext,
+                       WireFormat wireFormat,
                        String prefix,
                        long cleanerPeriod,
                        long pingInterval,
@@ -53,6 +55,7 @@ abstract class EventBusGrpcEndpoint {
       // Already registered ...
     }
 
+    this.wireFormat = wireFormat;
     this.vertx = producerContext.owner();
     this.producerContext = producerContext;
     this.eventBus = vertx.eventBus();
@@ -133,7 +136,7 @@ abstract class EventBusGrpcEndpoint {
       for (RemoteEndpoint remoteEndpoint : toPing) {
         TransportFrame frame = TransportFrame.newBuilder().setPing(Ping.newBuilder().setData(data)).build();
         DeliveryOptions options = new DeliveryOptions()
-          .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, remoteEndpoint.format.name())
+          .addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, remoteEndpoint.format.name())
           .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, address);
         switch (remoteEndpoint.format.name()) {
           case "json":
@@ -196,13 +199,11 @@ abstract class EventBusGrpcEndpoint {
     if (remoteEndpoint != null) {
       remoteEndpoint.lastSeenTimestamp = System.currentTimeMillis();
       if (!ping.getAck()) {
-        String wireFormatName = message.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT);
-        WireFormat wireFormat = JsonWireFormat.NAME.equals(wireFormatName) ? WireFormat.JSON : WireFormat.PROTOBUF;
         DeliveryOptions options = new DeliveryOptions()
-          .addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name())
+          .addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, wireFormat.name())
           .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, address);
         Ping.Builder ack = Ping.newBuilder().setData(ping.getData()).setAck(true);
-        remoteEndpoint.sendTransportFrame(TransportFrame.newBuilder().setPing(ack).build(), wireFormat, options);
+        remoteEndpoint.sendTransportFrame(TransportFrame.newBuilder().setPing(ack).build(), options);
       }
     }
   }
@@ -270,8 +271,7 @@ abstract class EventBusGrpcEndpoint {
       return producer.close();
     }
 
-    Future<Void> sendTransportFrame(TransportFrame frame, WireFormat format, DeliveryOptions options) {
-      options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, format.name());
+    Future<Void> sendTransportFrame(TransportFrame frame, DeliveryOptions options) {
       switch (format.name()) {
         case "json":
           options.setCodecName(EventBusGrpcJsonMessageCodec.CODEC_NAME);
@@ -322,7 +322,7 @@ abstract class EventBusGrpcEndpoint {
       remoteEndpoint = bound;
     }
 
-    final Future<Void> sendTransportFrame(TransportFrame.Builder builder, WireFormat wireFormat, DeliveryOptions options) {
+    Future<Void> sendTransportFrame(TransportFrame.Builder builder, DeliveryOptions options) {
       assert localEndpoint.producerContext.inThread();
       RemoteEndpoint remote = remoteEndpoint;
       if (remote == null) {
@@ -339,8 +339,8 @@ abstract class EventBusGrpcEndpoint {
         if (options == null) {
           options = new DeliveryOptions();
         }
-        options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name());
-        switch (wireFormat.name()) {
+        options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, format().name());
+        switch (remote.format.name()) {
           case "json":
             options.setCodecName(EventBusGrpcJsonMessageCodec.CODEC_NAME);
             break;
@@ -351,7 +351,7 @@ abstract class EventBusGrpcEndpoint {
             throw new UnsupportedOperationException();
         }
 
-        Future<Void> res = remote.sendTransportFrame(frame, wireFormat, options);
+        Future<Void> res = remote.sendTransportFrame(frame, options);
         return res.andThen(ar -> {
           if (ar.failed()) {
             localEndpoint.remoteEndpointDown(remote, false);
@@ -394,7 +394,7 @@ abstract class EventBusGrpcEndpoint {
             .setCancel(Cancel.newBuilder().setStatus(GrpcStatus.CANCELLED.code).setReason("Closed"))
             .setStreamId(id)
             .build();
-          remoteEndpoint.sendTransportFrame(frame, remoteEndpoint.format, new DeliveryOptions());
+          remoteEndpoint.sendTransportFrame(frame, new DeliveryOptions());
         }
         Future<Void> res = remove();
         handleProducerClosed(cause);

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerCall.java
@@ -171,7 +171,7 @@ class EventBusGrpcServerCall extends EventBusGrpcStreamBase<EventBusGrpcServerEn
     public void handleConnect(Message<Object> msg) {
       DeliveryOptions replyOptions = new DeliveryOptions()
         .addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address())
-        .addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, format().name())
+        .addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, localEndpoint.wireFormat.name())
         .addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, Integer.toString(localEndpoint.initialWindowSize));
 
       msg.reply(null, replyOptions);

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
@@ -28,7 +28,7 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
   private final AtomicReference<Map<String, ServiceConsumer>> consumersRef;
 
   private EventBusGrpcServerEndpoint(ContextInternal consumerContext, EventBusGrpcServerOptions options) {
-    super(Utils.eventLoopCtx(consumerContext),  "grpc.eb.server.", options.getCleanerPeriod().toMillis(),
+    super(Utils.eventLoopCtx(consumerContext),  options.getWireFormat(), "grpc.eb.server.", options.getCleanerPeriod().toMillis(),
       0L, options.getInitialWindowSize());
     this.consumerContext = consumerContext;
     this.supportedWireFormats = new LinkedHashSet<>(options.getSupportedWireFormats());

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -79,11 +79,11 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
       if (localUnary) {
         if (!remoteUnary) {
           options.addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
-          options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, wireFormat.name());
+          options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, localEndpoint.wireFormat.name());
           options.addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address());
         }
       } else {
-        options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, wireFormat.name());
+        options.addHeader(EventBusHeaders.ENDPOINT_WIRE_FORMAT, localEndpoint.wireFormat.name());
         options.addHeader(EventBusHeaders.ENDPOINT_ADDRESS, localEndpoint.address());
         if (!remoteUnary) {
           options.addHeader(EventBusHeaders.STREAM_INITIAL_WINDOW, "" + localEndpoint.initialWindowSize);
@@ -150,31 +150,31 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
 
         private Throwable handleReply(io.vertx.core.eventbus.Message<Object> reply) {
 
-          WireFormat serverFormat;
-          String serverAddress;
+          WireFormat remoteEndpointWireFormat;
+          String remoteEndpointAddress;
           if (!localUnary || !remoteUnary) {
             MultiMap replyHeaders = reply.headers();
-            serverAddress = replyHeaders.get(EventBusHeaders.ENDPOINT_ADDRESS);
+            remoteEndpointAddress = replyHeaders.get(EventBusHeaders.ENDPOINT_ADDRESS);
             String s = replyHeaders.get(EventBusHeaders.ENDPOINT_WIRE_FORMAT);
             if (s == null) {
               return new IllegalStateException("Malformed handshake reply: missing endpoint-wire-format header");
             }
-            if (serverAddress == null) {
+            if (remoteEndpointAddress == null) {
               return new IllegalStateException("Malformed handshake reply: missing grpc-endpoint-address header");
             }
             switch (s) {
               case "json":
-                serverFormat = WireFormat.JSON;
+                remoteEndpointWireFormat = WireFormat.JSON;
                 break;
               case "proto":
-                serverFormat = WireFormat.PROTOBUF;
+                remoteEndpointWireFormat = WireFormat.PROTOBUF;
                 break;
               default:
                 return new IllegalStateException("Malformed handshake reply: invalid endpoint-wire-format header");
             }
           } else {
-            serverAddress = null;
-            serverFormat = null;
+            remoteEndpointAddress = null;
+            remoteEndpointWireFormat = null;
           }
 
           int initialOutboundWindowSize;
@@ -195,8 +195,8 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
             }
           }
 
-          if (serverAddress != null) {
-            registerRemoteEndpoint(serverAddress, pingTimeout, serverFormat);
+          if (remoteEndpointAddress != null) {
+            registerRemoteEndpoint(remoteEndpointAddress, pingTimeout, remoteEndpointWireFormat);
           }
 
           updateOutboundWindow(initialOutboundWindowSize);
@@ -453,11 +453,11 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
 
   Future<Void> sendTransportFrame(TransportFrame.Builder builder, DeliveryOptions options) {
     if (producerContext.inThread()) {
-      return sendTransportFrame(builder, format(), options);
+      return super.sendTransportFrame(builder, options);
     } else {
       PromiseInternal<Void> ret = consumerContext.promise();
       producerContext.execute(() -> {
-        Future<Void> result = sendTransportFrame(builder, format(), options);
+        Future<Void> result = super.sendTransportFrame(builder, options);
         result.onComplete(ret);
       });
       return ret.future();

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClusteringTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClusteringTest.java
@@ -1,6 +1,8 @@
 package io.vertx.grpc.eventbus.tests;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -8,7 +10,12 @@ import io.vertx.grpc.client.GrpcClientRequest;
 import io.vertx.grpc.common.GrpcReadStream;
 import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
+import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
+import io.vertx.grpc.eventbus.impl.EventBusGrpcJsonMessageCodec;
+import io.vertx.grpc.eventbus.impl.EventBusGrpcProtobufMessageCodec;
+import io.vertx.grpc.eventbus.transport.v1alpha.TransportFrame;
 import io.vertx.grpc.server.GrpcServerResponse;
 import io.vertx.test.fakecluster.FakeClusterManager;
 import io.vertx.grpc.common.tests.Reply;
@@ -21,11 +28,13 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.vertx.grpc.eventbus.tests.EventBusGrpcTestBase.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(VertxUnitRunner.class)
 public class EventBusGrpcClusteringTest {
@@ -34,13 +43,23 @@ public class EventBusGrpcClusteringTest {
   Vertx vertx2;
   EventBusGrpcServer server;
   EventBusGrpcClient client;
+  MessageCodecSpy<TransportFrame, TransportFrame> clientProtoCodecSpy;
+  MessageCodecSpy<TransportFrame, TransportFrame> serverProtoCodecSpy;
+  MessageCodecSpy<TransportFrame, TransportFrame> clientJsonCodecSpy;
+  MessageCodecSpy<TransportFrame, TransportFrame> serverJsonCodecSpy;
 
   @Before
   public void setup() {
     vertx1 = Vertx.builder().withClusterManager(new FakeClusterManager()).buildClustered().await();
     vertx2 = Vertx.builder().withClusterManager(new FakeClusterManager()).buildClustered().await();
-    server = EventBusGrpcServer.server(vertx1).await();
-    client = EventBusGrpcClient.client(vertx2).await();
+    clientProtoCodecSpy = new MessageCodecSpy<>(EventBusGrpcProtobufMessageCodec.INSTANCE);
+    serverProtoCodecSpy = new MessageCodecSpy<>(EventBusGrpcProtobufMessageCodec.INSTANCE);
+    clientJsonCodecSpy = new MessageCodecSpy<>(EventBusGrpcJsonMessageCodec.INSTANCE);
+    serverJsonCodecSpy = new MessageCodecSpy<>(EventBusGrpcJsonMessageCodec.INSTANCE);
+    vertx1.eventBus().registerCodec(clientProtoCodecSpy);
+    vertx2.eventBus().registerCodec(serverProtoCodecSpy);
+    vertx1.eventBus().registerCodec(clientJsonCodecSpy);
+    vertx2.eventBus().registerCodec(serverJsonCodecSpy);
   }
 
   @After
@@ -58,15 +77,24 @@ public class EventBusGrpcClusteringTest {
 
   @Test
   public void testRequestReplyProtobuf() throws Exception {
-    testRequestReply(WireFormat.PROTOBUF);
+    testRequestReply(WireFormat.PROTOBUF, WireFormat.PROTOBUF);
   }
 
   @Test
   public void testRequestReplyJson() throws Exception {
-    testRequestReply(WireFormat.JSON);
+    testRequestReply(WireFormat.JSON, WireFormat.JSON);
   }
 
-  private void testRequestReply(WireFormat wireFormat) throws Exception {
+  @Test
+  public void testRequestReplyMixed() throws Exception {
+    testRequestReply(WireFormat.JSON, WireFormat.PROTOBUF);
+  }
+
+  private void testRequestReply(WireFormat clientWireFormat, WireFormat serverWireFormat) throws Exception {
+
+    server = EventBusGrpcServer.server(vertx1, new EventBusGrpcServerOptions().setWireFormat(serverWireFormat)).await();
+    client = EventBusGrpcClient.client(vertx2, new EventBusGrpcClientOptions().setWireFormat(clientWireFormat)).await();
+
     server.callHandler(UNARY_SERVER, request -> request.handler(msg -> {
       Reply reply = Reply.newBuilder().setMessage("Hello " + msg.getName()).build();
       request.response().end(reply);
@@ -74,7 +102,6 @@ public class EventBusGrpcClusteringTest {
 
     Reply reply = client.request(UNARY_CLIENT)
       .compose(request -> {
-        request.format(wireFormat);
         request.end(Request.newBuilder().setName("Julien").build());
         return request.response();
       })
@@ -82,19 +109,37 @@ public class EventBusGrpcClusteringTest {
       .await(10, TimeUnit.SECONDS);
 
     assertEquals("Hello Julien", reply.getMessage());
+
+    assertEquals(0, clientJsonCodecSpy.decodeOps.get());
+    assertEquals(0, clientJsonCodecSpy.encodeOps.get());
+    assertEquals(0, serverJsonCodecSpy.decodeOps.get());
+    assertEquals(0, serverJsonCodecSpy.encodeOps.get());
+    assertEquals(0, clientProtoCodecSpy.decodeOps.get());
+    assertEquals(0, clientJsonCodecSpy.encodeOps.get());
+    assertEquals(0, serverJsonCodecSpy.decodeOps.get());
+    assertEquals(0, serverJsonCodecSpy.encodeOps.get());
   }
 
   @Test
-  public void testStreamingProtobuf(TestContext should) throws Exception {
-    testStreaming(should, WireFormat.PROTOBUF);
+  public void testStreamingProtobuf(TestContext should) {
+    testStreaming(should, WireFormat.PROTOBUF, WireFormat.PROTOBUF);
   }
 
   @Test
-  public void testStreamingJson(TestContext should) throws Exception {
-    testStreaming(should, WireFormat.JSON);
+  public void testStreamingJson(TestContext should) {
+    testStreaming(should, WireFormat.JSON, WireFormat.JSON);
   }
 
-  private void testStreaming(TestContext should, WireFormat wireFormat) throws Exception {
+  @Test
+  public void testStreamingMixed(TestContext should) {
+    testStreaming(should, WireFormat.JSON, WireFormat.PROTOBUF);
+  }
+
+  private void testStreaming(TestContext should, WireFormat clientWireFormat, WireFormat serverWireFormat) {
+
+    client = EventBusGrpcClient.client(vertx1, new EventBusGrpcClientOptions().setWireFormat(clientWireFormat)).await();
+    server = EventBusGrpcServer.server(vertx2, new EventBusGrpcServerOptions().setWireFormat(serverWireFormat)).await();
+
     server.callHandler(PIPE_SERVER, request -> {
       GrpcServerResponse<Request, Reply> response = request.response();
       request.handler(msg -> {
@@ -114,7 +159,6 @@ public class EventBusGrpcClusteringTest {
 
     GrpcClientRequest<Request, Reply> request = client.request(PIPE_CLIENT).await();
     Async async = should.async();
-    request.format(wireFormat);
     request.response().onComplete(should.asyncAssertSuccess(response -> {
       List<String> result = new ArrayList<>();
       response.handler(reply -> {
@@ -130,5 +174,70 @@ public class EventBusGrpcClusteringTest {
       request.write(Request.newBuilder().setName("msg-" + i).build());
     }
     request.end();
+
+    async.awaitSuccess(20_000);
+
+    clientJsonCodecSpy.assertDecodedUsage(clientWireFormat == WireFormat.JSON);
+    clientJsonCodecSpy.assertEncodedUsage(serverWireFormat == WireFormat.JSON);
+    clientProtoCodecSpy.assertDecodedUsage(clientWireFormat == WireFormat.PROTOBUF);
+    clientProtoCodecSpy.assertEncodedUsage(serverWireFormat == WireFormat.PROTOBUF);
+    serverJsonCodecSpy.assertDecodedUsage(serverWireFormat == WireFormat.JSON);
+    serverJsonCodecSpy.assertEncodedUsage(clientWireFormat == WireFormat.JSON);
+    serverProtoCodecSpy.assertDecodedUsage(serverWireFormat == WireFormat.PROTOBUF);
+    serverProtoCodecSpy.assertEncodedUsage(clientWireFormat == WireFormat.PROTOBUF);
+  }
+
+  static class MessageCodecSpy<S, R> implements MessageCodec<S, R> {
+
+    final MessageCodec<S, R> delegate;
+    final AtomicInteger encodeOps = new AtomicInteger();
+    final AtomicInteger decodeOps = new AtomicInteger();
+
+    public MessageCodecSpy(MessageCodec<S, R> delegate) {
+      this.delegate = delegate;
+    }
+
+    public void assertDecodedUsage(boolean expectUsed) {
+      if (expectUsed) {
+        assertTrue(decodeOps.get() > 0);
+      } else {
+        assertEquals(0, decodeOps.get());
+      }
+    }
+
+    public void assertEncodedUsage(boolean expectUsed) {
+      if (expectUsed) {
+        assertTrue(encodeOps.get() > 0);
+      } else {
+        assertEquals(0, encodeOps.get());
+      }
+    }
+
+    @Override
+    public void encodeToWire(Buffer buffer, S s) {
+      encodeOps.incrementAndGet();
+      delegate.encodeToWire(buffer, s);
+    }
+
+    @Override
+    public R decodeFromWire(int pos, Buffer buffer) {
+      decodeOps.incrementAndGet();
+      return delegate.decodeFromWire(pos, buffer);
+    }
+
+    @Override
+    public R transform(S s) {
+      return delegate.transform(s);
+    }
+
+    @Override
+    public String name() {
+      return delegate.name();
+    }
+
+    @Override
+    public byte systemCodecID() {
+      return delegate.systemCodecID();
+    }
   }
 }

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcInterceptorTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcInterceptorTest.java
@@ -14,6 +14,7 @@ import io.vertx.grpc.common.tests.Reply;
 import io.vertx.grpc.common.tests.Request;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import io.vertx.test.core.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -410,5 +411,27 @@ public class EventBusGrpcInterceptorTest extends EventBusGrpcTestBase {
     request.write(Request.getDefaultInstance()).await();
     async.awaitSuccess(20_000);
     should.assertEquals(1, sequence.get());
+  }
+
+  @Test
+  public void testPing() {
+    AtomicInteger pings = new AtomicInteger();
+    AtomicInteger pongs = new AtomicInteger();
+    vertx.eventBus().addOutboundInterceptor(new TransportInterceptor() {
+      @Override
+      protected Result onPing(String srcAddress, String dstAddress, long data, boolean ack) {
+        if (ack) {
+          pongs.incrementAndGet();
+        } else {
+          pings.incrementAndGet();
+        }
+        return super.onPing(srcAddress, dstAddress, data, ack);
+      }
+    });
+    server.callHandler(PIPE_SERVER, request -> {
+    });
+    GrpcClientRequest<Request, Reply> request = client.request(PIPE_CLIENT).await();
+    request.write(Request.getDefaultInstance()).await();
+    TestUtils.assertWaitUntil(() -> pings.get() > 0 && pongs.get() > 0);
   }
 }

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusWireFormatTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusWireFormatTest.java
@@ -1,7 +1,6 @@
 package io.vertx.grpc.eventbus.tests;
 
 import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.GrpcReadStream;
@@ -21,7 +20,6 @@ public class EventBusWireFormatTest extends EventBusGrpcTestBase {
 
   private EventBusGrpcServer server;
   private EventBusGrpcClient client;
-  private volatile BiConsumer<String, Buffer> payloadHandler;
 
   @Before
   public void setUp(TestContext should) {

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
@@ -102,8 +102,9 @@ public class TransportInterceptor implements Handler<DeliveryContext<Object>> {
           }
         }
       } else {
-        if (wireFormat != null) {
-          TransportFrame frame = (TransportFrame)msg.body();
+        Object body = msg.body();
+        if (body instanceof TransportFrame) {
+          TransportFrame frame = (TransportFrame) body;
           String streamId = "" + frame.getStreamId();
           if (streamId.equals("0")) {
             if (frame.getFrameCase() == TransportFrame.FrameCase.PING) {


### PR DESCRIPTION
Motivation:

The event-bus grpc codec has two levels of codec which are currently coupled.

The codec of the transport frame indicated by the endpoint wire format should be distinct from the stream wire format.

Changes:

Move the options wire format configuration at the endpoint level, this configures how transport frames are adverised and which codec to use, this configures the event bus message codec, used on the cluster.
