### PR TITLE
Cleanup in event-bus grpc options.

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcClientOptions.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcClientOptions.java
@@ -23,14 +23,8 @@ public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
    */
   public static final Duration DEFAULT_PING_TIMEOUT = Duration.ofSeconds(60);
 
-  /**
-   * The default initial window size for inbound messages = {@code 64}
-   */
-  public static final int DEFAULT_INITIAL_WINDOW_SIZE = 64;
-
   private Duration pingInterval;
   private Duration pingTimeout;
-  private int initialWindowSize;
 
   /**
    * Default options.
@@ -38,7 +32,6 @@ public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
   public EventBusGrpcClientOptions() {
     pingInterval = DEFAULT_PING_INTERVAL;
     pingTimeout = DEFAULT_PING_TIMEOUT;
-    initialWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
   }
 
   /**
@@ -48,7 +41,6 @@ public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
     super(other);
     pingInterval = other.pingInterval;
     pingTimeout = other.pingTimeout;
-    initialWindowSize = other.initialWindowSize;
   }
 
   /**
@@ -100,27 +92,6 @@ public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
     return this;
   }
 
-  /**
-   * @return the initial window size
-   */
-  public int getInitialWindowSize() {
-    return initialWindowSize;
-  }
-
-  /**
-   * Set the initial window size.
-   *
-   * @param initialWindowSize the new value
-   * @return a reference to this, so the API can be used fluently
-   */
-  public EventBusGrpcClientOptions setInitialWindowSize(int initialWindowSize) {
-    if (initialWindowSize < 1) {
-      throw new IllegalArgumentException("initialWindowSize must be > 0");
-    }
-    this.initialWindowSize = initialWindowSize;
-    return this;
-  }
-
   @Override
   public EventBusGrpcClientOptions setCleanerPeriod(Duration cleanerPeriod) {
     return (EventBusGrpcClientOptions)super.setCleanerPeriod(cleanerPeriod);
@@ -129,5 +100,10 @@ public class EventBusGrpcClientOptions extends EventBusGrpcEndpointOptions {
   @Override
   public EventBusGrpcClientOptions setWireFormat(WireFormat wireFormat) {
     return (EventBusGrpcClientOptions)super.setWireFormat(wireFormat);
+  }
+
+  @Override
+  public EventBusGrpcClientOptions setInitialWindowSize(int initialWindowSize) {
+    return (EventBusGrpcClientOptions)super.setInitialWindowSize(initialWindowSize);
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcEndpointOptions.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcEndpointOptions.java
@@ -17,17 +17,25 @@ public abstract class EventBusGrpcEndpointOptions {
    */
   public static final WireFormat DEFAULT_WIRE_FORMAT = WireFormat.PROTOBUF;
 
+  /**
+   * The default initial window size for inbound messages = {@code 64}
+   */
+  public static final int DEFAULT_INITIAL_WINDOW_SIZE = 64;
+
   private Duration cleanerPeriod;
   private WireFormat wireFormat;
+  private int initialWindowSize;
 
   public EventBusGrpcEndpointOptions() {
     cleanerPeriod = DEFAULT_CLEANER_PERIOD;
     wireFormat = DEFAULT_WIRE_FORMAT;
+    initialWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
   }
 
   public EventBusGrpcEndpointOptions(EventBusGrpcEndpointOptions other) {
     cleanerPeriod = other.cleanerPeriod;
     wireFormat = other.wireFormat;
+    initialWindowSize = other.initialWindowSize;
   }
 
   public Duration getCleanerPeriod() {
@@ -57,6 +65,27 @@ public abstract class EventBusGrpcEndpointOptions {
    */
   public EventBusGrpcEndpointOptions setWireFormat(WireFormat wireFormat) {
     this.wireFormat = wireFormat;
+    return this;
+  }
+
+  /**
+   * @return the initial window size
+   */
+  public int getInitialWindowSize() {
+    return initialWindowSize;
+  }
+
+  /**
+   * Set the initial window size.
+   *
+   * @param initialWindowSize the new value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EventBusGrpcEndpointOptions setInitialWindowSize(int initialWindowSize) {
+    if (initialWindowSize < 1) {
+      throw new IllegalArgumentException("initialWindowSize must be > 0");
+    }
+    this.initialWindowSize = initialWindowSize;
     return this;
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcServerOptions.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcServerOptions.java
@@ -20,29 +20,22 @@ public class EventBusGrpcServerOptions extends EventBusGrpcEndpointOptions {
   /**
    * The default set of wire formats the server accepts = {@code [proto, json]}
    */
-  public static final Set<WireFormat> DEFAULT_SUPPORTED_WIRE_FORMATS = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(WireFormat.PROTOBUF, WireFormat.JSON)));
+  public static final Set<WireFormat> DEFAULT_ENABLED_WIRE_FORMATS = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(WireFormat.PROTOBUF, WireFormat.JSON)));
 
   /**
    * The default maximum ping timeout = {@code 2} minutes
    */
   public static final Duration DEFAULT_MAX_PING_TIMEOUT = Duration.ofMinutes(2);
 
-  /**
-   * The default initial window size for inbound messages = {@code 64}
-   */
-  public static final int DEFAULT_INITIAL_WINDOW_SIZE = 64;
-
-  private Set<WireFormat> supportedWireFormats;
+  private Set<WireFormat> enabledFormats;
   private Duration maxPingTimeout;
-  private int initialWindowSize;
 
   /**
    * Default options.
    */
   public EventBusGrpcServerOptions() {
-    supportedWireFormats = new LinkedHashSet<>(DEFAULT_SUPPORTED_WIRE_FORMATS);
+    enabledFormats = new LinkedHashSet<>(DEFAULT_ENABLED_WIRE_FORMATS);
     maxPingTimeout = DEFAULT_MAX_PING_TIMEOUT;
-    initialWindowSize = DEFAULT_INITIAL_WINDOW_SIZE;
   }
 
   /**
@@ -50,38 +43,29 @@ public class EventBusGrpcServerOptions extends EventBusGrpcEndpointOptions {
    */
   public EventBusGrpcServerOptions(EventBusGrpcServerOptions other) {
     super(other);
-    supportedWireFormats = new LinkedHashSet<>(other.supportedWireFormats);
+    enabledFormats = new LinkedHashSet<>(other.enabledFormats);
     maxPingTimeout = other.maxPingTimeout;
-    initialWindowSize = other.initialWindowSize;
   }
 
   /**
    * @return the set of wire formats the server accepts
    */
-  public Set<WireFormat> getSupportedWireFormats() {
-    return supportedWireFormats;
+  public Set<WireFormat> getEnabledFormats() {
+    return enabledFormats;
   }
 
   /**
-   * @param wireFormat the wire format to test
-   * @return whether the server accepts the given wire format
-   */
-  public boolean isWireFormatSupported(WireFormat wireFormat) {
-    return supportedWireFormats.contains(wireFormat);
-  }
-
-  /**
-   * Set the wire formats the server accepts. A request using a wire format outside this set is rejected with
+   * Set the wire formats the server accepts for the grpc payload. A request using a wire format outside this set is rejected with
    * {@code UNIMPLEMENTED}.
    *
-   * @param supportedWireFormats the supported wire formats, must not be empty
+   * @param enabledFormats the supported wire formats, must not be empty
    * @return a reference to this, so the API can be used fluently
    */
-  public EventBusGrpcServerOptions setSupportedWireFormats(Set<WireFormat> supportedWireFormats) {
-    if (supportedWireFormats == null || supportedWireFormats.isEmpty()) {
+  public EventBusGrpcServerOptions setEnabledFormats(Set<WireFormat> enabledFormats) {
+    if (enabledFormats == null || enabledFormats.isEmpty()) {
       throw new IllegalArgumentException("supportedWireFormats must not be empty");
     }
-    this.supportedWireFormats = new LinkedHashSet<>(supportedWireFormats);
+    this.enabledFormats = new LinkedHashSet<>(enabledFormats);
     return this;
   }
 
@@ -110,27 +94,6 @@ public class EventBusGrpcServerOptions extends EventBusGrpcEndpointOptions {
     return this;
   }
 
-  /**
-   * @return the initial window size
-   */
-  public int getInitialWindowSize() {
-    return initialWindowSize;
-  }
-
-  /**
-   * Set the initial window size.
-   *
-   * @param initialWindowSize the new value
-   * @return a reference to this, so the API can be used fluently
-   */
-  public EventBusGrpcServerOptions setInitialWindowSize(int initialWindowSize) {
-    if (initialWindowSize < 1) {
-      throw new IllegalArgumentException("initialWindowSize must be > 0");
-    }
-    this.initialWindowSize = initialWindowSize;
-    return this;
-  }
-
   @Override
   public EventBusGrpcServerOptions setCleanerPeriod(Duration cleanerPeriod) {
     return (EventBusGrpcServerOptions)super.setCleanerPeriod(cleanerPeriod);
@@ -139,5 +102,10 @@ public class EventBusGrpcServerOptions extends EventBusGrpcEndpointOptions {
   @Override
   public EventBusGrpcServerOptions setWireFormat(WireFormat wireFormat) {
     return (EventBusGrpcServerOptions)super.setWireFormat(wireFormat);
+  }
+
+  @Override
+  public EventBusGrpcServerOptions setInitialWindowSize(int initialWindowSize) {
+    return (EventBusGrpcServerOptions)super.setInitialWindowSize(initialWindowSize);
   }
 }

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements EventBusGrpcServer {
 
-  private final Set<WireFormat> supportedWireFormats;
+  private final Set<WireFormat> acceptedWireFormats;
   private final long maxPingTimeout;
   private final ContextInternal consumerContext;
   private final AtomicReference<Map<String, ServiceConsumer>> consumersRef;
@@ -31,7 +31,7 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
     super(Utils.eventLoopCtx(consumerContext),  options.getWireFormat(), "grpc.eb.server.", options.getCleanerPeriod().toMillis(),
       0L, options.getInitialWindowSize());
     this.consumerContext = consumerContext;
-    this.supportedWireFormats = new LinkedHashSet<>(options.getSupportedWireFormats());
+    this.acceptedWireFormats = new LinkedHashSet<>(options.getEnabledFormats());
     this.maxPingTimeout = options.getMaxPingTimeout().toMillis();
     this.consumersRef = new AtomicReference<>(new HashMap<>());
   }
@@ -260,7 +260,7 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
         }
       }
 
-      if (!supportedWireFormats.contains(wireFormat)) {
+      if (!acceptedWireFormats.contains(wireFormat)) {
         message.fail(GrpcStatus.UNIMPLEMENTED.code, "Unsupported wire format: " + wireFormat);
         return;
       }

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcStreamingTest.java
@@ -1115,7 +1115,7 @@ public class EventBusGrpcStreamingTest extends EventBusGrpcTestBase {
 
   @Test
   public void testUnsupportedWireFormatRejected() throws Exception {
-    EventBusGrpcServer protobufOnly = EventBusGrpcServer.server(vertx, new EventBusGrpcServerOptions().setSupportedWireFormats(Collections.singleton(WireFormat.PROTOBUF))).await();
+    EventBusGrpcServer protobufOnly = EventBusGrpcServer.server(vertx, new EventBusGrpcServerOptions().setEnabledFormats(Collections.singleton(WireFormat.PROTOBUF))).await();
     protobufOnly.callHandler(PIPE_SERVER, request -> {
       request.handler(req -> request.response().write(Reply.newBuilder().setMessage("echo-" + req.getName()).build()));
       request.endHandler(v -> request.response().end());


### PR DESCRIPTION
Motivation:

Make the grpc event-bus options more consistent.

Changes:

- move initial window size at the endpoint level
- rename server supported formats to enabled formats like HTTP grpc server options
