### PR TITLE
Add a GrpcClient#bind method for conveniently creating an invoker.

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClient.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/GrpcClient.java
@@ -150,6 +150,23 @@ public interface GrpcClient {
   <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(ServiceMethod<Resp, Req> method);
 
   /**
+   * Returns an invoker that interacts with the {@code server}
+   * @param server the server
+   * @return the invoker
+   */
+  default ServiceInvoker bind(Address server) {
+    if (server == null) {
+      throw new NullPointerException("Server argument must not be null");
+    }
+    return new ServiceInvoker() {
+      @Override
+      public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> invoker(ServiceMethod<Resp, Req> method) {
+        return request(server, method);
+      }
+    };
+  }
+
+  /**
    * Close this client.
    */
   Future<Void> close();

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
@@ -38,12 +38,7 @@ public interface GreeterGrpcClient extends GreeterClient {
    * @return the configured client
    */
   static GreeterGrpcClient create(GrpcClient client, SocketAddress host) {
-    return new GreeterGrpcClientImpl(new ServiceInvoker() {
-      @Override
-      public <Req, Resp> Future<io.vertx.grpc.client.GrpcClientRequest<Req, Resp>> invoker(ServiceMethod<Resp, Req> method) {
-        return client.request(host, method);
-      }
-    });
+    return new GreeterGrpcClientImpl(client.bind(host));
   }
 
   /**
@@ -55,12 +50,7 @@ public interface GreeterGrpcClient extends GreeterClient {
    * @return the configured client
    */
   static GreeterGrpcClient create(GrpcClient client, SocketAddress host, io.vertx.grpc.common.WireFormat wireFormat) {
-    return new GreeterGrpcClientImpl(new ServiceInvoker() {
-      @Override
-      public <Req, Resp> Future<io.vertx.grpc.client.GrpcClientRequest<Req, Resp>> invoker(ServiceMethod<Resp, Req> method) {
-        return client.request(host, method);
-      }
-    }, wireFormat);
+    return new GreeterGrpcClientImpl(client.bind(host), wireFormat);
   }
 
   /**

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
@@ -60,12 +60,7 @@ public interface StreamingGrpcClient extends StreamingClient {
    * @return the configured client
    */
   static StreamingGrpcClient create(GrpcClient client, SocketAddress host) {
-    return new StreamingGrpcClientImpl(new ServiceInvoker() {
-      @Override
-      public <Req, Resp> Future<io.vertx.grpc.client.GrpcClientRequest<Req, Resp>> invoker(ServiceMethod<Resp, Req> method) {
-        return client.request(host, method);
-      }
-    });
+    return new StreamingGrpcClientImpl(client.bind(host));
   }
 
   /**
@@ -77,12 +72,7 @@ public interface StreamingGrpcClient extends StreamingClient {
    * @return the configured client
    */
   static StreamingGrpcClient create(GrpcClient client, SocketAddress host, io.vertx.grpc.common.WireFormat wireFormat) {
-    return new StreamingGrpcClientImpl(new ServiceInvoker() {
-      @Override
-      public <Req, Resp> Future<io.vertx.grpc.client.GrpcClientRequest<Req, Resp>> invoker(ServiceMethod<Resp, Req> method) {
-        return client.request(host, method);
-      }
-    }, wireFormat);
+    return new StreamingGrpcClientImpl(client.bind(host), wireFormat);
   }
 
   /**

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
@@ -48,12 +48,7 @@ public interface {{grpcClientFqn}} extends {{clientFqn}} {
    * @return the configured client
    */
   static {{grpcClientFqn}} create(GrpcClient client, SocketAddress host) {
-    return new {{grpcClientFqn}}Impl(new ServiceInvoker() {
-      @Override
-      public <Req, Resp> Future<io.vertx.grpc.client.GrpcClientRequest<Req, Resp>> invoker(ServiceMethod<Resp, Req> method) {
-        return client.request(host, method);
-      }
-    });
+    return new {{grpcClientFqn}}Impl(client.bind(host));
   }
 
   /**
@@ -65,12 +60,7 @@ public interface {{grpcClientFqn}} extends {{clientFqn}} {
    * @return the configured client
    */
   static {{grpcClientFqn}} create(GrpcClient client, SocketAddress host, io.vertx.grpc.common.WireFormat wireFormat) {
-    return new {{grpcClientFqn}}Impl(new ServiceInvoker() {
-      @Override
-      public <Req, Resp> Future<io.vertx.grpc.client.GrpcClientRequest<Req, Resp>> invoker(ServiceMethod<Resp, Req> method) {
-        return client.request(host, method);
-      }
-    }, wireFormat);
+    return new {{grpcClientFqn}}Impl(client.bind(host), wireFormat);
   }
 
   /**


### PR DESCRIPTION
Motivation:

Generated grpc clients will create an invoker to bind an HTTP GrpcClient to a host to use it as an invoker.

We could have this as a default method of GrpcClient for more convenience.

Changes:

Add a GrpcClient#bind method that binds the GrpcClient to a given address.

Update the template to use bind instead of creating an anonymous inner class for the same feature.
