### PR TITLE
Change mapping of NO_ERROR to cancelled

### DIFF
--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcError.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/GrpcError.java
@@ -50,6 +50,7 @@ public enum GrpcError {
     switch ((int)code) {
       case 0x00:
         // NO_ERROR
+        return GrpcError.CANCELLED;
       case 0x01:
         // PROTOCOL_ERROR
       case 0x02:

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/tests/ServerRequestTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/tests/ServerRequestTest.java
@@ -24,6 +24,7 @@ import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.grpc.common.*;
+import io.vertx.grpc.common.impl.DefaultGrpcMessage;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerOptions;
 import io.vertx.grpc.server.GrpcServerResponse;
@@ -700,5 +701,30 @@ public class ServerRequestTest extends ServerTest {
     super.testCancelResponseSignalPropagation(should);
 
     async.awaitSuccess();
+  }
+
+  @Test
+  public void testClientSendsNoErrorRstStream(TestContext should) {
+
+    Async async = should.async();
+
+    startServer(GrpcServer.server(vertx).callHandler(UNARY, call -> {
+      call.errorHandler(err -> {
+        should.assertEquals(GrpcError.CANCELLED, err);
+        async.complete();
+      });
+    }));
+
+    HttpClient client = vertx.createHttpClient(new HttpClientOptions()
+      .setHttp2ClearTextUpgrade(false)
+      .setProtocolVersion(HttpVersion.HTTP_2));
+    client.request(HttpMethod.POST, port, "localhost", "/" + UNARY.fullMethodName())
+      .onComplete(should.asyncAssertSuccess(req -> {
+        req.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
+        req.end(DefaultGrpcMessage.encode(Buffer.buffer(Request.getDefaultInstance().toByteArray()), false, false));
+        req.reset(0x00); // NO_ERROR
+      }));
+
+    async.awaitSuccess(10_000);
   }
 }


### PR DESCRIPTION
**Motivation**
Issue https://github.com/quarkusio/quarkus/issues/56268 in Quarkus indicates that Vert.x and Netty treat `RST_STREAM` `NO_ERROR` differently: Vert.x assigned it `GrpcError.Internal` because of switch case-fallthrough, whereas Netty mapped it as a cancellation.

**Changes**
This PR changes NO_ERROR mapping to treat it as a Cancellation.