### PR TITLE
Improve gRPC over HTTP/2 message framing.

### DIFF
--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/HttpGrpcOutboundStream.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/HttpGrpcOutboundStream.java
@@ -1,5 +1,7 @@
 package io.vertx.grpc.server.impl;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -8,9 +10,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.grpc.common.*;
-import io.vertx.grpc.common.impl.DefaultGrpcMessage;
 import io.vertx.grpc.common.impl.GrpcFrame;
 import io.vertx.grpc.common.impl.GrpcHeadersFrame;
 import io.vertx.grpc.common.impl.GrpcStream;
@@ -25,6 +27,8 @@ import java.util.Map;
 
 public abstract class HttpGrpcOutboundStream extends HttpGrpcInboundStream implements GrpcStream {
 
+  private static final ByteBufAllocator VERTX_ALLOCATOR = BufferInternal.buffer().unwrap().alloc();
+
   private final HttpServerResponse httpResponse;
   private boolean headersSent;
   private Future<Void> trailersSent;
@@ -32,6 +36,7 @@ public abstract class HttpGrpcOutboundStream extends HttpGrpcInboundStream imple
 
   public HttpGrpcOutboundStream(HttpServerRequest httpRequest, GrpcProtocol protocol, GrpcMessageDeframer deframer) {
     super(((HttpServerRequestInternal) httpRequest).context(), protocol, deframer);
+
     this.httpResponse = httpRequest.response();
   }
 
@@ -151,18 +156,25 @@ public abstract class HttpGrpcOutboundStream extends HttpGrpcInboundStream imple
   }
 
   protected Future<Void> writeMessage(GrpcMessageFrame frame) {
+    GrpcMessage msg = frame.message();
     Buffer payload;
     try {
-      payload = frame.message().payload();
+      payload = msg.payload();
     } catch (CodecException e) {
       return context.failedFuture(e);
     }
     headersSent = true;
-    return httpResponse.write(encodeMessage(payload, frame.message().isCompressed(), false));
+    return writeMessage(payload, msg.isCompressed());
   }
 
-  protected Buffer encodeMessage(Buffer message, boolean compressed, boolean trailer) {
-    return DefaultGrpcMessage.encode(message, compressed, trailer);
+  protected Future<Void> writeMessage(Buffer payload, boolean compressed) {
+    int len = payload.length();
+    ByteBuf buf = VERTX_ALLOCATOR.buffer(5);
+    buf.writeByte(compressed ? 0x01 : 0x00);
+    buf.writeInt(len);
+    Buffer prefix = BufferInternal.buffer(buf);
+    httpResponse.write(prefix);
+    return httpResponse.write(payload);
   }
 
   @Override

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcOutboundStream.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcOutboundStream.java
@@ -10,6 +10,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.common.impl.DefaultGrpcMessage;
 import io.vertx.grpc.common.impl.GrpcHeadersFrame;
 import io.vertx.grpc.common.impl.GrpcMessageDeframer;
 import io.vertx.grpc.server.GrpcProtocol;
@@ -85,8 +86,13 @@ public class WebGrpcOutboundStream extends HttpGrpcOutboundStream {
     }
   }
 
-  protected Buffer encodeMessage(Buffer message, boolean compressed, boolean trailer) {
-    message = super.encodeMessage(message, compressed, trailer);
+  @Override
+  protected Future<Void> writeMessage(Buffer payload, boolean compressed) {
+    return httpResponse.write(encodeMessage(payload, compressed, false));
+  }
+
+  private Buffer encodeMessage(Buffer message, boolean compressed, boolean trailer) {
+    message = DefaultGrpcMessage.encode(message, compressed, trailer);
     if (protocol == WEB_TEXT) {
       message = grpcWebEncode(message);
     }


### PR DESCRIPTION
Motivation:

The implementation of gRPC over HTTP/2 message framing makes an un-necessary copy of the message payload which can easily be avoided.

Changes:

Refactor HttpGrpcOutboundStream such as the message write is fully controlled  by the implementation instead of transforming the payload into a new buffer that requries a copy.

Let HttpGrpcOutboundStream implement it with separate writes for the 5 bytes gRPC message prefix and the following payload.

Let WebGrpcOutboundStream override it.

Use the HTTP stream allocator to allocate the gRPC message prefix.
