### PR TITLE
Fix incorrect ClientRequestTest#testServerStreamingBackPressure

### DIFF
--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientRequestTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientRequestTest.java
@@ -177,7 +177,6 @@ public class ClientRequestTest extends ClientTest {
       }));
   }
 
-
   @Test
   public void testServerStreamingBackPressure(TestContext should) throws IOException {
     super.testServerStreamingBackPressure(should);
@@ -190,8 +189,8 @@ public class ClientRequestTest extends ClientTest {
           callResponse.pause();
           AtomicInteger num = new AtomicInteger();
           Runnable readBatch = () -> {
-            vertx.<Integer>executeBlocking(() -> {
-              while (batchQueue.size() == 0) {
+            vertx.executeBlocking(() -> {
+              while (batchQueue.isEmpty()) {
                 try {
                   Thread.sleep(10);
                 } catch (InterruptedException e) {
@@ -203,17 +202,20 @@ public class ClientRequestTest extends ClientTest {
               callResponse.resume();
             });
           };
-          readBatch.run();
           callResponse.messageHandler(item -> {
-            if (num.decrementAndGet() == 0) {
+            int val = num.decrementAndGet();
+            if (val == 0) {
               callResponse.pause();
               readBatch.run();
+            } else if (val < 0) {
+              should.fail();
             }
           });
           callResponse.endHandler(v -> {
             should.assertEquals(-1, num.get());
             test.complete();
           });
+          readBatch.run();
         }));
         callRequest.end(Empty.getDefaultInstance());
       }));

--- a/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientTest.java
+++ b/vertx-grpc-client/src/test/java/io/vertx/grpc/client/tests/ClientTest.java
@@ -109,15 +109,18 @@ public abstract class ClientTest extends ClientTestBase {
         ServerCallStreamObserver obs = (ServerCallStreamObserver) responseObserver;
         AtomicInteger numRounds = new AtomicInteger(20);
         Runnable readyHandler = () -> {
-          if (numRounds.decrementAndGet() > 0) {
+          int val = numRounds.decrementAndGet();
+          if (val > 0) {
             int num = 0;
             while (obs.isReady()) {
               num++;
               Reply item = Reply.newBuilder().setMessage("the-value-" + num).build();
               responseObserver.onNext(item);
             }
-            batchQueue.add(num);
-          } else {
+            if (num > 0) {
+              batchQueue.add(num);
+            }
+          } else if (val == 0) {
             batchQueue.add(-1);
             responseObserver.onCompleted();
           }


### PR DESCRIPTION
Motivation:

The client assumes the server will always send at least one message, however on the server side onReady is sometimes called when it is not ready, leading the client to consume a message that it should not and making the test fail.

Changes:

Update the test to signal the client only when at least one message has been produced.
