### PR TITLE
Encapsulate gRPC-Web specific encoding in WebGrpcOutboundStream.

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/Http2GrpcOutboundStream.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/Http2GrpcOutboundStream.java
@@ -127,8 +127,7 @@ abstract class Http2GrpcOutboundStream implements GrpcStream {
   private Future<Void> handleMessageFrame(GrpcMessageFrame frame) {
     Buffer payload;
     try {
-      GrpcMessage message = frame.message();
-      payload = DefaultGrpcMessage.encode(message.payload(), message.isCompressed(), false);
+      payload = DefaultGrpcMessage.encode(frame.message());
     } catch (CodecException e) {
       return context.failedFuture(e);
     }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/DefaultGrpcMessage.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/DefaultGrpcMessage.java
@@ -45,19 +45,8 @@ public class DefaultGrpcMessage implements GrpcMessage {
   }
 
   public static Buffer encode(GrpcMessage message) {
-    return encode(message, false);
-  }
-
-  /**
-   * Encode a {@link GrpcMessage}.
-   *
-   * @param message the message
-   * @param trailer whether this message is a gRPC-Web trailer
-   * @return the encoded message
-   */
-  public static BufferInternal encode(GrpcMessage message, boolean trailer) {
     boolean compressed = !message.encoding().equals("identity");
-    return encode(message.payload(), compressed, trailer);
+    return encode(message.payload(), compressed);
   }
 
   /**
@@ -65,13 +54,12 @@ public class DefaultGrpcMessage implements GrpcMessage {
    *
    * @param payload the message
    * @param compressed wether the message is compressed
-   * @param trailer whether this message is a gRPC-Web trailer
    * @return the encoded message
    */
-  public static BufferInternal encode(Buffer payload, boolean compressed, boolean trailer) {
+  public static BufferInternal encode(Buffer payload, boolean compressed) {
     int len = payload.length();
     BufferInternal encoded = BufferInternal.buffer(5 + len);
-    encoded.appendByte((byte) ((trailer ? 0x80 : 0x00) | (compressed ? 0x01 : 0x00)));
+    encoded.appendByte((byte) (compressed ? 0x01 : 0x00));
     encoded.appendInt(len);
     encoded.appendBuffer(payload);
     return encoded;

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/HttpGrpcOutboundStream.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/HttpGrpcOutboundStream.java
@@ -158,11 +158,11 @@ public abstract class HttpGrpcOutboundStream extends HttpGrpcInboundStream imple
       return context.failedFuture(e);
     }
     headersSent = true;
-    return httpResponse.write(encodeMessage(payload, frame.message().isCompressed(), false));
+    return httpResponse.write(encodeMessage(payload, frame.message().isCompressed()));
   }
 
-  protected Buffer encodeMessage(Buffer message, boolean compressed, boolean trailer) {
-    return DefaultGrpcMessage.encode(message, compressed, trailer);
+  protected Buffer encodeMessage(Buffer message, boolean compressed) {
+    return DefaultGrpcMessage.encode(message, compressed);
   }
 
   @Override

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcOutboundStream.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcOutboundStream.java
@@ -10,6 +10,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.common.impl.DefaultGrpcMessage;
 import io.vertx.grpc.common.impl.GrpcHeadersFrame;
 import io.vertx.grpc.common.impl.GrpcMessageDeframer;
 import io.vertx.grpc.server.GrpcProtocol;
@@ -85,11 +86,32 @@ public class WebGrpcOutboundStream extends HttpGrpcOutboundStream {
     }
   }
 
-  protected Buffer encodeMessage(Buffer message, boolean compressed, boolean trailer) {
-    message = super.encodeMessage(message, compressed, trailer);
+  protected Buffer encodeMessage(Buffer message, boolean compressed) {
+    return encodeMessage(message, compressed, false);
+  }
+
+  private Buffer encodeMessage(Buffer message, boolean compressed, boolean trailer) {
+    message = encode(message, compressed, trailer);
     if (protocol == WEB_TEXT) {
       message = grpcWebEncode(message);
     }
     return message;
+  }
+
+  /**
+   * Encode a gRPC-Web message;
+   *
+   * @param payload the message
+   * @param compressed wether the message is compressed
+   * @param trailer whether this message is a gRPC-Web trailer
+   * @return the encoded message
+   */
+  private static BufferInternal encode(Buffer payload, boolean compressed, boolean trailer) {
+    int len = payload.length();
+    BufferInternal encoded = BufferInternal.buffer(5 + len);
+    encoded.appendByte((byte) ((trailer ? 0x80 : 0x00) | (compressed ? 0x01 : 0x00)));
+    encoded.appendInt(len);
+    encoded.appendBuffer(payload);
+    return encoded;
   }
 }

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/tests/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/tests/ServerTest.java
@@ -530,7 +530,7 @@ public abstract class ServerTest extends ServerTestBase {
     client.request(HttpMethod.POST, port, "localhost", "/" + UNARY.fullMethodName())
       .onComplete(should.asyncAssertSuccess(req -> {
         req.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
-        req.end(DefaultGrpcMessage.encode(Buffer.buffer(Request.getDefaultInstance().toByteArray()), false, false));
+        req.end(DefaultGrpcMessage.encode(Buffer.buffer(Request.getDefaultInstance().toByteArray()), false));
         req.reset(GrpcError.CANCELLED.http2ResetCode);
       }));
   }


### PR DESCRIPTION
Motivation:

gRPC-Web specific encoding is not much useful elsewhere and can remain confined where it is used.

Changes:

Move gRPC-Web specific encoding to WebGrpcOutboundStream.
