### PR TITLE
Encapsulate gRPC-Web specific encoding in WebGrpcOutboundStream

### DIFF
--- a/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/Http2GrpcOutboundStream.java
+++ b/vertx-grpc-client/src/main/java/io/vertx/grpc/client/impl/Http2GrpcOutboundStream.java
@@ -128,7 +128,7 @@ abstract class Http2GrpcOutboundStream implements GrpcStream {
     Buffer payload;
     try {
       GrpcMessage message = frame.message();
-      payload = DefaultGrpcMessage.encode(message.payload(), message.isCompressed(), false);
+      payload = DefaultGrpcMessage.encode(message.payload(), message.isCompressed());
     } catch (CodecException e) {
       return context.failedFuture(e);
     }

--- a/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/DefaultGrpcMessage.java
+++ b/vertx-grpc-common/src/main/java/io/vertx/grpc/common/impl/DefaultGrpcMessage.java
@@ -44,34 +44,27 @@ public class DefaultGrpcMessage implements GrpcMessage {
     return payload;
   }
 
-  public static Buffer encode(GrpcMessage message) {
-    return encode(message, false);
-  }
-
   /**
    * Encode a {@link GrpcMessage}.
    *
    * @param message the message
-   * @param trailer whether this message is a gRPC-Web trailer
    * @return the encoded message
    */
-  public static BufferInternal encode(GrpcMessage message, boolean trailer) {
-    boolean compressed = !message.encoding().equals("identity");
-    return encode(message.payload(), compressed, trailer);
+  public static BufferInternal encode(GrpcMessage message) {
+    return encode(message.payload(), !message.encoding().equals("identity"));
   }
 
   /**
    * Encode a gRPC message;
    *
-   * @param payload the message
+   * @param payload    the message
    * @param compressed wether the message is compressed
-   * @param trailer whether this message is a gRPC-Web trailer
    * @return the encoded message
    */
-  public static BufferInternal encode(Buffer payload, boolean compressed, boolean trailer) {
+  public static BufferInternal encode(Buffer payload, boolean compressed) {
     int len = payload.length();
     BufferInternal encoded = BufferInternal.buffer(5 + len);
-    encoded.appendByte((byte) ((trailer ? 0x80 : 0x00) | (compressed ? 0x01 : 0x00)));
+    encoded.appendByte((byte) (compressed ? 0x01 : 0x00));
     encoded.appendInt(len);
     encoded.appendBuffer(payload);
     return encoded;

--- a/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcOutboundStream.java
+++ b/vertx-grpc-server/src/main/java/io/vertx/grpc/server/impl/WebGrpcOutboundStream.java
@@ -92,10 +92,24 @@ public class WebGrpcOutboundStream extends HttpGrpcOutboundStream {
   }
 
   private Buffer encodeMessage(Buffer message, boolean compressed, boolean trailer) {
-    message = DefaultGrpcMessage.encode(message, compressed, trailer);
+    message = encode(message, compressed, trailer);
     if (protocol == WEB_TEXT) {
       message = grpcWebEncode(message);
     }
     return message;
+  }
+
+  /**
+   * Encode a gRPC message;
+   *
+   * @param payload the message
+   * @param compressed wether the message is compressed
+   * @param trailer whether this message is a gRPC-Web trailer
+   * @return the encoded message
+   */
+  private static BufferInternal encode(Buffer payload, boolean compressed, boolean trailer) {
+    BufferInternal encoded = DefaultGrpcMessage.encode(payload, compressed);
+    encoded.setByte(0, (byte)(encoded.getByte(0) | (byte)(trailer ? 0x80 : 0x00)));
+    return encoded;
   }
 }

--- a/vertx-grpc-server/src/test/java/io/vertx/grpc/server/tests/ServerTest.java
+++ b/vertx-grpc-server/src/test/java/io/vertx/grpc/server/tests/ServerTest.java
@@ -530,7 +530,7 @@ public abstract class ServerTest extends ServerTestBase {
     client.request(HttpMethod.POST, port, "localhost", "/" + UNARY.fullMethodName())
       .onComplete(should.asyncAssertSuccess(req -> {
         req.putHeader(HttpHeaders.CONTENT_TYPE, "application/grpc");
-        req.end(DefaultGrpcMessage.encode(Buffer.buffer(Request.getDefaultInstance().toByteArray()), false, false));
+        req.end(DefaultGrpcMessage.encode(Buffer.buffer(Request.getDefaultInstance().toByteArray()), false));
         req.reset(GrpcError.CANCELLED.http2ResetCode);
       }));
   }


### PR DESCRIPTION
Motivation:

gRPC-Web specific encoding is not much useful elsewhere and can remain confined where it is used.

Changes:

Move gRPC-Web specific encoding to WebGrpcOutboundStream.
