### PR TITLE
Client should send service proxy action header only for json payload.

### DIFF
--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcStreamBase.java
@@ -97,7 +97,10 @@ abstract class EventBusGrpcStreamBase<E extends EventBusGrpcEndpoint> extends Ev
         options.setSendTimeout(timeout.toMillis());
       }
 
-      options.addHeader(EventBusHeaders.SERVICE_PROXY_ACTION, methodName);;
+      if (wireFormat.name().equals("json")) {
+        options.addHeader(EventBusHeaders.SERVICE_PROXY_ACTION, methodName);;
+      }
+
       options.addHeader(EventBusHeaders.STREAM_METHOD_NAME, methodName);;
       options.addHeader(EventBusHeaders.STREAM_WIRE_FORMAT, wireFormat.name());
       options.addHeader(EventBusHeaders.STREAM_ID, Long.toString(id()));

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClientTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/EventBusGrpcClientTest.java
@@ -35,7 +35,7 @@ public class EventBusGrpcClientTest extends EventBusGrpcTestBase {
   @Test
   public void testRequestReplyProtobuf(TestContext testContext) throws Exception {
     vertx.eventBus().<Buffer> consumer(UNARY_CLIENT.serviceName().fullyQualifiedName(), msg -> {
-      testContext.assertEquals("Unary", msg.headers().get(EventBusHeaders.SERVICE_PROXY_ACTION));
+      testContext.assertNull(msg.headers().get(EventBusHeaders.SERVICE_PROXY_ACTION));
       testContext.assertEquals("Unary", msg.headers().get(EventBusHeaders.STREAM_METHOD_NAME));
       testContext.assertEquals(WireFormat.PROTOBUF.name(), msg.headers().get(EventBusHeaders.STREAM_WIRE_FORMAT));
       try {

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/TransportInterceptor.java
@@ -39,7 +39,7 @@ public class TransportInterceptor implements Handler<DeliveryContext<Object>> {
     Deque<Supplier<Result>> actions = new ArrayDeque<>();
     Message<?> msg = ctx.message();
     MultiMap headers = msg.headers();
-    String actionHeader = headers.get(EventBusHeaders.SERVICE_PROXY_ACTION);
+    String methodHeader = headers.get(EventBusHeaders.STREAM_METHOD_NAME);
     String formatHeader = headers.get(EventBusHeaders.STREAM_WIRE_FORMAT);
     WireFormat wireFormat;
     if (formatHeader != null) {
@@ -58,7 +58,7 @@ public class TransportInterceptor implements Handler<DeliveryContext<Object>> {
       wireFormat = null;
     }
 
-    if (actionHeader != null) {
+    if (methodHeader != null) {
       if (msg.replyAddress() != null) {
         String address = headers.get(EventBusHeaders.ENDPOINT_ADDRESS);
         Stream stream = new Stream();


### PR DESCRIPTION
Motivation:

Currently a client will always send the service proxy action header.

Service proxies only decodes JSON payload and therefore it does not make sense to send the action header with protobuf.

Changes:

The client adds the service proxy header only for JSON encoded payload.
