### PR TITLE
Event bus gRPC endpoint as vertx resources.

### DIFF
--- a/vertx-grpc-eventbus/pom.xml
+++ b/vertx-grpc-eventbus/pom.xml
@@ -54,6 +54,12 @@
       <artifactId>grpc-stub</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.37</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcClient.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcClient.java
@@ -5,6 +5,7 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.internal.VertxInternal;
 import io.vertx.grpc.client.GrpcClientRequest;
 import io.vertx.grpc.client.GrpcClientRequestProvider;
 import io.vertx.grpc.common.ServiceMethod;
@@ -33,7 +34,7 @@ public interface EventBusGrpcClient extends GrpcClientRequestProvider {
    * @return a future of the created client
    */
   static Future<EventBusGrpcClient> client(Vertx vertx) {
-    return EventBusGrpcClientEndpoint.create(vertx, new EventBusGrpcClientOptions());
+    return EventBusGrpcClientEndpoint.create((VertxInternal)vertx, new EventBusGrpcClientOptions());
   }
 
   /**
@@ -45,7 +46,7 @@ public interface EventBusGrpcClient extends GrpcClientRequestProvider {
    * @return a future of the created client
    */
   static Future<EventBusGrpcClient> client(Vertx vertx, EventBusGrpcClientOptions options) {
-    return EventBusGrpcClientEndpoint.create(vertx, options);
+    return EventBusGrpcClientEndpoint.create((VertxInternal)vertx, options);
   }
 
   /**

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcServer.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/EventBusGrpcServer.java
@@ -6,6 +6,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.internal.VertxInternal;
 import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.eventbus.impl.EventBusGrpcServerEndpoint;
 import io.vertx.grpc.server.GrpcServerRequest;
@@ -33,7 +34,7 @@ public interface EventBusGrpcServer extends ServiceContainer {
    * @return a future of the created server
    */
   static Future<EventBusGrpcServer> server(Vertx vertx) {
-    return EventBusGrpcServerEndpoint.create(vertx, new EventBusGrpcServerOptions());
+    return EventBusGrpcServerEndpoint.create((VertxInternal)vertx, new EventBusGrpcServerOptions());
   }
 
   /**
@@ -45,7 +46,7 @@ public interface EventBusGrpcServer extends ServiceContainer {
    * @return a future of the created server
    */
   static Future<EventBusGrpcServer> server(Vertx vertx, EventBusGrpcServerOptions options) {
-    return EventBusGrpcServerEndpoint.create(vertx, options);
+    return EventBusGrpcServerEndpoint.create((VertxInternal)vertx, options);
   }
 
   @Fluent

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/CleanableEventBusGrpcClient.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/CleanableEventBusGrpcClient.java
@@ -1,0 +1,37 @@
+package io.vertx.grpc.eventbus.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.internal.CleanableResource;
+import io.vertx.core.internal.CloseableResource;
+import io.vertx.grpc.client.GrpcClientRequest;
+import io.vertx.grpc.client.impl.GrpcClientInvoker;
+import io.vertx.grpc.common.ServiceMethod;
+import io.vertx.grpc.eventbus.EventBusGrpcClient;
+
+import java.lang.ref.Cleaner;
+import java.time.Duration;
+
+public class CleanableEventBusGrpcClient extends CleanableResource<EventBusGrpcClientEndpoint> implements EventBusGrpcClient {
+
+  CleanableEventBusGrpcClient(Cleaner cleaner, CloseableResource<EventBusGrpcClientEndpoint> dispose) {
+    super(cleaner, dispose);
+  }
+
+  @Override
+  public <Req, Resp> Future<GrpcClientRequest<Req, Resp>> request(ServiceMethod<Resp, Req> method) {
+    return getOrDie().request(method);
+  }
+
+  public EventBusGrpcClientEndpoint unwrap() {
+    return get();
+  }
+
+  public Future<GrpcClientInvoker> connect(ServiceMethod<?, ?> method) {
+    return getOrDie().connect(method);
+  }
+
+  @Override
+  public Future<Void> close() {
+    return shutdown(Duration.ZERO);
+  }
+}

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/CleanableEventBusGrpcServer.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/CleanableEventBusGrpcServer.java
@@ -1,0 +1,40 @@
+package io.vertx.grpc.eventbus.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.ServiceResource;
+import io.vertx.grpc.eventbus.EventBusGrpcServerOptions;
+
+import java.time.Duration;
+
+class CleanableEventBusGrpcServer extends EventBusGrpcServerEndpoint {
+
+  private final ServiceResource<Void, Void> serviceResource;
+  private final ContextInternal consumerContext;
+
+  CleanableEventBusGrpcServer(ContextInternal consumerContext, EventBusGrpcServerOptions options) {
+    super(consumerContext, options);
+
+    this.consumerContext = consumerContext;
+    this.serviceResource = new ServiceResource<>() {
+      @Override
+      protected Future<Void> startImpl(ContextInternal context, Void args) {
+        return CleanableEventBusGrpcServer.super.bind();
+      }
+      @Override
+      protected Future<?> stopImpl(ContextInternal context, Void v, Duration timeout) {
+        return CleanableEventBusGrpcServer.super.close();
+      }
+    };
+  }
+
+  @Override
+  Future<Void> bind() {
+    return serviceResource.start(consumerContext, null);
+  }
+
+  @Override
+  public Future<Void> close() {
+    return serviceResource.stop(consumerContext, Duration.ZERO);
+  }
+}

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcClientEndpoint.java
@@ -1,7 +1,7 @@
 package io.vertx.grpc.eventbus.impl;
 
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.VertxInternal;
@@ -13,8 +13,33 @@ import io.vertx.grpc.common.WireFormat;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
 import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
 
+import java.time.Duration;
+
 
 public class EventBusGrpcClientEndpoint extends EventBusGrpcEndpoint implements EventBusGrpcClient {
+
+  public static Future<EventBusGrpcClient> create(VertxInternal vertx, EventBusGrpcClientOptions options) {
+    ContextInternal context = vertx.getOrCreateContext();
+    ContextInternal producerContext = Utils.eventLoopCtx(context);
+    EventBusGrpcClientEndpoint client = new EventBusGrpcClientEndpoint(producerContext, options);
+    CloseableResource<EventBusGrpcClientEndpoint> res = new CloseableResource<>() {
+      @Override
+      public EventBusGrpcClientEndpoint get() {
+        return client;
+      }
+
+      @Override
+      public Future<Void> shutdown(Duration timeout) {
+        return client.close();
+      }
+    };
+    CleanableEventBusGrpcClient cleanableClient = new CleanableEventBusGrpcClient(vertx.cleaner(), vertx.registerResource(res));
+    PromiseInternal<Void> promise = context.promise();
+    client.bind(promise);
+    return promise
+      .future()
+      .map(cleanableClient);
+  }
 
   private final VertxInternal vertx;
   final long pingTimeout;
@@ -31,17 +56,6 @@ public class EventBusGrpcClientEndpoint extends EventBusGrpcEndpoint implements 
       throw new IllegalArgumentException("pingTimeout (" + options.getPingTimeout() + ") must be greater than pingInterval (" + options.getPingInterval() + ")");
     }
     return options.getPingTimeout().toMillis();
-  }
-
-  public static Future<EventBusGrpcClient> create(Vertx vertx, EventBusGrpcClientOptions options) {
-    ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
-    ContextInternal producerContext = Utils.eventLoopCtx(context);
-    EventBusGrpcClientEndpoint client = new EventBusGrpcClientEndpoint(producerContext, options);
-    PromiseInternal<Void> promise = context.promise();
-    client.bind(promise);
-    return promise
-      .future()
-      .map(client);
   }
 
   @Override

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcEndpoint.java
@@ -211,7 +211,7 @@ abstract class EventBusGrpcEndpoint {
 
   protected abstract Future<Void> handleClose();
 
-  public final Future<Void> close() {
+  public Future<Void> close() {
     PromiseInternal<Void> completion = vertx.promise();
     if (producerContext.inThread()) {
       closeImpl(completion);

--- a/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
+++ b/vertx-grpc-eventbus/src/main/java/io/vertx/grpc/eventbus/impl/EventBusGrpcServerEndpoint.java
@@ -5,7 +5,7 @@ import io.vertx.core.*;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.PromiseInternal;
+import io.vertx.core.internal.VertxInternal;
 import io.vertx.grpc.common.*;
 import io.vertx.grpc.eventbus.EventBusGrpcClientOptions;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
@@ -21,18 +21,32 @@ import java.util.stream.Collectors;
 
 public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements EventBusGrpcServer {
 
+  public static Future<EventBusGrpcServer> create(VertxInternal vertx, EventBusGrpcServerOptions options) {
+    ContextInternal consumerContext = vertx.getOrCreateContext();
+    EventBusGrpcServerEndpoint server = new CleanableEventBusGrpcServer(consumerContext, options);
+    return server
+      .bind()
+      .map(server);
+  }
+
   private final Set<WireFormat> acceptedWireFormats;
   private final long maxPingTimeout;
   private final ContextInternal consumerContext;
   private final AtomicReference<Map<String, ServiceConsumer>> consumersRef;
 
-  private EventBusGrpcServerEndpoint(ContextInternal consumerContext, EventBusGrpcServerOptions options) {
+  EventBusGrpcServerEndpoint(ContextInternal consumerContext, EventBusGrpcServerOptions options) {
     super(Utils.eventLoopCtx(consumerContext),  options.getWireFormat(), "grpc.eb.server.", options.getCleanerPeriod().toMillis(),
       0L, options.getInitialWindowSize());
     this.consumerContext = consumerContext;
     this.acceptedWireFormats = new LinkedHashSet<>(options.getEnabledFormats());
     this.maxPingTimeout = options.getMaxPingTimeout().toMillis();
     this.consumersRef = new AtomicReference<>(new HashMap<>());
+  }
+
+  Future<Void> bind() {
+    Promise<Void> completion = consumerContext.promise();
+    bind(completion);
+    return completion.future();
   }
 
   /**
@@ -51,16 +65,6 @@ public class EventBusGrpcServerEndpoint extends EventBusGrpcEndpoint implements 
       }
     }
     return maxPingTimeout;
-  }
-
-  public static Future<EventBusGrpcServer> create(Vertx vertx, EventBusGrpcServerOptions options) {
-    ContextInternal consumerContext = (ContextInternal) vertx.getOrCreateContext();
-    EventBusGrpcServerEndpoint server = new EventBusGrpcServerEndpoint(consumerContext, options);
-    PromiseInternal<Void> promise = consumerContext.promise();
-    server.bind(promise);
-    return promise
-      .future()
-      .map(server);
   }
 
   @Override

--- a/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/VertxResourceTest.java
+++ b/vertx-grpc-eventbus/src/test/java/io/vertx/grpc/eventbus/tests/VertxResourceTest.java
@@ -1,0 +1,72 @@
+package io.vertx.grpc.eventbus.tests;
+
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.grpc.common.tests.Reply;
+import io.vertx.grpc.eventbus.EventBusGrpcClient;
+import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import io.vertx.grpc.eventbus.impl.CleanableEventBusGrpcClient;
+import io.vertx.grpc.eventbus.impl.EventBusGrpcClientEndpoint;
+import io.vertx.grpc.eventbus.impl.EventBusGrpcServerEndpoint;
+import org.junit.Before;
+import org.junit.Test;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class VertxResourceTest extends EventBusGrpcTestBase  {
+
+  private static final Runner runner = new Runner(new OptionsBuilder().shouldDoGC(true).build());
+  private EventBusGrpcServer server;
+  private EventBusGrpcClient client;
+
+  @Before
+  public void setUp(TestContext should) {
+    super.setUp(should);
+    server = EventBusGrpcServer.server(vertx).await();
+    client = EventBusGrpcClient.client(vertx).await();
+  }
+
+  @Test
+  public void testClient() {
+    server.callHandler(UNARY_SERVER, request -> {
+      request.endHandler(v -> request.response().end(Reply.getDefaultInstance()));
+    });
+
+    runner.runSystemGC();
+    client.request(UNARY_CLIENT).await();
+    EventBusGrpcClientEndpoint realClient = ((CleanableEventBusGrpcClient) client).unwrap();
+    String address = realClient.address();
+    client = null;
+    runner.runSystemGC();
+    try {
+      vertx.eventBus().request(address, "").await();
+      fail();
+    } catch (ReplyException e) {
+      assertEquals(ReplyFailure.NO_HANDLERS, e.failureType());
+    }
+  }
+
+  @Test
+  public void testServer() {
+    AtomicReference<EventBusGrpcServer> ref = new AtomicReference<>();
+    String id = vertx.deployVerticle(ctx -> EventBusGrpcServer.server(vertx).andThen(ar -> {
+      if ((ar.succeeded())) {
+        ref.set(ar.result());
+      }
+    })).await();
+    String address = ((EventBusGrpcServerEndpoint) ref.get()).address();
+    vertx.undeploy(id).await();
+    try {
+      vertx.eventBus().request(address, "").await();
+      fail();
+    } catch (ReplyException e) {
+      assertEquals(ReplyFailure.NO_HANDLERS, e.failureType());
+    }
+  }
+}

--- a/vertx-grpc-eventbus/src/test/java/module-info.java
+++ b/vertx-grpc-eventbus/src/test/java/module-info.java
@@ -12,4 +12,5 @@ open module io.vertx.grpc.eventbus.tests {
   requires com.google.protobuf;
   requires com.google.common;
   requires io.vertx.core.tests;
+  requires jmh.core;
 }

--- a/vertx-grpc-it/src/test/java/io/vertx/grpc/it/tests/ProxyTest.java
+++ b/vertx-grpc-it/src/test/java/io/vertx/grpc/it/tests/ProxyTest.java
@@ -31,7 +31,7 @@ import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.impl.GrpcStream;
 import io.vertx.grpc.eventbus.EventBusGrpcClient;
 import io.vertx.grpc.eventbus.EventBusGrpcServer;
-import io.vertx.grpc.eventbus.impl.EventBusGrpcClientEndpoint;
+import io.vertx.grpc.eventbus.impl.CleanableEventBusGrpcClient;
 import io.vertx.grpc.server.GrpcServer;
 import io.vertx.grpc.server.GrpcServerResponse;
 import io.vertx.grpc.server.impl.GrpcServerImpl;
@@ -166,7 +166,7 @@ public class ProxyTest extends ProxyTestBase {
       });
     });
 
-    EventBusGrpcClientEndpoint grpcClient = (EventBusGrpcClientEndpoint)EventBusGrpcClient.client(vertx).await();
+    CleanableEventBusGrpcClient grpcClient = (CleanableEventBusGrpcClient)EventBusGrpcClient.client(vertx).await();
 
     GrpcServerImpl s = (GrpcServerImpl) GrpcServer.server(vertx);
     s.streamHandler(call -> {


### PR DESCRIPTION
Motivaiton:

Let gRPC event bus endpoints be managed resources cooperating with garbage collector and vertx lifecycle.
