### PR TITLE
Let the generator generate FQN identifier expressions instead of relying on class imports

### DIFF
--- a/vertx-grpc-docs/src/main/java/examples/grpc/Greeter.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/Greeter.java
@@ -1,28 +1,10 @@
 package examples.grpc;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.streams.ReadStream;
-import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
-
-import com.google.protobuf.Descriptors;
-
-import java.util.LinkedList;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * <p>Contract definition Greeter service.</p>
  */
 public interface Greeter {
 
-  Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request);
+  io.vertx.core.Future<examples.grpc.HelloReply> sayHello(examples.grpc.HelloRequest request);
 
 }

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterClient.java
@@ -2,21 +2,13 @@ package examples.grpc;
 
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
-import io.vertx.core.Handler;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.grpc.client.GrpcClient;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
 
 /**
  * <p>A client for invoking the Greeter gRPC service.</p>
  */
-public interface GreeterClient extends Greeter {
+public interface GreeterClient extends examples.grpc.Greeter {
 
   /**
    * Calls the SayHello RPC service method.

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcClient.java
@@ -2,7 +2,6 @@ package examples.grpc;
 
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
-import io.vertx.core.Handler;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
 import io.vertx.grpc.client.GrpcClientRequestProvider;
@@ -18,7 +17,7 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
 /**
  * <p>A client for invoking the Greeter gRPC service.</p>
  */
-public interface GreeterGrpcClient extends GreeterClient {
+public interface GreeterGrpcClient extends examples.grpc.GreeterClient {
 
   /**
    * SayHello protobuf RPC client service method.

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcIo.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcIo.java
@@ -6,8 +6,6 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-import io.grpc.ClientCall;
-
 import io.grpc.stub.StreamObserver;
 
 import io.vertx.grpcio.client.GrpcIoClientChannel;
@@ -35,7 +33,7 @@ public final class GreeterGrpcIo {
   }
 
   
-  public static final class GreeterStub extends io.grpc.stub.AbstractStub<GreeterStub> implements GreeterClient {
+  public static final class GreeterStub extends io.grpc.stub.AbstractStub<GreeterStub> implements examples.grpc.GreeterClient {
     private final io.vertx.core.internal.ContextInternal context;
     private GreeterGrpc.GreeterStub delegateStub;
 
@@ -66,7 +64,7 @@ public final class GreeterGrpcIo {
   /**
    * @return a service binding the given {@code service}.
    */
-  public static io.grpc.BindableService bindableServiceOf(GreeterService service) {
+  public static io.grpc.BindableService bindableServiceOf(examples.grpc.GreeterService service) {
     return new io.grpc.BindableService() {
       public io.grpc.ServerServiceDefinition bindService() {
         return serverServiceDefinition(service);
@@ -74,7 +72,7 @@ public final class GreeterGrpcIo {
     };
   }
 
-  private static io.grpc.ServerServiceDefinition serverServiceDefinition(GreeterService service) {
+  private static io.grpc.ServerServiceDefinition serverServiceDefinition(examples.grpc.GreeterService service) {
     String compression = null;
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
       .addMethod(
@@ -95,11 +93,11 @@ public final class GreeterGrpcIo {
           io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
           io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
 
-    private final GreeterService serviceImpl;
+    private final examples.grpc.GreeterService serviceImpl;
     private final int methodId;
     private final String compression;
 
-    MethodHandlers(GreeterService serviceImpl, int methodId, String compression) {
+    MethodHandlers(examples.grpc.GreeterService serviceImpl, int methodId, String compression) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
       this.compression = compression;

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterGrpcService.java
@@ -1,26 +1,17 @@
 package examples.grpc;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.streams.ReadStream;
-import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.MethodCardinality;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.server.GrpcServerRequest;
-import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.ServiceContainer;
 import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.StatusException;
 
 import com.google.protobuf.Descriptors;
 
-import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +25,7 @@ import java.util.HashMap;
  *   <li>SayHello</li>
  * </ul>
  */
-public class GreeterGrpcService extends GreeterService implements Service {
+public class GreeterGrpcService extends examples.grpc.GreeterService implements Service {
 
   /**
    * Greeter service name.
@@ -44,7 +35,7 @@ public class GreeterGrpcService extends GreeterService implements Service {
   /**
    * Greeter service descriptor.
    */
-  public static final Descriptors.ServiceDescriptor SERVICE_DESCRIPTOR = Docs.getDescriptor().findServiceByName("Greeter");
+  public static final Descriptors.ServiceDescriptor SERVICE_DESCRIPTOR = examples.grpc.Docs.getDescriptor().findServiceByName("Greeter");
 
   @Override
   public ServiceName name() {
@@ -59,7 +50,7 @@ public class GreeterGrpcService extends GreeterService implements Service {
   /**
    * @return a service binding all methods of the given {@code service}
    */
-  public static Service of(GreeterService service) {
+  public static Service of(examples.grpc.GreeterService service) {
     return builder(service).bind(all()).build();
   }
 
@@ -108,7 +99,7 @@ public class GreeterGrpcService extends GreeterService implements Service {
   /**
    * @return a free form builder that gives the opportunity to bind only certain methods of a service
    */
-  public static Builder builder(GreeterService service) {
+  public static Builder builder(examples.grpc.GreeterService service) {
     return new Builder(service);
   }
 
@@ -118,9 +109,9 @@ public class GreeterGrpcService extends GreeterService implements Service {
   public static class Builder {
 
     private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>();
-    private final GreeterService instance;
+    private final examples.grpc.GreeterService instance;
 
-    private Builder(GreeterService instance) {
+    private Builder(examples.grpc.GreeterService instance) {
       this.instance = instance;
     }
 
@@ -146,11 +137,11 @@ public class GreeterGrpcService extends GreeterService implements Service {
 
   private static class RequestHandler implements Service {
 
-    private final GreeterService instance;
+    private final examples.grpc.GreeterService instance;
     private final List<ServiceMethod<?, ?>> serviceMethods;
     private final Map<String, Handler<GrpcServerRequest<?, ?>>> handlers;
 
-    public RequestHandler(GreeterService instance, List<ServiceMethod<?, ?>> serviceMethods) {
+    public RequestHandler(examples.grpc.GreeterService instance, List<ServiceMethod<?, ?>> serviceMethods) {
       Map<String, Handler<GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
       for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
         Handler<GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);

--- a/vertx-grpc-docs/src/main/java/examples/grpc/GreeterService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/GreeterService.java
@@ -2,25 +2,8 @@ package examples.grpc;
 
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
-import io.vertx.grpc.server.GrpcServerRequest;
-import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.ServiceBuilder;
-
-import com.google.protobuf.Descriptors;
-
-import java.util.LinkedList;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * <p>Provides support for RPC methods implementations of the Greeter gRPC service.</p>
@@ -30,7 +13,7 @@ import java.util.List;
  *   <li>SayHello</li>
  * </ul>
  */
-public class GreeterService implements Greeter {
+public class GreeterService implements examples.grpc.Greeter {
 
   /**
    * Override this method to implement the SayHello RPC.

--- a/vertx-grpc-docs/src/main/java/examples/grpc/Streaming.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/Streaming.java
@@ -1,32 +1,14 @@
 package examples.grpc;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.streams.ReadStream;
-import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
-
-import com.google.protobuf.Descriptors;
-
-import java.util.LinkedList;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * <p>Contract definition Streaming service.</p>
  */
 public interface Streaming {
 
-  Future<ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request);
+  io.vertx.core.Future<io.vertx.core.streams.ReadStream<examples.grpc.Item>> source(examples.grpc.Empty request);
 
-  Future<examples.grpc.Empty> sink(ReadStream<examples.grpc.Item> request);
+  io.vertx.core.Future<examples.grpc.Empty> sink(io.vertx.core.streams.ReadStream<examples.grpc.Item> request);
 
-  Future<ReadStream<examples.grpc.Item>> pipe(ReadStream<examples.grpc.Item> request);
+  io.vertx.core.Future<io.vertx.core.streams.ReadStream<examples.grpc.Item>> pipe(io.vertx.core.streams.ReadStream<examples.grpc.Item> request);
 
 }

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingClient.java
@@ -2,21 +2,13 @@ package examples.grpc;
 
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
-import io.vertx.core.Handler;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.grpc.client.GrpcClient;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
 
 /**
  * <p>A client for invoking the Streaming gRPC service.</p>
  */
-public interface StreamingClient extends Streaming {
+public interface StreamingClient extends examples.grpc.Streaming {
 
   /**
    * Calls the Source RPC service method.

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcClient.java
@@ -2,7 +2,6 @@ package examples.grpc;
 
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
-import io.vertx.core.Handler;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
 import io.vertx.grpc.client.GrpcClientRequestProvider;
@@ -18,7 +17,7 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
 /**
  * <p>A client for invoking the Streaming gRPC service.</p>
  */
-public interface StreamingGrpcClient extends StreamingClient {
+public interface StreamingGrpcClient extends examples.grpc.StreamingClient {
 
   /**
    * Source protobuf RPC client service method.

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcIo.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcIo.java
@@ -6,8 +6,6 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-import io.grpc.ClientCall;
-
 import io.grpc.stub.StreamObserver;
 
 import io.vertx.grpcio.client.GrpcIoClientChannel;
@@ -35,7 +33,7 @@ public final class StreamingGrpcIo {
   }
 
   
-  public static final class StreamingStub extends io.grpc.stub.AbstractStub<StreamingStub> implements StreamingClient {
+  public static final class StreamingStub extends io.grpc.stub.AbstractStub<StreamingStub> implements examples.grpc.StreamingClient {
     private final io.vertx.core.internal.ContextInternal context;
     private StreamingGrpc.StreamingStub delegateStub;
 
@@ -75,7 +73,7 @@ public final class StreamingGrpcIo {
   /**
    * @return a service binding the given {@code service}.
    */
-  public static io.grpc.BindableService bindableServiceOf(StreamingService service) {
+  public static io.grpc.BindableService bindableServiceOf(examples.grpc.StreamingService service) {
     return new io.grpc.BindableService() {
       public io.grpc.ServerServiceDefinition bindService() {
         return serverServiceDefinition(service);
@@ -83,7 +81,7 @@ public final class StreamingGrpcIo {
     };
   }
 
-  private static io.grpc.ServerServiceDefinition serverServiceDefinition(StreamingService service) {
+  private static io.grpc.ServerServiceDefinition serverServiceDefinition(examples.grpc.StreamingService service) {
     String compression = null;
     return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
       .addMethod(
@@ -120,11 +118,11 @@ public final class StreamingGrpcIo {
           io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
           io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
 
-    private final StreamingService serviceImpl;
+    private final examples.grpc.StreamingService serviceImpl;
     private final int methodId;
     private final String compression;
 
-    MethodHandlers(StreamingService serviceImpl, int methodId, String compression) {
+    MethodHandlers(examples.grpc.StreamingService serviceImpl, int methodId, String compression) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
       this.compression = compression;

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingGrpcService.java
@@ -1,26 +1,17 @@
 package examples.grpc;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.streams.ReadStream;
-import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.MethodCardinality;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.server.GrpcServerRequest;
-import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.ServiceContainer;
 import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.StatusException;
 
 import com.google.protobuf.Descriptors;
 
-import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +27,7 @@ import java.util.HashMap;
  *   <li>Pipe</li>
  * </ul>
  */
-public class StreamingGrpcService extends StreamingService implements Service {
+public class StreamingGrpcService extends examples.grpc.StreamingService implements Service {
 
   /**
    * Streaming service name.
@@ -46,7 +37,7 @@ public class StreamingGrpcService extends StreamingService implements Service {
   /**
    * Streaming service descriptor.
    */
-  public static final Descriptors.ServiceDescriptor SERVICE_DESCRIPTOR = Docs.getDescriptor().findServiceByName("Streaming");
+  public static final Descriptors.ServiceDescriptor SERVICE_DESCRIPTOR = examples.grpc.Docs.getDescriptor().findServiceByName("Streaming");
 
   @Override
   public ServiceName name() {
@@ -61,7 +52,7 @@ public class StreamingGrpcService extends StreamingService implements Service {
   /**
    * @return a service binding all methods of the given {@code service}
    */
-  public static Service of(StreamingService service) {
+  public static Service of(examples.grpc.StreamingService service) {
     return builder(service).bind(all()).build();
   }
 
@@ -122,7 +113,7 @@ public class StreamingGrpcService extends StreamingService implements Service {
   /**
    * @return a free form builder that gives the opportunity to bind only certain methods of a service
    */
-  public static Builder builder(StreamingService service) {
+  public static Builder builder(examples.grpc.StreamingService service) {
     return new Builder(service);
   }
 
@@ -132,9 +123,9 @@ public class StreamingGrpcService extends StreamingService implements Service {
   public static class Builder {
 
     private final List<ServiceMethod<?, ?>> serviceMethods = new ArrayList<>();
-    private final StreamingService instance;
+    private final examples.grpc.StreamingService instance;
 
-    private Builder(StreamingService instance) {
+    private Builder(examples.grpc.StreamingService instance) {
       this.instance = instance;
     }
 
@@ -160,11 +151,11 @@ public class StreamingGrpcService extends StreamingService implements Service {
 
   private static class RequestHandler implements Service {
 
-    private final StreamingService instance;
+    private final examples.grpc.StreamingService instance;
     private final List<ServiceMethod<?, ?>> serviceMethods;
     private final Map<String, Handler<GrpcServerRequest<?, ?>>> handlers;
 
-    public RequestHandler(StreamingService instance, List<ServiceMethod<?, ?>> serviceMethods) {
+    public RequestHandler(examples.grpc.StreamingService instance, List<ServiceMethod<?, ?>> serviceMethods) {
       Map<String, Handler<GrpcServerRequest<?, ?>>> handlers = new HashMap<>();
       for (ServiceMethod<?, ?> serviceMethod : serviceMethods) {
         Handler<GrpcServerRequest<?, ?>> handler = resolveHandler(serviceMethod);

--- a/vertx-grpc-docs/src/main/java/examples/grpc/StreamingService.java
+++ b/vertx-grpc-docs/src/main/java/examples/grpc/StreamingService.java
@@ -2,25 +2,8 @@ package examples.grpc;
 
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
-import io.vertx.grpc.server.GrpcServerRequest;
-import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.ServiceBuilder;
-
-import com.google.protobuf.Descriptors;
-
-import java.util.LinkedList;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * <p>Provides support for RPC methods implementations of the Streaming gRPC service.</p>
@@ -32,7 +15,7 @@ import java.util.List;
  *   <li>Pipe</li>
  * </ul>
  */
-public class StreamingService implements Streaming {
+public class StreamingService implements examples.grpc.Streaming {
 
   /**
    * Override this method to implement the Source RPC.

--- a/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/generation/context/ServiceTemplateContext.java
+++ b/vertx-grpc-protoc-plugin2/src/main/java/io/vertx/grpc/plugin/generation/context/ServiceTemplateContext.java
@@ -12,14 +12,11 @@ public class ServiceTemplateContext {
   public String javaPackageFqn;
   public String serviceName;
   public String packageName;
+  public String serviceNameBase;
   public String contractFqn;
   public String serviceFqn;
   public String clientFqn;
-  public String grpcClientFqn;
-  public String grpcServiceFqn;
-  public String grpcIoFqn;
   public String outerFqn;
-  public String prefixedServiceName;
   public boolean codegenEnabled;
   public String javaDoc;
 
@@ -39,19 +36,18 @@ public class ServiceTemplateContext {
     context.javaPackageFqn = service.getJavaPackage();
     context.serviceName = service.getName();
     context.packageName = service.getPackageName();
-    context.outerFqn = service.getOuterClass();
     context.codegenEnabled = options.isGenerateVertxGeneratorAnnotations();
     context.javaDoc = service.getDocumentation();
 
-    // Build FQN names with prefix
+    // Build the names with prefix, the templates declare their own type from serviceNameBase and refer to the other
+    // generated types with the package qualified names
     String prefix = options.getServicePrefix();
-    context.contractFqn = prefix + service.getName();
-    context.clientFqn = prefix + service.getName() + "Client";
-    context.serviceFqn = prefix + service.getName() + "Service";
-    context.grpcClientFqn = prefix + service.getName() + "GrpcClient";
-    context.grpcServiceFqn = prefix + service.getName() + "GrpcService";
-    context.grpcIoFqn = prefix + service.getName() + "GrpcIo";
-    context.prefixedServiceName = prefix + service.getName();
+    String packageQualifier = context.javaPackageFqn == null || context.javaPackageFqn.isEmpty() ? "" : context.javaPackageFqn + ".";
+    context.serviceNameBase = prefix + service.getName();
+    context.contractFqn = packageQualifier + context.serviceNameBase;
+    context.clientFqn = packageQualifier + context.serviceNameBase + "Client";
+    context.serviceFqn = packageQualifier + context.serviceNameBase + "Service";
+    context.outerFqn = packageQualifier + service.getOuterClass();
 
     // Convert methods
     context.allMethods = service.getMethods().stream()

--- a/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/client.mustache
@@ -4,16 +4,8 @@ package {{javaPackageFqn}};
 
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
-import io.vertx.core.Handler;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.grpc.client.GrpcClient;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
 
 /**
  * <p>A client for invoking the {{serviceName}} gRPC service.</p>
@@ -21,7 +13,7 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
 {{#codegenEnabled}}
 @io.vertx.codegen.annotations.VertxGen
 {{/codegenEnabled}}
-public interface {{clientFqn}} extends {{contractFqn}} {
+public interface {{serviceNameBase}}Client extends {{contractFqn}} {
 {{#unaryUnaryMethods}}
 
   /**

--- a/vertx-grpc-protoc-plugin2/src/main/resources/contract.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/contract.mustache
@@ -2,43 +2,25 @@
 package {{javaPackageFqn}};
 {{/javaPackageFqn}}
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.streams.ReadStream;
-import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
-
-import com.google.protobuf.Descriptors;
-
-import java.util.LinkedList;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * <p>Contract definition {{serviceName}} service.</p>
  */
-public interface {{contractFqn}} {
+public interface {{serviceNameBase}} {
 {{#unaryUnaryMethods}}
 
-  Future<{{outputType}}> {{vertxMethodName}}({{inputType}} request);
+  io.vertx.core.Future<{{outputType}}> {{vertxMethodName}}({{inputType}} request);
 {{/unaryUnaryMethods}}
 {{#unaryManyMethods}}
 
-  Future<ReadStream<{{outputType}}>> {{vertxMethodName}}({{inputType}} request);
+  io.vertx.core.Future<io.vertx.core.streams.ReadStream<{{outputType}}>> {{vertxMethodName}}({{inputType}} request);
 {{/unaryManyMethods}}
 {{#manyUnaryMethods}}
 
-  Future<{{outputType}}> {{vertxMethodName}}(ReadStream<{{inputType}}> request);
+  io.vertx.core.Future<{{outputType}}> {{vertxMethodName}}(io.vertx.core.streams.ReadStream<{{inputType}}> request);
 {{/manyUnaryMethods}}
 {{#manyManyMethods}}
 
-  Future<ReadStream<{{outputType}}>> {{vertxMethodName}}(ReadStream<{{inputType}}> request);
+  io.vertx.core.Future<io.vertx.core.streams.ReadStream<{{outputType}}>> {{vertxMethodName}}(io.vertx.core.streams.ReadStream<{{inputType}}> request);
 {{/manyManyMethods}}
 
 }

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-client.mustache
@@ -4,7 +4,6 @@ package {{javaPackageFqn}};
 
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
-import io.vertx.core.Handler;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.grpc.client.GrpcClient;
 import io.vertx.grpc.client.GrpcClientRequestProvider;
@@ -23,7 +22,7 @@ import io.vertx.grpc.common.GrpcMessageEncoder;
 {{#codegenEnabled}}
 @io.vertx.codegen.annotations.VertxGen
 {{/codegenEnabled}}
-public interface {{grpcClientFqn}} extends {{clientFqn}} {
+public interface {{serviceNameBase}}GrpcClient extends {{clientFqn}} {
 {{#allMethods}}
 
   /**
@@ -47,8 +46,8 @@ public interface {{grpcClientFqn}} extends {{clientFqn}} {
    * @param host   the host providing the service
    * @return the configured client
    */
-  static {{grpcClientFqn}} create(GrpcClient client, SocketAddress host) {
-    return new {{grpcClientFqn}}Impl(client.bind(host));
+  static {{serviceNameBase}}GrpcClient create(GrpcClient client, SocketAddress host) {
+    return new {{serviceNameBase}}GrpcClientImpl(client.bind(host));
   }
 
   /**
@@ -59,8 +58,8 @@ public interface {{grpcClientFqn}} extends {{clientFqn}} {
    * @param wireFormat the wire format
    * @return the configured client
    */
-  static {{grpcClientFqn}} create(GrpcClient client, SocketAddress host, io.vertx.grpc.common.WireFormat wireFormat) {
-    return new {{grpcClientFqn}}Impl(client.bind(host), wireFormat);
+  static {{serviceNameBase}}GrpcClient create(GrpcClient client, SocketAddress host, io.vertx.grpc.common.WireFormat wireFormat) {
+    return new {{serviceNameBase}}GrpcClientImpl(client.bind(host), wireFormat);
   }
 
   /**
@@ -69,8 +68,8 @@ public interface {{grpcClientFqn}} extends {{clientFqn}} {
    * @param client the gRPC client service
    * @return the configured client
    */
-  static {{grpcClientFqn}} create(GrpcClientRequestProvider client) {
-    return new {{grpcClientFqn}}Impl(client);
+  static {{serviceNameBase}}GrpcClient create(GrpcClientRequestProvider client) {
+    return new {{serviceNameBase}}GrpcClientImpl(client);
   }
 
   /**
@@ -80,24 +79,24 @@ public interface {{grpcClientFqn}} extends {{clientFqn}} {
    * @param wireFormat the wire format
    * @return the configured client
    */
-  static {{grpcClientFqn}} create(GrpcClientRequestProvider client, io.vertx.grpc.common.WireFormat wireFormat) {
-    return new {{grpcClientFqn}}Impl(client, wireFormat);
+  static {{serviceNameBase}}GrpcClient create(GrpcClientRequestProvider client, io.vertx.grpc.common.WireFormat wireFormat) {
+    return new {{serviceNameBase}}GrpcClientImpl(client, wireFormat);
   }
 }
 
 /**
  * The proxy implementation.
  */
-class {{grpcClientFqn}}Impl implements {{grpcClientFqn}} {
+class {{serviceNameBase}}GrpcClientImpl implements {{serviceNameBase}}GrpcClient {
 
   private final GrpcClientRequestProvider client;
   private final io.vertx.grpc.common.WireFormat wireFormat;
 
-  {{grpcClientFqn}}Impl(GrpcClientRequestProvider client) {
+  {{serviceNameBase}}GrpcClientImpl(GrpcClientRequestProvider client) {
     this(client, io.vertx.grpc.common.WireFormat.PROTOBUF);
   }
 
-  {{grpcClientFqn}}Impl(GrpcClientRequestProvider client, io.vertx.grpc.common.WireFormat wireFormat) {
+  {{serviceNameBase}}GrpcClientImpl(GrpcClientRequestProvider client, io.vertx.grpc.common.WireFormat wireFormat) {
     this.client = java.util.Objects.requireNonNull(client);
     this.wireFormat = java.util.Objects.requireNonNull(wireFormat);
   }

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-io.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-io.mustache
@@ -8,8 +8,6 @@ import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
 
-import io.grpc.ClientCall;
-
 import io.grpc.stub.StreamObserver;
 
 import io.vertx.grpcio.client.GrpcIoClientChannel;
@@ -18,9 +16,9 @@ import io.vertx.grpcio.client.impl.GrpcIoClientImpl;
 /**
  * gRPC/IO client/service in a Vert.x idiomatic way.
  */
-public final class {{grpcIoFqn}} {
+public final class {{serviceNameBase}}GrpcIo {
 
-  private {{grpcIoFqn}}() {}
+  private {{serviceNameBase}}GrpcIo() {}
 
   /**
    * Build a new stub.
@@ -123,11 +121,11 @@ public final class {{grpcIoFqn}} {
           io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
           io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
 
-    private final {{prefixedServiceName}}Service serviceImpl;
+    private final {{serviceFqn}} serviceImpl;
     private final int methodId;
     private final String compression;
 
-    MethodHandlers({{prefixedServiceName}}Service serviceImpl, int methodId, String compression) {
+    MethodHandlers({{serviceFqn}} serviceImpl, int methodId, String compression) {
       this.serviceImpl = serviceImpl;
       this.methodId = methodId;
       this.compression = compression;

--- a/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/grpc-service.mustache
@@ -2,27 +2,18 @@
 package {{javaPackageFqn}};
 {{/javaPackageFqn}}
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.streams.ReadStream;
-import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.ServiceName;
 import io.vertx.grpc.common.ServiceMethod;
 import io.vertx.grpc.common.MethodCardinality;
 import io.vertx.grpc.common.GrpcMessageDecoder;
 import io.vertx.grpc.common.GrpcMessageEncoder;
 import io.vertx.grpc.server.GrpcServerRequest;
-import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.ServiceContainer;
 import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.StatusException;
 
 import com.google.protobuf.Descriptors;
 
-import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +29,7 @@ import java.util.HashMap;
 {{/allMethods}}
  * </ul>
  */
-public class {{grpcServiceFqn}} extends {{serviceFqn}} implements Service {
+public class {{serviceNameBase}}GrpcService extends {{serviceFqn}} implements Service {
 
   /**
    * {{serviceName}} service name.

--- a/vertx-grpc-protoc-plugin2/src/main/resources/service.mustache
+++ b/vertx-grpc-protoc-plugin2/src/main/resources/service.mustache
@@ -4,25 +4,8 @@ package {{javaPackageFqn}};
 
 import io.vertx.core.Future;
 import io.vertx.core.Completable;
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
-import io.vertx.grpc.common.GrpcStatus;
-import io.vertx.grpc.common.ServiceName;
-import io.vertx.grpc.common.ServiceMethod;
-import io.vertx.grpc.common.GrpcMessageDecoder;
-import io.vertx.grpc.common.GrpcMessageEncoder;
-import io.vertx.grpc.server.GrpcServerRequest;
-import io.vertx.grpc.server.GrpcServer;
-import io.vertx.grpc.server.Service;
-import io.vertx.grpc.server.ServiceBuilder;
-
-import com.google.protobuf.Descriptors;
-
-import java.util.LinkedList;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * <p>Provides support for RPC methods implementations of the {{serviceName}} gRPC service.</p>
@@ -34,7 +17,7 @@ import java.util.List;
 {{/allMethods}}
  * </ul>
  */
-public class {{serviceFqn}} implements {{contractFqn}} {
+public class {{serviceNameBase}}Service implements {{contractFqn}} {
 {{#unaryUnaryMethods}}
 
   /**


### PR DESCRIPTION
Motivation:

The generator gives the contract interface the name of the service. A service with the name `Service` thus gets a contract interface `Service`. The generated `ServiceService` class imports `io.vertx.grpc.server.Service`. In Java, an import hides a type of the same name in the same package. Thus the class implements the wrong `Service`, and the code does not compile. This occurs for each service that has the name of a type that the templates import. `Future` is another example.

Changes:

- Each template declares its own type with `serviceNameBase`.
- Each template refers to the other generated types with the full names in `contractFqn`, `clientFqn`, `serviceFqn` and `outerFqn`. These fields did not contain full names before.
- The fields `grpcClientFqn`, `grpcServiceFqn` and `grpcIoFqn` are removed. Each of them spelled only its own declaration.
- The contract template has no imports. It declares the bare service name, thus an import of the same name is a compile error. The template gives the full names of the two types that it uses.
- The other templates lose their unused imports. `io.vertx.grpc.server.Service` in the service template is the import of the report.

Results:

The generated code does not rely anymore on imports and minimize conflicts with user provided names.

Closes #351

